### PR TITLE
Handle with exceptional lines of "Permission denied" in du output

### DIFF
--- a/example_1_permission_denied.log
+++ b/example_1_permission_denied.log
@@ -1,0 +1,14486 @@
+du: cannot access `./st203/FDM_026_PD_SPE.o': Permission denied
+du: cannot access `./st203/FDM_023_SMOOTHING.F90': Permission denied
+du: cannot access `./st203/SHOWGEO': Permission denied
+du: cannot access `./st203/FDM_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./st203/libtecio.a': Permission denied
+du: cannot access `./st203/FDM_302_WAVYVOR_DECOMPOSITION.F90': Permission denied
+du: cannot access `./st203/FDM_033_IBM_INTFORCING.F90': Permission denied
+du: cannot access `./st203/FDM_010_INIT_PARALLEL.o': Permission denied
+du: cannot access `./st203/GEOMETRY': Permission denied
+du: cannot access `./st203/FDM_110_RNG.o': Permission denied
+du: cannot access `./st203/st203': Permission denied
+du: cannot access `./st203/FDM_070_PARALLEL.F90': Permission denied
+du: cannot access `./st203/FDM_121_WALLMODEL_KANG.F90': Permission denied
+du: cannot access `./st203/FDM_304_ASSIMILATION_WAVY.o': Permission denied
+du: cannot access `./st203/FDM_111_GERMANO.F90': Permission denied
+du: cannot access `./st203/FDM_023_SMOOTHING.o': Permission denied
+du: cannot access `./st203/FDM_122_WALLMODEL_ROMAN.F90': Permission denied
+du: cannot access `./st203/POST_BASIC': Permission denied
+du: cannot access `./st203/FDM_304_ASSIMILATION_WAVY.F90': Permission denied
+du: cannot access `./st203/st202.o3322029': Permission denied
+du: cannot access `./st203/FDM_000_MAIN.F90': Permission denied
+du: cannot access `./st203/FDM_032_IBM_EXTFORCING.F90': Permission denied
+du: cannot access `./st203/FDM_042_LS.F90': Permission denied
+du: cannot access `./st203/INCLUDE_FFT.FI': Permission denied
+du: cannot access `./st203/FDM_123_WALLMODEL_POWERLAW.F90': Permission denied
+du: cannot access `./st203/FDM_044_PRESCRIBEWAVE.F90': Permission denied
+du: cannot access `./st203/FDM_080_FFT.F90': Permission denied
+du: cannot access `./st203/submit_p': Permission denied
+du: cannot access `./st203/FDM_020_PRESOLVE.o': Permission denied
+du: cannot access `./st203/FDM_091_SEDIMENT.F90': Permission denied
+du: cannot access `./st203/FDM_300_ASSIMILATION.o': Permission denied
+du: cannot access `./st203/FDM_060_STATS_TS.o': Permission denied
+du: cannot access `./st203/INCLUDE_LES.FI': Permission denied
+du: cannot access `./st203/screen': Permission denied
+du: cannot access `./st203/INCLUDE_IO.FI': Permission denied
+du: cannot access `./st203/sink.dat': Permission denied
+du: cannot access `./st203/Makefile': Permission denied
+du: cannot access `./st203/DYE.IN': Permission denied
+du: cannot access `./st203/INCLUDE_WAVEGENERATOR.FI': Permission denied
+du: cannot access `./st203/FDM_303_MEANFLUC_DECOMPOSITION.F90': Permission denied
+du: cannot access `./st203/FDM_070_PARALLEL.o': Permission denied
+du: cannot access `./st203/FDM_305_ASSIMILATION_VORT.o': Permission denied
+du: cannot access `./st203/screenp': Permission denied
+du: cannot access `./st203/FDM_301_ASSIMILATION_GEOMETRY.F90': Permission denied
+du: cannot access `./st203/WAVE': Permission denied
+du: cannot access `./st203/st202.o3324437': Permission denied
+du: cannot access `./st203/st203.o3327145': Permission denied
+du: cannot access `./st203/FDM_033_IBM_INTFORCING.o': Permission denied
+du: cannot access `./st203/FDM_030_IBM.F90': Permission denied
+du: cannot access `./st203/STATS': Permission denied
+du: cannot access `./st203/FDM_306_ASSIMILATION_TOTAL.o': Permission denied
+du: cannot access `./st203/FDM_027_RK.o': Permission denied
+du: cannot access `./st203/FDM_020_PRESOLVE.F90': Permission denied
+du: cannot access `./st203/st202.o3324088': Permission denied
+du: cannot access `./st203/FDM_021_RHS.o': Permission denied
+du: cannot access `./st203/submit': Permission denied
+du: cannot access `./st203/FDM_111_GERMANO.o': Permission denied
+du: cannot access `./st203/FDM_999_FINALIZE.o': Permission denied
+du: cannot access `./st203/FDM_062_STRAINRATE.F90': Permission denied
+du: cannot access `./st203/FDM_130_INT.o': Permission denied
+du: cannot access `./st203/resga': Permission denied
+du: cannot access `./st203/FDM_051_IO.F90': Permission denied
+du: cannot access `./st203/FDM_063_CIRCVELO.F90': Permission denied
+du: cannot access `./st203/fort.1': Permission denied
+du: cannot access `./st203/st202.o3324040': Permission denied
+du: cannot access `./st203/aga.sh': Permission denied
+du: cannot access `./st203/TAGS': Permission denied
+du: cannot access `./st203/POST': Permission denied
+du: cannot access `./st203/screen1': Permission denied
+du: cannot access `./st203/FDM_121_WALLMODEL_KANG.o': Permission denied
+du: cannot access `./st203/PARAM.IN': Permission denied
+du: cannot access `./st203/FDM_043_VOF.o': Permission denied
+du: cannot access `./st203/INCLUDE_IBM.FI': Permission denied
+du: cannot access `./st203/CIRC_VELO': Permission denied
+du: cannot access `./st203/FDM_130_INT.F90': Permission denied
+du: cannot access `./st203/FDM_120_WALLMODEL_TBL.o': Permission denied
+du: cannot access `./st203/INCLUDE_SINKPARAM.FI': Permission denied
+du: cannot access `./st203/FDM_303_MEANFLUC_DECOMPOSITION.o': Permission denied
+du: cannot access `./st203/FDM_306_ASSIMILATION_TOTAL.F90': Permission denied
+du: cannot access `./st203/FDM_100_LES.F90': Permission denied
+du: cannot access `./st203/FDM_031_IBM_INIT.F90': Permission denied
+du: cannot access `./st203/FDM_061_STATS_TA.o': Permission denied
+du: cannot access `./st203/FDM_301_ASSIMILATION_GEOMETRY.o': Permission denied
+du: cannot access `./st203/TIME_SERIES': Permission denied
+du: cannot access `./st203/FDM_300_ASSIMILATION.F90': Permission denied
+du: cannot access `./st203/FDM_010_INIT_PARALLEL.F90': Permission denied
+du: cannot access `./st203/FDM_050_OUTPUT.F90': Permission denied
+du: cannot access `./st203/GATHERDATA': Permission denied
+du: cannot access `./st203/st202.o3322890': Permission denied
+du: cannot access `./st203/FDM_044_PRESCRIBEWAVE.o': Permission denied
+du: cannot access `./st203/INCLUDE_SCALAR.FI': Permission denied
+du: cannot access `./st203/README.md': Permission denied
+du: cannot access `./st203/tags': Permission denied
+du: cannot access `./st203/POST_WAVY_WALL': Permission denied
+du: cannot access `./st203/FDM_110_RNG.F90': Permission denied
+du: cannot access `./st203/FDM_022_WG.o': Permission denied
+du: cannot access `./st203/GRID.IN': Permission denied
+du: cannot access `./st203/FDM_999_FINALIZE.F90': Permission denied
+du: cannot access `./st203/FDM_025_PD.o': Permission denied
+du: cannot access `./st203/FDM_122_WALLMODEL_ROMAN.o': Permission denied
+du: cannot access `./st203/FDM_012_INIT_FIELD.F90': Permission denied
+du: cannot access `./st203/FDM_200_PETSC_SOLVER.F90': Permission denied
+du: cannot access `./st203/results_aegean': Permission denied
+du: cannot access `./st203/FDM_307_TRACER.F90': Permission denied
+du: cannot access `./st203/st202.o3324044': Permission denied
+du: cannot access `./st203/SURFACE': Permission denied
+du: cannot access `./st203/INCLUDE_STATS.FI': Permission denied
+du: cannot access `./st203/FDM_100_LES.o': Permission denied
+du: cannot access `./st203/FDM_060_STATS_TS.F90': Permission denied
+du: cannot access `./st203/FDM_091_SEDIMENT.o': Permission denied
+du: cannot access `./st203/FDM_031_IBM_INIT.o': Permission denied
+du: cannot access `./st203/FDM_080_FFT.o': Permission denied
+du: cannot access `./st203/FDM_120_WALLMODEL_TBL.F90': Permission denied
+du: cannot access `./st203/FDM_012_INIT_FIELD.o': Permission denied
+du: cannot access `./st203/prof_step': Permission denied
+du: cannot access `./st203/post_skewness': Permission denied
+du: cannot access `./st203/GATHERDATA.F90': Permission denied
+du: cannot access `./st203/fort.91': Permission denied
+du: cannot access `./st203/FDM_000_MAIN.o': Permission denied
+du: cannot access `./st203/FDM_042_LS.o': Permission denied
+du: cannot access `./st203/FDM_011_INIT_CONSTANTS.o': Permission denied
+du: cannot access `./st203/FDM_200_PETSC_SOLVER.o': Permission denied
+du: cannot access `./st203/MID': Permission denied
+du: cannot access `./st203/INCLUDE_POISSON.FI': Permission denied
+du: cannot access `./st203/PRIO_GENERATE_GRID': Permission denied
+12	./st203
+du: cannot access `./st141_c/FDM_026_PD_SPE.o': Permission denied
+du: cannot access `./st141_c/FDM_043_VOF.F90': Permission denied
+du: cannot access `./st141_c/FDM_123_WALLMODEL_POWERLAW.o': Permission denied
+du: cannot access `./st141_c/FDM_023_SMOOTHING.F90': Permission denied
+du: cannot access `./st141_c/SHOWGEO': Permission denied
+du: cannot access `./st141_c/FDM_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./st141_c/libtecio.a': Permission denied
+du: cannot access `./st141_c/FDM_027_RK.F90': Permission denied
+du: cannot access `./st141_c/FDM_302_WAVYVOR_DECOMPOSITION.F90': Permission denied
+du: cannot access `./st141_c/FDM_033_IBM_INTFORCING.F90': Permission denied
+du: cannot access `./st141_c/FDM_010_INIT_PARALLEL.o': Permission denied
+du: cannot access `./st141_c/GEOMETRY': Permission denied
+du: cannot access `./st141_c/FDM_110_RNG.o': Permission denied
+du: cannot access `./st141_c/FDM_025_PD.F90': Permission denied
+du: cannot access `./st141_c/FDM_070_PARALLEL.F90': Permission denied
+du: cannot access `./st141_c/FDM_121_WALLMODEL_KANG.F90': Permission denied
+du: cannot access `./st141_c/DATA': Permission denied
+du: cannot access `./st141_c/strainrate.dat': Permission denied
+du: cannot access `./st141_c/FDM_304_ASSIMILATION_WAVY.o': Permission denied
+du: cannot access `./st141_c/FDM_032_IBM_EXTFORCING.o': Permission denied
+du: cannot access `./st141_c/FDM_111_GERMANO.F90': Permission denied
+du: cannot access `./st141_c/FDM_023_SMOOTHING.o': Permission denied
+du: cannot access `./st141_c/FDM_122_WALLMODEL_ROMAN.F90': Permission denied
+du: cannot access `./st141_c/POST_BASIC': Permission denied
+du: cannot access `./st141_c/FDM_304_ASSIMILATION_WAVY.F90': Permission denied
+du: cannot access `./st141_c/FDM_000_MAIN.F90': Permission denied
+du: cannot access `./st141_c/FDM_032_IBM_EXTFORCING.F90': Permission denied
+du: cannot access `./st141_c/FDM_042_LS.F90': Permission denied
+du: cannot access `./st141_c/FDM_133_FLUIDP.F90': Permission denied
+du: cannot access `./st141_c/INCLUDE_FFT.FI': Permission denied
+du: cannot access `./st141_c/FDM_123_WALLMODEL_POWERLAW.F90': Permission denied
+du: cannot access `./st141_c/FDM_030_IBM.o': Permission denied
+du: cannot access `./st141_c/FDM_044_PRESCRIBEWAVE.F90': Permission denied
+du: cannot access `./st141_c/FDM_080_FFT.F90': Permission denied
+du: cannot access `./st141_c/submit_p': Permission denied
+du: cannot access `./st141_c/FDM_020_PRESOLVE.o': Permission denied
+du: cannot access `./st141_c/FDM_091_SEDIMENT.F90': Permission denied
+du: cannot access `./st141_c/FDM_300_ASSIMILATION.o': Permission denied
+du: cannot access `./st141_c/FDM_060_STATS_TS.o': Permission denied
+du: cannot access `./st141_c/aegean_stream.sh': Permission denied
+du: cannot access `./st141_c/INCLUDE_LES.FI': Permission denied
+du: cannot access `./st141_c/INCLUDE_IO.FI': Permission denied
+du: cannot access `./st141_c/sink.dat': Permission denied
+du: cannot access `./st141_c/Makefile': Permission denied
+du: cannot access `./st141_c/INCLUDE_WAVEGENERATOR.FI': Permission denied
+du: cannot access `./st141_c/FDM_303_MEANFLUC_DECOMPOSITION.F90': Permission denied
+du: cannot access `./st141_c/FDM_070_PARALLEL.o': Permission denied
+du: cannot access `./st141_c/FDM_305_ASSIMILATION_VORT.o': Permission denied
+du: cannot access `./st141_c/submit_data': Permission denied
+du: cannot access `./st141_c/FDM_301_ASSIMILATION_GEOMETRY.F90': Permission denied
+du: cannot access `./st141_c/WAVE': Permission denied
+du: cannot access `./st141_c/INCLUDE_PARALLEL.FI': Permission denied
+du: cannot access `./st141_c/FDM_033_IBM_INTFORCING.o': Permission denied
+du: cannot access `./st141_c/FDM_030_IBM.F90': Permission denied
+du: cannot access `./st141_c/STATS': Permission denied
+du: cannot access `./st141_c/FDM_306_ASSIMILATION_TOTAL.o': Permission denied
+du: cannot access `./st141_c/FDM_027_RK.o': Permission denied
+du: cannot access `./st141_c/FDM_020_PRESOLVE.F90': Permission denied
+du: cannot access `./st141_c/FDM_021_RHS.o': Permission denied
+du: cannot access `./st141_c/submit': Permission denied
+du: cannot access `./st141_c/FDM_111_GERMANO.o': Permission denied
+du: cannot access `./st141_c/FDM_999_FINALIZE.o': Permission denied
+du: cannot access `./st141_c/FDM_090_DYE.o': Permission denied
+du: cannot access `./st141_c/test3vof.dat': Permission denied
+du: cannot access `./st141_c/FDM_062_STRAINRATE.F90': Permission denied
+du: cannot access `./st141_c/resga': Permission denied
+du: cannot access `./st141_c/FDM_051_IO.F90': Permission denied
+du: cannot access `./st141_c/FDM_061_STATS_TA.F90': Permission denied
+du: cannot access `./st141_c/FDM_062_STRAINRATE.o': Permission denied
+du: cannot access `./st141_c/aga.sh': Permission denied
+du: cannot access `./st141_c/FDM_022_WG.F90': Permission denied
+du: cannot access `./st141_c/FDM_050_OUTPUT.o': Permission denied
+du: cannot access `./st141_c/TAGS': Permission denied
+du: cannot access `./st141_c/POST': Permission denied
+du: cannot access `./st141_c/INCLUDE_ASSIMILATION.FI': Permission denied
+du: cannot access `./st141_c/FDM_121_WALLMODEL_KANG.o': Permission denied
+du: cannot access `./st141_c/PARAM.IN': Permission denied
+du: cannot access `./st141_c/FDM_043_VOF.o': Permission denied
+du: cannot access `./st141_c/FDM_090_DYE.F90': Permission denied
+du: cannot access `./st141_c/INCLUDE_IBM.FI': Permission denied
+du: cannot access `./st141_c/FDM_120_WALLMODEL_TBL.o': Permission denied
+du: cannot access `./st141_c/ACCELERATION.DAT': Permission denied
+du: cannot access `./st141_c/INCLUDE_SINKPARAM.FI': Permission denied
+du: cannot access `./st141_c/INCLUDE_PARAMETER.FI': Permission denied
+du: cannot access `./st141_c/FDM_021_RHS.F90': Permission denied
+du: cannot access `./st141_c/FDM_303_MEANFLUC_DECOMPOSITION.o': Permission denied
+du: cannot access `./st141_c/FDM_306_ASSIMILATION_TOTAL.F90': Permission denied
+du: cannot access `./st141_c/FDM_100_LES.F90': Permission denied
+du: cannot access `./st141_c/FDM_031_IBM_INIT.F90': Permission denied
+du: cannot access `./st141_c/FDM_061_STATS_TA.o': Permission denied
+du: cannot access `./st141_c/FDM_301_ASSIMILATION_GEOMETRY.o': Permission denied
+du: cannot access `./st141_c/TIME_SERIES': Permission denied
+du: cannot access `./st141_c/FDM_300_ASSIMILATION.F90': Permission denied
+du: cannot access `./st141_c/FDM_010_INIT_PARALLEL.F90': Permission denied
+du: cannot access `./st141_c/FDM_050_OUTPUT.F90': Permission denied
+du: cannot access `./st141_c/GATHERDATA': Permission denied
+du: cannot access `./st141_c/FDM_044_PRESCRIBEWAVE.o': Permission denied
+du: cannot access `./st141_c/INCLUDE_SCALAR.FI': Permission denied
+du: cannot access `./st141_c/README.md': Permission denied
+du: cannot access `./st141_c/tags': Permission denied
+du: cannot access `./st141_c/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./st141_c/POST_WAVY_WALL': Permission denied
+du: cannot access `./st141_c/TRACER': Permission denied
+du: cannot access `./st141_c/FDM_051_IO.o': Permission denied
+du: cannot access `./st141_c/FDM_110_RNG.F90': Permission denied
+du: cannot access `./st141_c/FDM_022_WG.o': Permission denied
+du: cannot access `./st141_c/GRID.IN': Permission denied
+du: cannot access `./st141_c/FDM_999_FINALIZE.F90': Permission denied
+du: cannot access `./st141_c/FDM_025_PD.o': Permission denied
+du: cannot access `./st141_c/FDM_122_WALLMODEL_ROMAN.o': Permission denied
+du: cannot access `./st141_c/FDM_012_INIT_FIELD.F90': Permission denied
+du: cannot access `./st141_c/FDM_200_PETSC_SOLVER.F90': Permission denied
+du: cannot access `./st141_c/results_aegean': Permission denied
+du: cannot access `./st141_c/FDM_307_TRACER.F90': Permission denied
+du: cannot access `./st141_c/FDM_305_ASSIMILATION_VORT.F90': Permission denied
+du: cannot access `./st141_c/SURFACE': Permission denied
+du: cannot access `./st141_c/INCLUDE_STATS.FI': Permission denied
+du: cannot access `./st141_c/FDM_100_LES.o': Permission denied
+du: cannot access `./st141_c/FDM_060_STATS_TS.F90': Permission denied
+du: cannot access `./st141_c/FDM_091_SEDIMENT.o': Permission denied
+du: cannot access `./st141_c/FDM_307_TRACER.o': Permission denied
+du: cannot access `./st141_c/FDM_031_IBM_INIT.o': Permission denied
+du: cannot access `./st141_c/FDM_302_WAVYVOR_DECOMPOSITION.o': Permission denied
+du: cannot access `./st141_c/FDM_080_FFT.o': Permission denied
+du: cannot access `./st141_c/FDM_120_WALLMODEL_TBL.F90': Permission denied
+du: cannot access `./st141_c/FDM_026_PD_SPE.F90': Permission denied
+du: cannot access `./st141_c/FDM_012_INIT_FIELD.o': Permission denied
+du: cannot access `./st141_c/prof_step': Permission denied
+du: cannot access `./st141_c/post_skewness': Permission denied
+du: cannot access `./st141_c/FDM_000_MAIN.o': Permission denied
+du: cannot access `./st141_c/FDM_042_LS.o': Permission denied
+du: cannot access `./st141_c/FDM_011_INIT_CONSTANTS.o': Permission denied
+du: cannot access `./st141_c/FDM_200_PETSC_SOLVER.o': Permission denied
+du: cannot access `./st141_c/MID': Permission denied
+du: cannot access `./st141_c/INCLUDE_POISSON.FI': Permission denied
+du: cannot access `./st141_c/PRIO_GENERATE_GRID': Permission denied
+12	./st141_c
+4	./st139/GEOMETRY
+310272	./st139/DATA/V00037000.H5
+310272	./st139/DATA/V00024200.H5
+310272	./st139/DATA/V00030400.H5
+310272	./st139/DATA/V00008200.H5
+310272	./st139/DATA/V00036400.H5
+310272	./st139/DATA/V00008000.H5
+310272	./st139/DATA/V00019000.H5
+310272	./st139/DATA/V00001800.H5
+310272	./st139/DATA/V00003800.H5
+310272	./st139/DATA/V00024400.H5
+310272	./st139/DATA/V00022200.H5
+310272	./st139/DATA/V00033400.H5
+310272	./st139/DATA/V00031000.H5
+310272	./st139/DATA/V00034800.H5
+310272	./st139/DATA/V00018600.H5
+310272	./st139/DATA/V00030800.H5
+310272	./st139/DATA/V00030200.H5
+310272	./st139/DATA/V00011000.H5
+310272	./st139/DATA/V00019200.H5
+310272	./st139/DATA/V00027800.H5
+310272	./st139/DATA/V00030000.H5
+310272	./st139/DATA/V00026200.H5
+310272	./st139/DATA/V00018000.H5
+310272	./st139/DATA/V00015200.H5
+310272	./st139/DATA/V00000200.H5
+310272	./st139/DATA/V00009600.H5
+310272	./st139/DATA/V00027400.H5
+310272	./st139/DATA/V00033000.H5
+310272	./st139/DATA/V00027200.H5
+310272	./st139/DATA/V00023600.H5
+310272	./st139/DATA/V00018800.H5
+310272	./st139/DATA/V00037600.H5
+310272	./st139/DATA/V00025800.H5
+310272	./st139/DATA/V00005200.H5
+310272	./st139/DATA/V00021800.H5
+310272	./st139/DATA/V00012800.H5
+310272	./st139/DATA/V00023400.H5
+310272	./st139/DATA/V00011400.H5
+310272	./st139/DATA/V00036000.H5
+310272	./st139/DATA/V00012200.H5
+310272	./st139/DATA/V00019800.H5
+310272	./st139/DATA/V00014800.H5
+310272	./st139/DATA/V00007600.H5
+310272	./st139/DATA/V00006600.H5
+310272	./st139/DATA/V00036800.H5
+310272	./st139/DATA/V00013200.H5
+310272	./st139/DATA/V00033600.H5
+310272	./st139/DATA/V00018200.H5
+310272	./st139/DATA/V00024600.H5
+310272	./st139/DATA/V00019600.H5
+310272	./st139/DATA/V00035800.H5
+310272	./st139/DATA/V00038800.H5
+310272	./st139/DATA/V00020800.H5
+310272	./st139/DATA/V00037400.H5
+310272	./st139/DATA/V00026600.H5
+310272	./st139/DATA/V00027000.H5
+310272	./st139/DATA/V00021200.H5
+310272	./st139/DATA/V00015400.H5
+310272	./st139/DATA/V00005800.H5
+310272	./st139/DATA/V00016400.H5
+310272	./st139/DATA/V00029200.H5
+310272	./st139/DATA/V00038000.H5
+310272	./st139/DATA/V00005600.H5
+310272	./st139/DATA/V00033800.H5
+310272	./st139/DATA/V00025200.H5
+310272	./st139/DATA/V00032600.H5
+310272	./st139/DATA/V00009200.H5
+310272	./st139/DATA/V00001000.H5
+310272	./st139/DATA/V00014600.H5
+310272	./st139/DATA/V00005000.H5
+310272	./st139/DATA/V00016800.H5
+310272	./st139/DATA/V00038200.H5
+310272	./st139/DATA/V00009400.H5
+310272	./st139/DATA/V00000800.H5
+310272	./st139/DATA/V00007200.H5
+310272	./st139/DATA/V00010400.H5
+310272	./st139/DATA/V00012400.H5
+310272	./st139/DATA/V00025600.H5
+310272	./st139/DATA/V00010600.H5
+310272	./st139/DATA/V00029800.H5
+310272	./st139/DATA/V00007400.H5
+310272	./st139/DATA/V00034000.H5
+310272	./st139/DATA/V00028000.H5
+310272	./st139/DATA/V00007000.H5
+310272	./st139/DATA/V00002600.H5
+310272	./st139/DATA/V00031400.H5
+310272	./st139/DATA/V00002000.H5
+310272	./st139/DATA/V00010000.H5
+310272	./st139/DATA/V00006000.H5
+310272	./st139/DATA/V00004000.H5
+310272	./st139/DATA/V00029000.H5
+310272	./st139/DATA/V00013600.H5
+310272	./st139/DATA/V00010200.H5
+310272	./st139/DATA/V00004800.H5
+310272	./st139/DATA/V00034400.H5
+310272	./st139/DATA/V00013800.H5
+310272	./st139/DATA/V00027600.H5
+310272	./st139/DATA/V00017600.H5
+310272	./st139/DATA/V00012000.H5
+310272	./st139/DATA/V00031200.H5
+310272	./st139/DATA/V00028600.H5
+310272	./st139/DATA/V00001200.H5
+310272	./st139/DATA/V00013000.H5
+310272	./st139/DATA/V00007800.H5
+310272	./st139/DATA/V00001400.H5
+310272	./st139/DATA/V00029400.H5
+310272	./st139/DATA/V00020600.H5
+310272	./st139/DATA/V00022400.H5
+310272	./st139/DATA/V00016000.H5
+310272	./st139/DATA/V00009800.H5
+310272	./st139/DATA/V00031800.H5
+310272	./st139/DATA/V00000400.H5
+310272	./st139/DATA/V00011800.H5
+310272	./st139/DATA/V00015000.H5
+310272	./st139/DATA/V00024000.H5
+310272	./st139/DATA/V00003400.H5
+310272	./st139/DATA/V00029600.H5
+310272	./st139/DATA/V00017200.H5
+310272	./st139/DATA/V00021400.H5
+310272	./st139/DATA/V00020200.H5
+310272	./st139/DATA/V00023000.H5
+310272	./st139/DATA/V00015600.H5
+310272	./st139/DATA/V00011200.H5
+310272	./st139/DATA/V00032800.H5
+310272	./st139/DATA/V00025400.H5
+310272	./st139/DATA/V00023200.H5
+310272	./st139/DATA/V00024800.H5
+310272	./st139/DATA/V00026400.H5
+310272	./st139/DATA/V00035600.H5
+310272	./st139/DATA/V00004200.H5
+310272	./st139/DATA/V00012600.H5
+310272	./st139/DATA/V00035000.H5
+310272	./st139/DATA/V00023800.H5
+310272	./st139/DATA/V00006200.H5
+310272	./st139/DATA/V00003200.H5
+310272	./st139/DATA/V00035400.H5
+310272	./st139/DATA/V00037800.H5
+310272	./st139/DATA/V00008400.H5
+310272	./st139/DATA/V00002400.H5
+310272	./st139/DATA/V00004400.H5
+310272	./st139/DATA/V00018400.H5
+310272	./st139/DATA/V00009000.H5
+310272	./st139/DATA/V00028800.H5
+310272	./st139/DATA/V00020000.H5
+310272	./st139/DATA/V00033200.H5
+310272	./st139/DATA/V00022600.H5
+310272	./st139/DATA/V00008800.H5
+310272	./st139/DATA/V00032200.H5
+310272	./st139/DATA/V00000000.H5
+310272	./st139/DATA/V00006800.H5
+310272	./st139/DATA/V00017800.H5
+310272	./st139/DATA/V00000600.H5
+310272	./st139/DATA/V00015800.H5
+310272	./st139/DATA/V00032400.H5
+310272	./st139/DATA/V00014200.H5
+310272	./st139/DATA/V00014000.H5
+310272	./st139/DATA/V00036200.H5
+310272	./st139/DATA/V00022800.H5
+310272	./st139/DATA/V00003600.H5
+310272	./st139/DATA/V00016600.H5
+310272	./st139/DATA/V00035200.H5
+310272	./st139/DATA/V00030600.H5
+310272	./st139/DATA/V00001600.H5
+310272	./st139/DATA/V00028400.H5
+310272	./st139/DATA/V00022000.H5
+310272	./st139/DATA/V00014400.H5
+310272	./st139/DATA/V00020400.H5
+310272	./st139/DATA/V00002800.H5
+310272	./st139/DATA/V00017400.H5
+310272	./st139/DATA/V00036600.H5
+310272	./st139/DATA/V00032000.H5
+310272	./st139/DATA/V00021000.H5
+310272	./st139/DATA/V00026000.H5
+310272	./st139/DATA/V00011600.H5
+310272	./st139/DATA/V00005400.H5
+310272	./st139/DATA/V00026800.H5
+310272	./st139/DATA/V00037200.H5
+310272	./st139/DATA/V00038400.H5
+310272	./st139/DATA/V00017000.H5
+310272	./st139/DATA/V00019400.H5
+310272	./st139/DATA/V00025000.H5
+310272	./st139/DATA/V00031600.H5
+310272	./st139/DATA/V00013400.H5
+310272	./st139/DATA/V00038600.H5
+310272	./st139/DATA/V00006400.H5
+310272	./st139/DATA/V00003000.H5
+310272	./st139/DATA/V00008600.H5
+310272	./st139/DATA/V00010800.H5
+310272	./st139/DATA/V00002200.H5
+310272	./st139/DATA/V00021600.H5
+310272	./st139/DATA/V00034200.H5
+310272	./st139/DATA/V00028200.H5
+310272	./st139/DATA/V00004600.H5
+310272	./st139/DATA/V00034600.H5
+310272	./st139/DATA/V00016200.H5
+60503052	./st139/DATA
+4	./st139/aegean_stream.sh
+4036	./st139/sink.dat
+4	./st139/WAVE
+356440	./st139/STATS/BASIC.H5
+4	./st139/STATS/STAT_STEP
+356448	./st139/STATS
+2020	./st139/test3vof.dat
+4	./st139/aga.sh
+4	./st139/PARAM.IN
+7424	./st139/TIME_SERIES/MAXUVW.DAT
+4496	./st139/TIME_SERIES/CDCF.DAT
+11924	./st139/TIME_SERIES
+16724	./st139/wave
+4	./st139/TRACER
+8	./st139/GRID.IN
+10692	./st139/results_aegean
+8	./st139/SURFACE/00033050.dat
+8	./st139/SURFACE/00024400.dat
+8	./st139/SURFACE/00035300.dat
+8	./st139/SURFACE/00002850.dat
+8	./st139/SURFACE/00025200.dat
+8	./st139/SURFACE/00003250.dat
+8	./st139/SURFACE/00031850.dat
+8	./st139/SURFACE/00005900.dat
+8	./st139/SURFACE/00010950.dat
+8	./st139/SURFACE/00016350.dat
+8	./st139/SURFACE/00010700.dat
+8	./st139/SURFACE/00028100.dat
+8	./st139/SURFACE/00032950.dat
+8	./st139/SURFACE/00016500.dat
+8	./st139/SURFACE/00012650.dat
+8	./st139/SURFACE/00009400.dat
+8	./st139/SURFACE/00018950.dat
+8	./st139/SURFACE/00024900.dat
+8	./st139/SURFACE/00032650.dat
+8	./st139/SURFACE/00009850.dat
+8	./st139/SURFACE/00035500.dat
+8	./st139/SURFACE/00034200.dat
+8	./st139/SURFACE/00013150.dat
+8	./st139/SURFACE/00019950.dat
+8	./st139/SURFACE/00029450.dat
+8	./st139/SURFACE/00028750.dat
+8	./st139/SURFACE/00026250.dat
+8	./st139/SURFACE/00031550.dat
+8	./st139/SURFACE/00032900.dat
+8	./st139/SURFACE/00014300.dat
+8	./st139/SURFACE/00007200.dat
+8	./st139/SURFACE/00031350.dat
+8	./st139/SURFACE/00021400.dat
+8	./st139/SURFACE/00018550.dat
+8	./st139/SURFACE/00013600.dat
+8	./st139/SURFACE/00004950.dat
+8	./st139/SURFACE/00004450.dat
+8	./st139/SURFACE/00033900.dat
+8	./st139/SURFACE/00020800.dat
+8	./st139/SURFACE/00009000.dat
+8	./st139/SURFACE/00014250.dat
+8	./st139/SURFACE/00024300.dat
+8	./st139/SURFACE/00036750.dat
+8	./st139/SURFACE/00035450.dat
+8	./st139/SURFACE/00009450.dat
+8	./st139/SURFACE/00011600.dat
+8	./st139/SURFACE/00002950.dat
+8	./st139/SURFACE/00001650.dat
+8	./st139/SURFACE/00026050.dat
+8	./st139/SURFACE/00034350.dat
+8	./st139/SURFACE/00026900.dat
+8	./st139/SURFACE/00030550.dat
+8	./st139/SURFACE/00010800.dat
+8	./st139/SURFACE/00028900.dat
+8	./st139/SURFACE/00034750.dat
+8	./st139/SURFACE/00024350.dat
+8	./st139/SURFACE/00006100.dat
+8	./st139/SURFACE/00015700.dat
+8	./st139/SURFACE/00016750.dat
+8	./st139/SURFACE/00015200.dat
+8	./st139/SURFACE/00016250.dat
+8	./st139/SURFACE/00011100.dat
+8	./st139/SURFACE/00004300.dat
+8	./st139/SURFACE/00012350.dat
+8	./st139/SURFACE/00021000.dat
+8	./st139/SURFACE/00022300.dat
+8	./st139/SURFACE/00033950.dat
+8	./st139/SURFACE/00005000.dat
+8	./st139/SURFACE/00037300.dat
+8	./st139/SURFACE/00030450.dat
+8	./st139/SURFACE/00006250.dat
+8	./st139/SURFACE/00037400.dat
+8	./st139/SURFACE/00019300.dat
+8	./st139/SURFACE/00023300.dat
+8	./st139/SURFACE/00007050.dat
+8	./st139/SURFACE/00012600.dat
+8	./st139/SURFACE/00037600.dat
+8	./st139/SURFACE/00026200.dat
+8	./st139/SURFACE/00033400.dat
+8	./st139/SURFACE/00001500.dat
+8	./st139/SURFACE/00036900.dat
+8	./st139/SURFACE/00037350.dat
+8	./st139/SURFACE/00011300.dat
+8	./st139/SURFACE/00023200.dat
+8	./st139/SURFACE/00003300.dat
+8	./st139/SURFACE/00007300.dat
+8	./st139/SURFACE/00017400.dat
+8	./st139/SURFACE/00004550.dat
+8	./st139/SURFACE/00007950.dat
+8	./st139/SURFACE/00022000.dat
+8	./st139/SURFACE/00008100.dat
+8	./st139/SURFACE/00027700.dat
+8	./st139/SURFACE/00034700.dat
+8	./st139/SURFACE/00014850.dat
+8	./st139/SURFACE/00007800.dat
+8	./st139/SURFACE/00005300.dat
+8	./st139/SURFACE/00018000.dat
+8	./st139/SURFACE/00005700.dat
+8	./st139/SURFACE/00020300.dat
+8	./st139/SURFACE/00004500.dat
+8	./st139/SURFACE/00018800.dat
+8	./st139/SURFACE/00017750.dat
+8	./st139/SURFACE/00003100.dat
+8	./st139/SURFACE/00018400.dat
+8	./st139/SURFACE/00035100.dat
+8	./st139/SURFACE/00034400.dat
+8	./st139/SURFACE/00023250.dat
+8	./st139/SURFACE/00008650.dat
+8	./st139/SURFACE/00023150.dat
+8	./st139/SURFACE/00007450.dat
+8	./st139/SURFACE/00029250.dat
+8	./st139/SURFACE/00013400.dat
+8	./st139/SURFACE/00004150.dat
+8	./st139/SURFACE/00016050.dat
+8	./st139/SURFACE/00036650.dat
+8	./st139/SURFACE/00025700.dat
+8	./st139/SURFACE/00036350.dat
+8	./st139/SURFACE/00020650.dat
+8	./st139/SURFACE/00006850.dat
+8	./st139/SURFACE/00037450.dat
+8	./st139/SURFACE/00027000.dat
+8	./st139/SURFACE/00009650.dat
+8	./st139/SURFACE/00000750.dat
+8	./st139/SURFACE/00019750.dat
+8	./st139/SURFACE/00030500.dat
+8	./st139/SURFACE/00000100.dat
+8	./st139/SURFACE/00028700.dat
+8	./st139/SURFACE/00002700.dat
+8	./st139/SURFACE/00038500.dat
+8	./st139/SURFACE/00005650.dat
+8	./st139/SURFACE/00003450.dat
+8	./st139/SURFACE/00009100.dat
+8	./st139/SURFACE/00019150.dat
+8	./st139/SURFACE/00010400.dat
+8	./st139/SURFACE/00009250.dat
+8	./st139/SURFACE/00034600.dat
+8	./st139/SURFACE/00037100.dat
+8	./st139/SURFACE/00012800.dat
+8	./st139/SURFACE/00024050.dat
+8	./st139/SURFACE/00028550.dat
+8	./st139/SURFACE/00029000.dat
+8	./st139/SURFACE/00028850.dat
+8	./st139/SURFACE/00021800.dat
+8	./st139/SURFACE/00000200.dat
+8	./st139/SURFACE/00030400.dat
+8	./st139/SURFACE/00011750.dat
+8	./st139/SURFACE/00029350.dat
+8	./st139/SURFACE/00025950.dat
+8	./st139/SURFACE/00033850.dat
+8	./st139/SURFACE/00000900.dat
+8	./st139/SURFACE/00029200.dat
+8	./st139/SURFACE/00001900.dat
+8	./st139/SURFACE/00008450.dat
+8	./st139/SURFACE/00018500.dat
+8	./st139/SURFACE/00023850.dat
+8	./st139/SURFACE/00025250.dat
+8	./st139/SURFACE/00026000.dat
+8	./st139/SURFACE/00030850.dat
+8	./st139/SURFACE/00038450.dat
+8	./st139/SURFACE/00030050.dat
+8	./st139/SURFACE/00010900.dat
+8	./st139/SURFACE/00012300.dat
+8	./st139/SURFACE/00020150.dat
+8	./st139/SURFACE/00010250.dat
+8	./st139/SURFACE/00004000.dat
+8	./st139/SURFACE/00014050.dat
+8	./st139/SURFACE/00036050.dat
+8	./st139/SURFACE/00023450.dat
+8	./st139/SURFACE/00019450.dat
+8	./st139/SURFACE/00016650.dat
+8	./st139/SURFACE/00002900.dat
+8	./st139/SURFACE/00035850.dat
+8	./st139/SURFACE/00024000.dat
+8	./st139/SURFACE/00018100.dat
+8	./st139/SURFACE/00005850.dat
+8	./st139/SURFACE/00009750.dat
+8	./st139/SURFACE/00031950.dat
+8	./st139/SURFACE/00035650.dat
+8	./st139/SURFACE/00002800.dat
+8	./st139/SURFACE/00014450.dat
+8	./st139/SURFACE/00012250.dat
+8	./st139/SURFACE/00017000.dat
+8	./st139/SURFACE/00001700.dat
+8	./st139/SURFACE/00029300.dat
+8	./st139/SURFACE/00038550.dat
+8	./st139/SURFACE/00006400.dat
+8	./st139/SURFACE/00015050.dat
+8	./st139/SURFACE/00029850.dat
+8	./st139/SURFACE/00029400.dat
+8	./st139/SURFACE/00016300.dat
+8	./st139/SURFACE/00006550.dat
+8	./st139/SURFACE/00003950.dat
+8	./st139/SURFACE/00002200.dat
+8	./st139/SURFACE/00021350.dat
+8	./st139/SURFACE/00036450.dat
+8	./st139/SURFACE/00027800.dat
+8	./st139/SURFACE/00032100.dat
+8	./st139/SURFACE/00019700.dat
+8	./st139/SURFACE/00010450.dat
+8	./st139/SURFACE/00011150.dat
+8	./st139/SURFACE/00015350.dat
+8	./st139/SURFACE/00032150.dat
+8	./st139/SURFACE/00004750.dat
+8	./st139/SURFACE/00000850.dat
+8	./st139/SURFACE/00023550.dat
+8	./st139/SURFACE/00034100.dat
+8	./st139/SURFACE/00020600.dat
+8	./st139/SURFACE/00022050.dat
+8	./st139/SURFACE/00037050.dat
+8	./st139/SURFACE/00004350.dat
+8	./st139/SURFACE/00007500.dat
+8	./st139/SURFACE/00035250.dat
+8	./st139/SURFACE/00033700.dat
+8	./st139/SURFACE/00013300.dat
+8	./st139/SURFACE/00002000.dat
+8	./st139/SURFACE/00023900.dat
+8	./st139/SURFACE/00013350.dat
+8	./st139/SURFACE/00034850.dat
+8	./st139/SURFACE/00037750.dat
+8	./st139/SURFACE/00016450.dat
+8	./st139/SURFACE/00031750.dat
+8	./st139/SURFACE/00007700.dat
+8	./st139/SURFACE/00023800.dat
+8	./st139/SURFACE/00011700.dat
+8	./st139/SURFACE/00024500.dat
+8	./st139/SURFACE/00034150.dat
+8	./st139/SURFACE/00018050.dat
+8	./st139/SURFACE/00002350.dat
+8	./st139/SURFACE/00024700.dat
+8	./st139/SURFACE/00025150.dat
+8	./st139/SURFACE/00017650.dat
+8	./st139/SURFACE/00017800.dat
+8	./st139/SURFACE/00027200.dat
+8	./st139/SURFACE/00004100.dat
+8	./st139/SURFACE/00038200.dat
+8	./st139/SURFACE/00036100.dat
+8	./st139/SURFACE/00029950.dat
+8	./st139/SURFACE/00006300.dat
+8	./st139/SURFACE/00014100.dat
+8	./st139/SURFACE/00017950.dat
+8	./st139/SURFACE/00002550.dat
+8	./st139/SURFACE/00015300.dat
+8	./st139/SURFACE/00001100.dat
+8	./st139/SURFACE/00016100.dat
+8	./st139/SURFACE/00025900.dat
+8	./st139/SURFACE/00005750.dat
+8	./st139/SURFACE/00036300.dat
+8	./st139/SURFACE/00021950.dat
+8	./st139/SURFACE/00022450.dat
+8	./st139/SURFACE/00002500.dat
+8	./st139/SURFACE/00037850.dat
+8	./st139/SURFACE/00035600.dat
+8	./st139/SURFACE/00023000.dat
+8	./st139/SURFACE/00008800.dat
+8	./st139/SURFACE/00023950.dat
+8	./st139/SURFACE/00037700.dat
+8	./st139/SURFACE/00028800.dat
+8	./st139/SURFACE/00015150.dat
+8	./st139/SURFACE/00011650.dat
+8	./st139/SURFACE/00030000.dat
+8	./st139/SURFACE/00003700.dat
+8	./st139/SURFACE/00031450.dat
+8	./st139/SURFACE/00037900.dat
+8	./st139/SURFACE/00031400.dat
+8	./st139/SURFACE/00032350.dat
+8	./st139/SURFACE/00005400.dat
+8	./st139/SURFACE/00008750.dat
+8	./st139/SURFACE/00021050.dat
+8	./st139/SURFACE/00011950.dat
+8	./st139/SURFACE/00017550.dat
+8	./st139/SURFACE/00011550.dat
+8	./st139/SURFACE/00022850.dat
+8	./st139/SURFACE/00005500.dat
+8	./st139/SURFACE/00009950.dat
+8	./st139/SURFACE/00024450.dat
+8	./st139/SURFACE/00009150.dat
+8	./st139/SURFACE/00007000.dat
+8	./st139/SURFACE/00024950.dat
+8	./st139/SURFACE/00034250.dat
+8	./st139/SURFACE/00028950.dat
+8	./st139/SURFACE/00013100.dat
+8	./st139/SURFACE/00031700.dat
+8	./st139/SURFACE/00017300.dat
+8	./st139/SURFACE/00015250.dat
+8	./st139/SURFACE/00003150.dat
+8	./st139/SURFACE/00010150.dat
+8	./st139/SURFACE/00017050.dat
+8	./st139/SURFACE/00021550.dat
+8	./st139/SURFACE/00029750.dat
+8	./st139/SURFACE/00004700.dat
+8	./st139/SURFACE/00028200.dat
+8	./st139/SURFACE/00016800.dat
+8	./st139/SURFACE/00032550.dat
+8	./st139/SURFACE/00000400.dat
+8	./st139/SURFACE/00017350.dat
+8	./st139/SURFACE/00035700.dat
+8	./st139/SURFACE/00038300.dat
+8	./st139/SURFACE/00006450.dat
+8	./st139/SURFACE/00004650.dat
+8	./st139/SURFACE/00017850.dat
+8	./st139/SURFACE/00029100.dat
+8	./st139/SURFACE/00007750.dat
+8	./st139/SURFACE/00006350.dat
+8	./st139/SURFACE/00020050.dat
+8	./st139/SURFACE/00009200.dat
+8	./st139/SURFACE/00031050.dat
+8	./st139/SURFACE/00030300.dat
+8	./st139/SURFACE/00004900.dat
+8	./st139/SURFACE/00022950.dat
+8	./st139/SURFACE/00012750.dat
+8	./st139/SURFACE/00000150.dat
+8	./st139/SURFACE/00025350.dat
+8	./st139/SURFACE/00026500.dat
+8	./st139/SURFACE/00008000.dat
+8	./st139/SURFACE/00010500.dat
+8	./st139/SURFACE/00034000.dat
+8	./st139/SURFACE/00021450.dat
+8	./st139/SURFACE/00037200.dat
+8	./st139/SURFACE/00020900.dat
+8	./st139/SURFACE/00020700.dat
+8	./st139/SURFACE/00007100.dat
+8	./st139/SURFACE/00009700.dat
+8	./st139/SURFACE/00038000.dat
+8	./st139/SURFACE/00021650.dat
+8	./st139/SURFACE/00004250.dat
+8	./st139/SURFACE/00015800.dat
+8	./st139/SURFACE/00001550.dat
+8	./st139/SURFACE/00019800.dat
+8	./st139/SURFACE/00010550.dat
+8	./st139/SURFACE/00021750.dat
+8	./st139/SURFACE/00025550.dat
+8	./st139/SURFACE/00028300.dat
+8	./st139/SURFACE/00013500.dat
+8	./st139/SURFACE/00025100.dat
+8	./st139/SURFACE/00005200.dat
+8	./st139/SURFACE/00027550.dat
+8	./st139/SURFACE/00012450.dat
+8	./st139/SURFACE/00014800.dat
+8	./st139/SURFACE/00011350.dat
+8	./st139/SURFACE/00035150.dat
+8	./st139/SURFACE/00002300.dat
+8	./st139/SURFACE/00014000.dat
+8	./st139/SURFACE/00007250.dat
+8	./st139/SURFACE/00029900.dat
+8	./st139/SURFACE/00002650.dat
+8	./st139/SURFACE/00006600.dat
+8	./st139/SURFACE/00019850.dat
+8	./st139/SURFACE/00011400.dat
+8	./st139/SURFACE/00029150.dat
+8	./st139/SURFACE/00013650.dat
+8	./st139/SURFACE/00030200.dat
+8	./st139/SURFACE/00006950.dat
+8	./st139/SURFACE/00018900.dat
+8	./st139/SURFACE/00033750.dat
+8	./st139/SURFACE/00006000.dat
+8	./st139/SURFACE/00024150.dat
+8	./st139/SURFACE/00012050.dat
+8	./st139/SURFACE/00029050.dat
+8	./st139/SURFACE/00006750.dat
+8	./st139/SURFACE/00003850.dat
+8	./st139/SURFACE/00008150.dat
+8	./st139/SURFACE/00001050.dat
+8	./st139/SURFACE/00033550.dat
+8	./st139/SURFACE/00036000.dat
+8	./st139/SURFACE/00029650.dat
+8	./st139/SURFACE/00020450.dat
+8	./st139/SURFACE/00036950.dat
+8	./st139/SURFACE/00035900.dat
+8	./st139/SURFACE/00018600.dat
+8	./st139/SURFACE/00026800.dat
+8	./st139/SURFACE/00030650.dat
+8	./st139/SURFACE/00007600.dat
+8	./st139/SURFACE/00036500.dat
+8	./st139/SURFACE/00038650.dat
+8	./st139/SURFACE/00000600.dat
+8	./st139/SURFACE/00020000.dat
+8	./st139/SURFACE/00024600.dat
+8	./st139/SURFACE/00031600.dat
+8	./st139/SURFACE/00019600.dat
+8	./st139/SURFACE/00013700.dat
+8	./st139/SURFACE/00000700.dat
+8	./st139/SURFACE/00007350.dat
+8	./st139/SURFACE/00003600.dat
+8	./st139/SURFACE/00000450.dat
+8	./st139/SURFACE/00017450.dat
+8	./st139/SURFACE/00022100.dat
+8	./st139/SURFACE/00028250.dat
+8	./st139/SURFACE/00023700.dat
+8	./st139/SURFACE/00001000.dat
+8	./st139/SURFACE/00009900.dat
+8	./st139/SURFACE/00035400.dat
+8	./st139/SURFACE/00000350.dat
+8	./st139/SURFACE/00010650.dat
+8	./st139/SURFACE/00019500.dat
+8	./st139/SURFACE/00025000.dat
+8	./st139/SURFACE/00028600.dat
+8	./st139/SURFACE/00017100.dat
+8	./st139/SURFACE/00019400.dat
+8	./st139/SURFACE/00027100.dat
+8	./st139/SURFACE/00033200.dat
+8	./st139/SURFACE/00001600.dat
+8	./st139/SURFACE/00032300.dat
+8	./st139/SURFACE/00005550.dat
+8	./st139/SURFACE/00018150.dat
+8	./st139/SURFACE/00017600.dat
+8	./st139/SURFACE/00021900.dat
+8	./st139/SURFACE/00021300.dat
+8	./st139/SURFACE/00034650.dat
+8	./st139/SURFACE/00027450.dat
+8	./st139/SURFACE/00029800.dat
+8	./st139/SURFACE/00021200.dat
+8	./st139/SURFACE/00000050.dat
+8	./st139/SURFACE/00032850.dat
+8	./st139/SURFACE/00002250.dat
+8	./st139/SURFACE/00005050.dat
+8	./st139/SURFACE/00022500.dat
+8	./st139/SURFACE/00020950.dat
+8	./st139/SURFACE/00008950.dat
+8	./st139/SURFACE/00038350.dat
+8	./st139/SURFACE/00000650.dat
+8	./st139/SURFACE/00028050.dat
+8	./st139/SURFACE/00022350.dat
+8	./st139/SURFACE/00003750.dat
+8	./st139/SURFACE/00020350.dat
+8	./st139/SURFACE/00026700.dat
+8	./st139/SURFACE/00036200.dat
+8	./st139/SURFACE/00022700.dat
+8	./st139/SURFACE/00024200.dat
+8	./st139/SURFACE/00030900.dat
+8	./st139/SURFACE/00035050.dat
+8	./st139/SURFACE/00006700.dat
+8	./st139/SURFACE/00027600.dat
+8	./st139/SURFACE/00004050.dat
+8	./st139/SURFACE/00008350.dat
+8	./st139/SURFACE/00032800.dat
+8	./st139/SURFACE/00011800.dat
+8	./st139/SURFACE/00010050.dat
+8	./st139/SURFACE/00020750.dat
+8	./st139/SURFACE/00035000.dat
+8	./st139/SURFACE/00027750.dat
+8	./st139/SURFACE/00002750.dat
+8	./st139/SURFACE/00019200.dat
+8	./st139/SURFACE/00019100.dat
+8	./st139/SURFACE/00015850.dat
+8	./st139/SURFACE/00002150.dat
+8	./st139/SURFACE/00016550.dat
+8	./st139/SURFACE/00034500.dat
+8	./st139/SURFACE/00025750.dat
+8	./st139/SURFACE/00025850.dat
+8	./st139/SURFACE/00021500.dat
+8	./st139/SURFACE/00011000.dat
+8	./st139/SURFACE/00025400.dat
+8	./st139/SURFACE/00032600.dat
+8	./st139/SURFACE/00015750.dat
+8	./st139/SURFACE/00002600.dat
+8	./st139/SURFACE/00020850.dat
+8	./st139/SURFACE/00029500.dat
+8	./st139/SURFACE/00021700.dat
+8	./st139/SURFACE/00035750.dat
+8	./st139/SURFACE/00018750.dat
+8	./st139/SURFACE/00007150.dat
+8	./st139/SURFACE/00022200.dat
+8	./st139/SURFACE/00036850.dat
+8	./st139/SURFACE/00012100.dat
+8	./st139/SURFACE/00032500.dat
+8	./st139/SURFACE/00000550.dat
+8	./st139/SURFACE/00036400.dat
+8	./st139/SURFACE/00028650.dat
+8	./st139/SURFACE/00019000.dat
+8	./st139/SURFACE/00037550.dat
+8	./st139/SURFACE/00025650.dat
+8	./st139/SURFACE/00016600.dat
+8	./st139/SURFACE/00022650.dat
+8	./st139/SURFACE/00017150.dat
+8	./st139/SURFACE/00032700.dat
+8	./st139/SURFACE/00016850.dat
+8	./st139/SURFACE/00025800.dat
+8	./st139/SURFACE/00033000.dat
+8	./st139/SURFACE/00031250.dat
+8	./st139/SURFACE/00031200.dat
+8	./st139/SURFACE/00021250.dat
+8	./st139/SURFACE/00009300.dat
+8	./st139/SURFACE/00010200.dat
+8	./st139/SURFACE/00027050.dat
+8	./st139/SURFACE/00036600.dat
+8	./st139/SURFACE/00020200.dat
+8	./st139/SURFACE/00035350.dat
+8	./st139/SURFACE/00017500.dat
+8	./st139/SURFACE/00038250.dat
+8	./st139/SURFACE/00030100.dat
+8	./st139/SURFACE/00023400.dat
+8	./st139/SURFACE/00022600.dat
+8	./st139/SURFACE/00018700.dat
+8	./st139/SURFACE/00014650.dat
+8	./st139/SURFACE/00033450.dat
+8	./st139/SURFACE/00019650.dat
+8	./st139/SURFACE/00027950.dat
+8	./st139/SURFACE/00029550.dat
+8	./st139/SURFACE/00013450.dat
+8	./st139/SURFACE/00019900.dat
+8	./st139/SURFACE/00026100.dat
+8	./st139/SURFACE/00026600.dat
+8	./st139/SURFACE/00007850.dat
+8	./st139/SURFACE/00003350.dat
+8	./st139/SURFACE/00001350.dat
+8	./st139/SURFACE/00036700.dat
+8	./st139/SURFACE/00016900.dat
+8	./st139/SURFACE/00027300.dat
+8	./st139/SURFACE/00025050.dat
+8	./st139/SURFACE/00038700.dat
+8	./st139/SURFACE/00019250.dat
+8	./st139/SURFACE/00009550.dat
+8	./st139/SURFACE/00015550.dat
+8	./st139/SURFACE/00009600.dat
+8	./st139/SURFACE/00031150.dat
+8	./st139/SURFACE/00036800.dat
+8	./st139/SURFACE/00006800.dat
+8	./st139/SURFACE/00032250.dat
+8	./st139/SURFACE/00020250.dat
+8	./st139/SURFACE/00024750.dat
+8	./st139/SURFACE/00014150.dat
+8	./st139/SURFACE/00001150.dat
+8	./st139/SURFACE/00038400.dat
+8	./st139/SURFACE/00027400.dat
+8	./st139/SURFACE/00014900.dat
+8	./st139/SURFACE/00032000.dat
+8	./st139/SURFACE/00026400.dat
+8	./st139/SURFACE/00022800.dat
+8	./st139/SURFACE/00012000.dat
+8	./st139/SURFACE/00006500.dat
+8	./st139/SURFACE/00026950.dat
+8	./st139/SURFACE/00030750.dat
+8	./st139/SURFACE/00020500.dat
+8	./st139/SURFACE/00026350.dat
+8	./st139/SURFACE/00031300.dat
+8	./st139/SURFACE/00031650.dat
+8	./st139/SURFACE/00015400.dat
+8	./st139/SURFACE/00015500.dat
+8	./st139/SURFACE/00015900.dat
+8	./st139/SURFACE/00030350.dat
+8	./st139/SURFACE/00027850.dat
+8	./st139/SURFACE/00007400.dat
+8	./st139/SURFACE/00037800.dat
+8	./st139/SURFACE/00008900.dat
+8	./st139/SURFACE/00021850.dat
+8	./st139/SURFACE/00033100.dat
+8	./st139/SURFACE/00016400.dat
+8	./st139/SURFACE/00035800.dat
+8	./st139/SURFACE/00009500.dat
+8	./st139/SURFACE/00014500.dat
+8	./st139/SURFACE/00008600.dat
+8	./st139/SURFACE/00015950.dat
+8	./st139/SURFACE/00010750.dat
+8	./st139/SURFACE/00026850.dat
+8	./st139/SURFACE/00008550.dat
+8	./st139/SURFACE/00027350.dat
+8	./st139/SURFACE/00018650.dat
+8	./st139/SURFACE/00022250.dat
+8	./st139/SURFACE/00006650.dat
+8	./st139/SURFACE/00013000.dat
+8	./st139/SURFACE/00003050.dat
+8	./st139/SURFACE/00014700.dat
+8	./st139/SURFACE/00033500.dat
+8	./st139/SURFACE/00001750.dat
+8	./st139/SURFACE/00037950.dat
+8	./st139/SURFACE/00006900.dat
+8	./st139/SURFACE/00031000.dat
+8	./st139/SURFACE/00038050.dat
+8	./st139/SURFACE/00032400.dat
+8	./st139/SURFACE/00027250.dat
+8	./st139/SURFACE/00026550.dat
+8	./st139/SURFACE/00001250.dat
+8	./st139/SURFACE/00023650.dat
+8	./st139/SURFACE/00022400.dat
+8	./st139/SURFACE/00014750.dat
+8	./st139/SURFACE/00030800.dat
+8	./st139/SURFACE/00037650.dat
+8	./st139/SURFACE/00032200.dat
+8	./st139/SURFACE/00034800.dat
+8	./st139/SURFACE/00024650.dat
+8	./st139/SURFACE/00024250.dat
+8	./st139/SURFACE/00010350.dat
+8	./st139/SURFACE/00028500.dat
+8	./st139/SURFACE/00018300.dat
+8	./st139/SURFACE/00005600.dat
+8	./st139/SURFACE/00004200.dat
+8	./st139/SURFACE/00035950.dat
+8	./st139/SURFACE/00015100.dat
+8	./st139/SURFACE/00001800.dat
+8	./st139/SURFACE/00017900.dat
+8	./st139/SURFACE/00018350.dat
+8	./st139/SURFACE/00027650.dat
+8	./st139/SURFACE/00009350.dat
+8	./st139/SURFACE/00037000.dat
+8	./st139/SURFACE/00033350.dat
+8	./st139/SURFACE/00028350.dat
+8	./st139/SURFACE/00008250.dat
+8	./st139/SURFACE/00012150.dat
+8	./st139/SURFACE/00000250.dat
+8	./st139/SURFACE/00012500.dat
+8	./st139/SURFACE/00035200.dat
+8	./st139/SURFACE/00022750.dat
+8	./st139/SURFACE/00038150.dat
+8	./st139/SURFACE/00024850.dat
+8	./st139/SURFACE/00006050.dat
+8	./st139/SURFACE/00033650.dat
+8	./st139/SURFACE/00011850.dat
+8	./st139/SURFACE/00012950.dat
+8	./st139/SURFACE/00020100.dat
+8	./st139/SURFACE/00019350.dat
+8	./st139/SURFACE/00035550.dat
+8	./st139/SURFACE/00030600.dat
+8	./st139/SURFACE/00011450.dat
+8	./st139/SURFACE/00028150.dat
+8	./st139/SURFACE/00000950.dat
+8	./st139/SURFACE/00025600.dat
+8	./st139/SURFACE/00015600.dat
+8	./st139/SURFACE/00013050.dat
+8	./st139/SURFACE/00023350.dat
+8	./st139/SURFACE/00028000.dat
+8	./st139/SURFACE/00037150.dat
+8	./st139/SURFACE/00038600.dat
+8	./st139/SURFACE/00005950.dat
+8	./st139/SURFACE/00033300.dat
+8	./st139/SURFACE/00016950.dat
+8	./st139/SURFACE/00010850.dat
+8	./st139/SURFACE/00017250.dat
+8	./st139/SURFACE/00013850.dat
+8	./st139/SURFACE/00004600.dat
+8	./st139/SURFACE/00013750.dat
+8	./st139/SURFACE/00009800.dat
+8	./st139/SURFACE/00025500.dat
+8	./st139/SURFACE/00017700.dat
+8	./st139/SURFACE/00024100.dat
+8	./st139/SURFACE/00030150.dat
+8	./st139/SURFACE/00002100.dat
+8	./st139/SURFACE/00002050.dat
+8	./st139/SURFACE/00019550.dat
+8	./st139/SURFACE/00034950.dat
+8	./st139/SURFACE/00014200.dat
+8	./st139/SURFACE/00009050.dat
+8	./st139/SURFACE/00026300.dat
+8	./st139/SURFACE/00005350.dat
+8	./st139/SURFACE/00020550.dat
+8	./st139/SURFACE/00020400.dat
+8	./st139/SURFACE/00014400.dat
+8	./st139/SURFACE/00033600.dat
+8	./st139/SURFACE/00023600.dat
+8	./st139/SURFACE/00001450.dat
+8	./st139/SURFACE/00023500.dat
+8	./st139/SURFACE/00001200.dat
+8	./st139/SURFACE/00011050.dat
+8	./st139/SURFACE/00013200.dat
+8	./st139/SURFACE/00026450.dat
+8	./st139/SURFACE/00025450.dat
+8	./st139/SURFACE/00016200.dat
+8	./st139/SURFACE/00026650.dat
+8	./st139/SURFACE/00034550.dat
+8	./st139/SURFACE/00011250.dat
+8	./st139/SURFACE/00003400.dat
+8	./st139/SURFACE/00014550.dat
+8	./st139/SURFACE/00008700.dat
+8	./st139/SURFACE/00005250.dat
+8	./st139/SURFACE/00003650.dat
+0	./st139/SURFACE/00038800.dat
+8	./st139/SURFACE/00031100.dat
+8	./st139/SURFACE/00014600.dat
+8	./st139/SURFACE/00002400.dat
+8	./st139/SURFACE/00011200.dat
+8	./st139/SURFACE/00037250.dat
+8	./st139/SURFACE/00008050.dat
+8	./st139/SURFACE/00026150.dat
+8	./st139/SURFACE/00033250.dat
+8	./st139/SURFACE/00001850.dat
+8	./st139/SURFACE/00028450.dat
+8	./st139/SURFACE/00006200.dat
+8	./st139/SURFACE/00024800.dat
+8	./st139/SURFACE/00029700.dat
+8	./st139/SURFACE/00007900.dat
+8	./st139/SURFACE/00013950.dat
+8	./st139/SURFACE/00022550.dat
+8	./st139/SURFACE/00013900.dat
+8	./st139/SURFACE/00000300.dat
+8	./st139/SURFACE/00030950.dat
+8	./st139/SURFACE/00013800.dat
+8	./st139/SURFACE/00021600.dat
+8	./st139/SURFACE/00027900.dat
+8	./st139/SURFACE/00008400.dat
+8	./st139/SURFACE/00018250.dat
+8	./st139/SURFACE/00007650.dat
+8	./st139/SURFACE/00010100.dat
+8	./st139/SURFACE/00010300.dat
+8	./st139/SURFACE/00004400.dat
+8	./st139/SURFACE/00012900.dat
+8	./st139/SURFACE/00021100.dat
+8	./st139/SURFACE/00005800.dat
+8	./st139/SURFACE/00003200.dat
+8	./st139/SURFACE/00015450.dat
+8	./st139/SURFACE/00011900.dat
+8	./st139/SURFACE/00023750.dat
+8	./st139/SURFACE/00002450.dat
+8	./st139/SURFACE/00016150.dat
+8	./st139/SURFACE/00034050.dat
+8	./st139/SURFACE/00031800.dat
+8	./st139/SURFACE/00023050.dat
+8	./st139/SURFACE/00005150.dat
+8	./st139/SURFACE/00014950.dat
+8	./st139/SURFACE/00005100.dat
+8	./st139/SURFACE/00015000.dat
+8	./st139/SURFACE/00031900.dat
+8	./st139/SURFACE/00019050.dat
+8	./st139/SURFACE/00033150.dat
+8	./st139/SURFACE/00003000.dat
+8	./st139/SURFACE/00012700.dat
+8	./st139/SURFACE/00032450.dat
+8	./st139/SURFACE/00005450.dat
+8	./st139/SURFACE/00016700.dat
+8	./st139/SURFACE/00032750.dat
+8	./st139/SURFACE/00004800.dat
+8	./st139/SURFACE/00024550.dat
+8	./st139/SURFACE/00023100.dat
+8	./st139/SURFACE/00001300.dat
+8	./st139/SURFACE/00036150.dat
+8	./st139/SURFACE/00008300.dat
+8	./st139/SURFACE/00003500.dat
+8	./st139/SURFACE/00012550.dat
+8	./st139/SURFACE/00008850.dat
+8	./st139/SURFACE/00008500.dat
+8	./st139/SURFACE/00038100.dat
+8	./st139/SURFACE/00018850.dat
+8	./st139/SURFACE/00018450.dat
+8	./st139/SURFACE/00027150.dat
+8	./st139/SURFACE/00000500.dat
+8	./st139/SURFACE/00022900.dat
+8	./st139/SURFACE/00026750.dat
+8	./st139/SURFACE/00034450.dat
+8	./st139/SURFACE/00036250.dat
+8	./st139/SURFACE/00038750.dat
+8	./st139/SURFACE/00015650.dat
+8	./st139/SURFACE/00010000.dat
+8	./st139/SURFACE/00036550.dat
+8	./st139/SURFACE/00006150.dat
+8	./st139/SURFACE/00034300.dat
+8	./st139/SURFACE/00003550.dat
+8	./st139/SURFACE/00007550.dat
+8	./st139/SURFACE/00011500.dat
+8	./st139/SURFACE/00012200.dat
+8	./st139/SURFACE/00003900.dat
+8	./st139/SURFACE/00033800.dat
+8	./st139/SURFACE/00013550.dat
+8	./st139/SURFACE/00012400.dat
+8	./st139/SURFACE/00032050.dat
+8	./st139/SURFACE/00031500.dat
+8	./st139/SURFACE/00027500.dat
+8	./st139/SURFACE/00037500.dat
+8	./st139/SURFACE/00012850.dat
+8	./st139/SURFACE/00010600.dat
+8	./st139/SURFACE/00018200.dat
+8	./st139/SURFACE/00013250.dat
+8	./st139/SURFACE/00034900.dat
+8	./st139/SURFACE/00017200.dat
+8	./st139/SURFACE/00008200.dat
+8	./st139/SURFACE/00014350.dat
+8	./st139/SURFACE/00022150.dat
+8	./st139/SURFACE/00030250.dat
+8	./st139/SURFACE/00001950.dat
+8	./st139/SURFACE/00004850.dat
+8	./st139/SURFACE/00025300.dat
+8	./st139/SURFACE/00001400.dat
+8	./st139/SURFACE/00028400.dat
+8	./st139/SURFACE/00000800.dat
+8	./st139/SURFACE/00003800.dat
+8	./st139/SURFACE/00021150.dat
+8	./st139/SURFACE/00029600.dat
+8	./st139/SURFACE/00016000.dat
+8	./st139/SURFACE/00030700.dat
+6244	./st139/SURFACE
+4	./st139/prof_step
+4	./st139/MID/TIME.MID
+8	./st139/MID
+60911188	./st139
+du: cannot read directory `./JFM0': Permission denied
+12	./JFM0
+4	./st137/GEOMETRY
+310272	./st137/DATA/V00001800.H5
+310272	./st137/DATA/V00000200.H5
+310272	./st137/DATA/V00001000.H5
+310272	./st137/DATA/V00000800.H5
+310272	./st137/DATA/V00002600.H5
+310272	./st137/DATA/V00002000.H5
+310272	./st137/DATA/V00001200.H5
+310272	./st137/DATA/V00001400.H5
+310272	./st137/DATA/V00000400.H5
+310272	./st137/DATA/V00003200.H5
+310272	./st137/DATA/V00002400.H5
+310272	./st137/DATA/V00000000.H5
+310272	./st137/DATA/V00000600.H5
+310272	./st137/DATA/V00001600.H5
+310272	./st137/DATA/V00002800.H5
+310272	./st137/DATA/V00003000.H5
+310272	./st137/DATA/V00002200.H5
+5274628	./st137/DATA
+4	./st137/aegean_stream.sh
+356	./st137/sink.dat
+4	./st137/WAVE
+356440	./st137/STATS/BASIC.H5
+4	./st137/STATS/STAT_STEP
+356448	./st137/STATS
+180	./st137/test3vof.dat
+4	./st137/aga.sh
+4	./st137/PARAM.IN
+648	./st137/TIME_SERIES/MAXUVW.DAT
+356	./st137/TIME_SERIES/CDCF.DAT
+1008	./st137/TIME_SERIES
+16724	./st137/wave
+4	./st137/TRACER
+8	./st137/GRID.IN
+932	./st137/results_aegean
+8	./st137/SURFACE/00002850.dat
+8	./st137/SURFACE/00003250.dat
+8	./st137/SURFACE/00002950.dat
+8	./st137/SURFACE/00001650.dat
+8	./st137/SURFACE/00001500.dat
+8	./st137/SURFACE/00003300.dat
+8	./st137/SURFACE/00003100.dat
+8	./st137/SURFACE/00000750.dat
+8	./st137/SURFACE/00000100.dat
+8	./st137/SURFACE/00002700.dat
+8	./st137/SURFACE/00000200.dat
+8	./st137/SURFACE/00000900.dat
+8	./st137/SURFACE/00001900.dat
+8	./st137/SURFACE/00002900.dat
+8	./st137/SURFACE/00002800.dat
+8	./st137/SURFACE/00001700.dat
+8	./st137/SURFACE/00002200.dat
+8	./st137/SURFACE/00000850.dat
+8	./st137/SURFACE/00002000.dat
+8	./st137/SURFACE/00002350.dat
+8	./st137/SURFACE/00002550.dat
+8	./st137/SURFACE/00001100.dat
+8	./st137/SURFACE/00002500.dat
+8	./st137/SURFACE/00003150.dat
+8	./st137/SURFACE/00000400.dat
+8	./st137/SURFACE/00000150.dat
+8	./st137/SURFACE/00001550.dat
+8	./st137/SURFACE/00002300.dat
+8	./st137/SURFACE/00002650.dat
+8	./st137/SURFACE/00001050.dat
+8	./st137/SURFACE/00000600.dat
+8	./st137/SURFACE/00000700.dat
+8	./st137/SURFACE/00000450.dat
+8	./st137/SURFACE/00001000.dat
+8	./st137/SURFACE/00000350.dat
+8	./st137/SURFACE/00001600.dat
+8	./st137/SURFACE/00000050.dat
+8	./st137/SURFACE/00002250.dat
+8	./st137/SURFACE/00000650.dat
+8	./st137/SURFACE/00002750.dat
+8	./st137/SURFACE/00002150.dat
+8	./st137/SURFACE/00002600.dat
+8	./st137/SURFACE/00000550.dat
+0	./st137/SURFACE/00003350.dat
+8	./st137/SURFACE/00001350.dat
+8	./st137/SURFACE/00001150.dat
+8	./st137/SURFACE/00003050.dat
+8	./st137/SURFACE/00001750.dat
+8	./st137/SURFACE/00001250.dat
+8	./st137/SURFACE/00001800.dat
+8	./st137/SURFACE/00000250.dat
+8	./st137/SURFACE/00000950.dat
+8	./st137/SURFACE/00002100.dat
+8	./st137/SURFACE/00002050.dat
+8	./st137/SURFACE/00001450.dat
+8	./st137/SURFACE/00001200.dat
+8	./st137/SURFACE/00002400.dat
+8	./st137/SURFACE/00001850.dat
+8	./st137/SURFACE/00000300.dat
+8	./st137/SURFACE/00003200.dat
+8	./st137/SURFACE/00002450.dat
+8	./st137/SURFACE/00003000.dat
+8	./st137/SURFACE/00001300.dat
+8	./st137/SURFACE/00000500.dat
+8	./st137/SURFACE/00001950.dat
+8	./st137/SURFACE/00001400.dat
+8	./st137/SURFACE/00000800.dat
+532	./st137/SURFACE
+4	./st137/prof_step
+4	./st137/MID/TIME.MID
+8	./st137/MID
+5650856	./st137
+du: cannot access `./st201/FDM_043_VOF.F90': Permission denied
+du: cannot access `./st201/FDM_023_SMOOTHING.F90': Permission denied
+du: cannot access `./st201/SHOWGEO': Permission denied
+du: cannot access `./st201/FDM_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./st201/libtecio.a': Permission denied
+du: cannot access `./st201/FDM_027_RK.F90': Permission denied
+du: cannot access `./st201/FDM_302_WAVYVOR_DECOMPOSITION.F90': Permission denied
+du: cannot access `./st201/FDM_033_IBM_INTFORCING.F90': Permission denied
+du: cannot access `./st201/GEOMETRY': Permission denied
+du: cannot access `./st201/FDM_025_PD.F90': Permission denied
+du: cannot access `./st201/FDM_070_PARALLEL.F90': Permission denied
+du: cannot access `./st201/FDM_121_WALLMODEL_KANG.F90': Permission denied
+du: cannot access `./st201/FDM_111_GERMANO.F90': Permission denied
+du: cannot access `./st201/FDM_122_WALLMODEL_ROMAN.F90': Permission denied
+du: cannot access `./st201/POST_BASIC': Permission denied
+du: cannot access `./st201/FDM_304_ASSIMILATION_WAVY.F90': Permission denied
+du: cannot access `./st201/FDM_000_MAIN.F90': Permission denied
+du: cannot access `./st201/FDM_032_IBM_EXTFORCING.F90': Permission denied
+du: cannot access `./st201/FDM_042_LS.F90': Permission denied
+du: cannot access `./st201/INCLUDE_FFT.FI': Permission denied
+du: cannot access `./st201/FDM_123_WALLMODEL_POWERLAW.F90': Permission denied
+du: cannot access `./st201/FDM_044_PRESCRIBEWAVE.F90': Permission denied
+du: cannot access `./st201/FDM_080_FFT.F90': Permission denied
+du: cannot access `./st201/submit_p': Permission denied
+du: cannot access `./st201/FDM_091_SEDIMENT.F90': Permission denied
+du: cannot access `./st201/aegean_stream.sh': Permission denied
+du: cannot access `./st201/INCLUDE_LES.FI': Permission denied
+du: cannot access `./st201/INCLUDE_IO.FI': Permission denied
+du: cannot access `./st201/sink.dat': Permission denied
+du: cannot access `./st201/Makefile': Permission denied
+du: cannot access `./st201/DYE.IN': Permission denied
+du: cannot access `./st201/INCLUDE_WAVEGENERATOR.FI': Permission denied
+du: cannot access `./st201/FDM_303_MEANFLUC_DECOMPOSITION.F90': Permission denied
+du: cannot access `./st201/screenp': Permission denied
+du: cannot access `./st201/submit_data': Permission denied
+du: cannot access `./st201/FDM_301_ASSIMILATION_GEOMETRY.F90': Permission denied
+du: cannot access `./st201/WAVE': Permission denied
+du: cannot access `./st201/INCLUDE_PARALLEL.FI': Permission denied
+du: cannot access `./st201/FDM_030_IBM.F90': Permission denied
+du: cannot access `./st201/STATS': Permission denied
+du: cannot access `./st201/FDM_020_PRESOLVE.F90': Permission denied
+du: cannot access `./st201/submit': Permission denied
+du: cannot access `./st201/test3vof.dat': Permission denied
+du: cannot access `./st201/FDM_062_STRAINRATE.F90': Permission denied
+du: cannot access `./st201/resga': Permission denied
+du: cannot access `./st201/FDM_051_IO.F90': Permission denied
+du: cannot access `./st201/FDM_061_STATS_TA.F90': Permission denied
+du: cannot access `./st201/aga.sh': Permission denied
+du: cannot access `./st201/FDM_022_WG.F90': Permission denied
+du: cannot access `./st201/TAGS': Permission denied
+du: cannot access `./st201/core': Permission denied
+du: cannot access `./st201/POST': Permission denied
+du: cannot access `./st201/screen1': Permission denied
+du: cannot access `./st201/INCLUDE_ASSIMILATION.FI': Permission denied
+du: cannot access `./st201/PARAM.IN': Permission denied
+du: cannot access `./st201/FDM_090_DYE.F90': Permission denied
+du: cannot access `./st201/INCLUDE_IBM.FI': Permission denied
+du: cannot access `./st201/INCLUDE_SINKPARAM.FI': Permission denied
+du: cannot access `./st201/INCLUDE_PARAMETER.FI': Permission denied
+du: cannot access `./st201/FDM_021_RHS.F90': Permission denied
+du: cannot access `./st201/FDM_306_ASSIMILATION_TOTAL.F90': Permission denied
+du: cannot access `./st201/FDM_100_LES.F90': Permission denied
+du: cannot access `./st201/FDM_031_IBM_INIT.F90': Permission denied
+du: cannot access `./st201/TIME_SERIES': Permission denied
+du: cannot access `./st201/screenga': Permission denied
+du: cannot access `./st201/FDM_300_ASSIMILATION.F90': Permission denied
+du: cannot access `./st201/FDM_010_INIT_PARALLEL.F90': Permission denied
+du: cannot access `./st201/FDM_050_OUTPUT.F90': Permission denied
+du: cannot access `./st201/GATHERDATA': Permission denied
+du: cannot access `./st201/INCLUDE_SCALAR.FI': Permission denied
+du: cannot access `./st201/README.md': Permission denied
+du: cannot access `./st201/tags': Permission denied
+du: cannot access `./st201/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./st201/POST_WAVY_WALL': Permission denied
+du: cannot access `./st201/TRACER': Permission denied
+du: cannot access `./st201/FDM_110_RNG.F90': Permission denied
+du: cannot access `./st201/GRID.IN': Permission denied
+du: cannot access `./st201/FDM_999_FINALIZE.F90': Permission denied
+du: cannot access `./st201/FDM_012_INIT_FIELD.F90': Permission denied
+du: cannot access `./st201/FDM_200_PETSC_SOLVER.F90': Permission denied
+du: cannot access `./st201/results_aegean': Permission denied
+du: cannot access `./st201/FDM_307_TRACER.F90': Permission denied
+du: cannot access `./st201/FDM_305_ASSIMILATION_VORT.F90': Permission denied
+du: cannot access `./st201/SURFACE': Permission denied
+du: cannot access `./st201/INCLUDE_STATS.FI': Permission denied
+du: cannot access `./st201/FDM_060_STATS_TS.F90': Permission denied
+du: cannot access `./st201/FDM_120_WALLMODEL_TBL.F90': Permission denied
+du: cannot access `./st201/FDM_026_PD_SPE.F90': Permission denied
+du: cannot access `./st201/prof_step': Permission denied
+du: cannot access `./st201/post_skewness': Permission denied
+du: cannot access `./st201/GATHERDATA.F90': Permission denied
+du: cannot access `./st201/MID': Permission denied
+du: cannot access `./st201/INCLUDE_POISSON.FI': Permission denied
+du: cannot access `./st201/PRIO_GENERATE_GRID': Permission denied
+12	./st201
+912	./IBM12/libtecio.a
+du: cannot access `./IBM12/INCLUDE/INCLUDE_FFT.FI': Permission denied
+du: cannot access `./IBM12/INCLUDE/INCLUDE_CINTERFACE.FI': Permission denied
+du: cannot access `./IBM12/INCLUDE/INCLUDE_LES.FI': Permission denied
+du: cannot access `./IBM12/INCLUDE/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM12/INCLUDE/INCLUDE_WAVEGENERATOR.FI': Permission denied
+du: cannot access `./IBM12/INCLUDE/INCLUDE_PARALLEL.FI': Permission denied
+du: cannot access `./IBM12/INCLUDE/INCLUDE_PETSC.FI': Permission denied
+du: cannot access `./IBM12/INCLUDE/INCLUDE_ASSIMILATION.FI': Permission denied
+du: cannot access `./IBM12/INCLUDE/INCLUDE_IBM.FI': Permission denied
+du: cannot access `./IBM12/INCLUDE/variables_new.h': Permission denied
+du: cannot access `./IBM12/INCLUDE/INCLUDE_PARAMETER.FI': Permission denied
+du: cannot access `./IBM12/INCLUDE/mpm_vars_new.h': Permission denied
+du: cannot access `./IBM12/INCLUDE/INCLUDE_SCALAR.FI': Permission denied
+du: cannot access `./IBM12/INCLUDE/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM12/INCLUDE/INCLUDE_STATS.FI': Permission denied
+du: cannot access `./IBM12/INCLUDE/INCLUDE_POISSON.FI': Permission denied
+4	./IBM12/INCLUDE
+du: cannot access `./IBM12/CALCULATE/FDM_043_VOF.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_023_SMOOTHING.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_027_RK.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_302_WAVYVOR_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_033_IBM_INTFORCING.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_025_PD.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_070_PARALLEL.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_121_WALLMODEL_KANG.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_111_GERMANO.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_122_WALLMODEL_ROMAN.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_304_ASSIMILATION_WAVY.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_000_MAIN.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_032_IBM_EXTFORCING.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_042_LS.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_123_WALLMODEL_POWERLAW.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_044_PRESCRIBEWAVE.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_080_FFT.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_091_SEDIMENT.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_303_MEANFLUC_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_301_ASSIMILATION_GEOMETRY.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_030_IBM.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_020_PRESOLVE.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_062_STRAINRATE.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_051_IO.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_063_CIRCVELO.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_061_STATS_TA.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_022_WG.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_090_DYE.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_130_INT.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_021_RHS.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_306_ASSIMILATION_TOTAL.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_100_LES.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_031_IBM_INIT.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_300_ASSIMILATION.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_010_INIT_PARALLEL.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_050_OUTPUT.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/tags': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_110_RNG.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_012_INIT_FIELD.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_200_PETSC_SOLVER.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_307_TRACER.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_001_FSTRANSFER.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_305_ASSIMILATION_VORT.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_060_STATS_TS.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_120_WALLMODEL_TBL.F90': Permission denied
+du: cannot access `./IBM12/CALCULATE/FDM_026_PD_SPE.F90': Permission denied
+12	./IBM12/CALCULATE
+du: cannot access `./IBM12/POST_BASIC/POST_020_STATS.F90': Permission denied
+du: cannot access `./IBM12/POST_BASIC/POST_030_READFILE.F90': Permission denied
+du: cannot access `./IBM12/POST_BASIC/POST_031_PARALLEL.F90': Permission denied
+du: cannot access `./IBM12/POST_BASIC/POST_000_MAIN.F90': Permission denied
+du: cannot access `./IBM12/POST_BASIC/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM12/POST_BASIC/POST_040_AVERAGE.F90': Permission denied
+du: cannot access `./IBM12/POST_BASIC/POST_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM12/POST_BASIC/POST_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM12/POST_BASIC/POST_050_WRITEFILE.F90': Permission denied
+du: cannot access `./IBM12/POST_BASIC/POST_010_INIT_PARALLEL.F90': Permission denied
+4	./IBM12/POST_BASIC
+4	./IBM12/aegean_stream.sh
+8	./IBM12/Makefile
+4	./IBM12/WAVE
+4	./IBM12/resga
+4964	./IBM12/sour.dat
+4	./IBM12/aga.sh
+4	./IBM12/PARAM.IN
+du: cannot access `./IBM12/GATHERDATA/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM12/GATHERDATA/tecio.f90': Permission denied
+du: cannot access `./IBM12/GATHERDATA/GATHER_IO.F90': Permission denied
+du: cannot access `./IBM12/GATHERDATA/GATHERDATA.F90': Permission denied
+4	./IBM12/GATHERDATA
+du: cannot access `./IBM12/POST_WAVY_WALL/POST_030_READFILE.F90': Permission denied
+du: cannot access `./IBM12/POST_WAVY_WALL/POST_000_MAIN.F90': Permission denied
+du: cannot access `./IBM12/POST_WAVY_WALL/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM12/POST_WAVY_WALL/POST_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM12/POST_WAVY_WALL/POST_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM12/POST_WAVY_WALL/POST_040_WRITEFILE.F90': Permission denied
+du: cannot access `./IBM12/POST_WAVY_WALL/POST_020_AVERAGE.F90': Permission denied
+du: cannot access `./IBM12/POST_WAVY_WALL/POST_010_INIT_PARALLEL.F90': Permission denied
+4	./IBM12/POST_WAVY_WALL
+du: cannot read directory `./IBM12/TRACER': Permission denied
+4	./IBM12/TRACER
+8	./IBM12/GRID.IN
+308	./IBM12/results_aegean
+4	./IBM12/prof_step
+4	./IBM12/Beforemaking
+du: cannot access `./IBM12/PRIO_GENERATE_GRID/Makefile': Permission denied
+du: cannot access `./IBM12/PRIO_GENERATE_GRID/genegrid': Permission denied
+du: cannot access `./IBM12/PRIO_GENERATE_GRID/GENEGRID.F90': Permission denied
+4	./IBM12/PRIO_GENERATE_GRID
+6268	./IBM12
+du: cannot access `./IBM1/libtecio.a': Permission denied
+du: cannot access `./IBM1/INCLUDE': Permission denied
+du: cannot access `./IBM1/GEOMETRY': Permission denied
+du: cannot access `./IBM1/CALCULATE': Permission denied
+du: cannot access `./IBM1/DATA': Permission denied
+du: cannot access `./IBM1/LIB': Permission denied
+du: cannot access `./IBM1/POST_BASIC': Permission denied
+du: cannot access `./IBM1/gatherdata': Permission denied
+du: cannot access `./IBM1/submit_p': Permission denied
+du: cannot access `./IBM1/aegean_stream.sh': Permission denied
+du: cannot access `./IBM1/screen': Permission denied
+du: cannot access `./IBM1/Makefile': Permission denied
+du: cannot access `./IBM1/submit_data': Permission denied
+du: cannot access `./IBM1/WAVE': Permission denied
+du: cannot access `./IBM1/RESTART_SOLID': Permission denied
+du: cannot access `./IBM1/STATS': Permission denied
+du: cannot access `./IBM1/submit': Permission denied
+du: cannot access `./IBM1/batchrun': Permission denied
+du: cannot access `./IBM1/resga': Permission denied
+du: cannot access `./IBM1/phi-v.mcr': Permission denied
+du: cannot access `./IBM1/sour.dat': Permission denied
+du: cannot access `./IBM1/aga.sh': Permission denied
+du: cannot access `./IBM1/PARAM.IN': Permission denied
+du: cannot access `./IBM1/CIRC_VELO': Permission denied
+du: cannot access `./IBM1/TIME_SERIES': Permission denied
+du: cannot access `./IBM1/screenga': Permission denied
+du: cannot access `./IBM1/GATHERDATA': Permission denied
+du: cannot access `./IBM1/wave': Permission denied
+du: cannot access `./IBM1/POST_WAVY_WALL': Permission denied
+du: cannot access `./IBM1/TRACER': Permission denied
+du: cannot access `./IBM1/GRID.IN': Permission denied
+du: cannot access `./IBM1/FLUX': Permission denied
+du: cannot access `./IBM1/results_aegean': Permission denied
+du: cannot access `./IBM1/SURFACE': Permission denied
+du: cannot access `./IBM1/phi-f.mcr': Permission denied
+du: cannot access `./IBM1/prof_step': Permission denied
+du: cannot access `./IBM1/Beforemaking': Permission denied
+du: cannot access `./IBM1/MID': Permission denied
+du: cannot access `./IBM1/PRIO_GENERATE_GRID': Permission denied
+4	./IBM1
+du: cannot access `./IBM10/libtecio.a': Permission denied
+du: cannot access `./IBM10/INCLUDE': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R1': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R1Z': Permission denied
+du: cannot access `./IBM10/vorcenterp.sh': Permission denied
+du: cannot access `./IBM10/GEOMETRY': Permission denied
+du: cannot access `./IBM10/CALCULATE': Permission denied
+du: cannot access `./IBM10/volume.dat': Permission denied
+du: cannot access `./IBM10/DATA': Permission denied
+du: cannot access `./IBM10/vordynamic.sh': Permission denied
+du: cannot access `./IBM10/LIB': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L1W': Permission denied
+du: cannot access `./IBM10/vorcenterp': Permission denied
+du: cannot access `./IBM10/POST_BASIC': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_C': Permission denied
+du: cannot access `./IBM10/gatherdata': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L4X': Permission denied
+du: cannot access `./IBM10/VORCENTER_TIME_J57.DAT': Permission denied
+du: cannot access `./IBM10/vordynamic': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L1Z': Permission denied
+du: cannot access `./IBM10/POST_TKE': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R1W': Permission denied
+du: cannot access `./IBM10/submit_p': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R2W': Permission denied
+du: cannot access `./IBM10/aegean_stream.sh': Permission denied
+du: cannot access `./IBM10/resdy1': Permission denied
+du: cannot access `./IBM10/resvor': Permission denied
+du: cannot access `./IBM10/screen': Permission denied
+du: cannot access `./IBM10/Makefile': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R2X': Permission denied
+du: cannot access `./IBM10/submit_data': Permission denied
+du: cannot access `./IBM10/VORCENTER_PRE': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L4Y': Permission denied
+du: cannot access `./IBM10/WAVE': Permission denied
+du: cannot access `./IBM10/RESTART_SOLID': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L4W': Permission denied
+du: cannot access `./IBM10/VORSTEP1.DAT': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R1X': Permission denied
+du: cannot access `./IBM10/VORCENTER_CIR': Permission denied
+du: cannot access `./IBM10/STATS': Permission denied
+du: cannot access `./IBM10/submit': Permission denied
+du: cannot access `./IBM10/resvorcp': Permission denied
+du: cannot access `./IBM10/batchrun': Permission denied
+du: cannot access `./IBM10/resga': Permission denied
+du: cannot access `./IBM10/sour.dat': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L2Y': Permission denied
+du: cannot access `./IBM10/aga.sh': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R1Y': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L1': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_CX': Permission denied
+du: cannot access `./IBM10/vorcenter': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R4': Permission denied
+du: cannot access `./IBM10/POST': Permission denied
+du: cannot access `./IBM10/prof_step2': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_CY': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L4Z': Permission denied
+du: cannot access `./IBM10/PARAM.IN': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R4W': Permission denied
+du: cannot access `./IBM10/CIRC_VELO': Permission denied
+du: cannot access `./IBM10/vorcenter.sh': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L4': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_CZ': Permission denied
+du: cannot access `./IBM10/VORCENTER_STEP': Permission denied
+du: cannot access `./IBM10/TIME_SERIES': Permission denied
+du: cannot access `./IBM10/screenga': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_CW': Permission denied
+du: cannot access `./IBM10/GATHERDATA': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L2X': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R4X': Permission denied
+du: cannot access `./IBM10/POST_VORTEX': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R2Y': Permission denied
+du: cannot access `./IBM10/tags': Permission denied
+du: cannot access `./IBM10/wave': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L2Z': Permission denied
+du: cannot access `./IBM10/POST_WAVY_WALL': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L1X': Permission denied
+du: cannot access `./IBM10/TRACER': Permission denied
+du: cannot access `./IBM10/VORCENTER_STEP.DAT': Permission denied
+du: cannot access `./IBM10/GRID.IN': Permission denied
+du: cannot access `./IBM10/INSTANTANEOUS': Permission denied
+du: cannot access `./IBM10/VORCENTER_STEP_J57.DAT': Permission denied
+du: cannot access `./IBM10/results_aegean': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R2': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L2W': Permission denied
+du: cannot access `./IBM10/SURFACE': Permission denied
+du: cannot access `./IBM10/vortex.sh': Permission denied
+du: cannot access `./IBM10/resdy': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L2': Permission denied
+du: cannot access `./IBM10/phi-f.mcr': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R4Z': Permission denied
+du: cannot access `./IBM10/prof_step1': Permission denied
+du: cannot access `./IBM10/vortex': Permission denied
+du: cannot access `./IBM10/VORTEX_plt': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_PRE': Permission denied
+du: cannot access `./IBM10/prof_step': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_L1Y': Permission denied
+du: cannot access `./IBM10/VORCENTER': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R2Z': Permission denied
+du: cannot access `./IBM10/Beforemaking': Permission denied
+du: cannot access `./IBM10/VORDYNAMIC_R4Y': Permission denied
+du: cannot access `./IBM10/MID': Permission denied
+du: cannot access `./IBM10/VORCENTER_TIME.DAT': Permission denied
+du: cannot access `./IBM10/PRIO_GENERATE_GRID': Permission denied
+du: cannot access `./IBM10/resvorc': Permission denied
+12	./IBM10
+36	./WAVE/FDM_043_VOF.F90
+20	./WAVE/FDM_123_WALLMODEL_POWERLAW.o
+16	./WAVE/FDM_023_SMOOTHING.F90
+12	./WAVE/SHOWGEO/tecio.f90
+4	./WAVE/SHOWGEO/SHOWGEO.F90
+20	./WAVE/SHOWGEO
+16	./WAVE/FDM_011_INIT_CONSTANTS.F90
+648	./WAVE/libtecio.a
+4	./WAVE/FDM_027_RK.F90
+20	./WAVE/FDM_302_WAVYVOR_DECOMPOSITION.F90
+16	./WAVE/FDM_033_IBM_INTFORCING.F90
+12	./WAVE/FDM_010_INIT_PARALLEL.o
+4	./WAVE/GEOMETRY
+24	./WAVE/FDM_110_RNG.o
+16	./WAVE/FDM_025_PD.F90
+40	./WAVE/FDM_070_PARALLEL.F90
+4	./WAVE/FDM_121_WALLMODEL_KANG.F90
+104	./WAVE/FDM_304_ASSIMILATION_WAVY.o
+4	./WAVE/FDM_111_GERMANO.F90
+324	./WAVE/FDM_023_SMOOTHING.o
+8	./WAVE/FDM_122_WALLMODEL_ROMAN.F90
+24	./WAVE/POST_BASIC/POST_032_IO.F90
+8	./WAVE/POST_BASIC/POST_020_STATS.F90
+12	./WAVE/POST_BASIC/POST_030_READFILE.F90
+12	./WAVE/POST_BASIC/POST_031_PARALLEL.F90
+4	./WAVE/POST_BASIC/POST_000_MAIN.F90
+8	./WAVE/POST_BASIC/INCLUDE_COMMON.FI
+4	./WAVE/POST_BASIC/POST_040_AVERAGE.F90
+12	./WAVE/POST_BASIC/POST_011_INIT_CONSTANTS.F90
+4	./WAVE/POST_BASIC/POST_999_FINALIZE.F90
+4	./WAVE/POST_BASIC/POST_050_WRITEFILE.F90
+4	./WAVE/POST_BASIC/POST_010_INIT_PARALLEL.F90
+100	./WAVE/POST_BASIC
+16	./WAVE/FDM_304_ASSIMILATION_WAVY.F90
+368	./WAVE/gatherdata
+8	./WAVE/FDM_000_MAIN.F90
+20	./WAVE/FDM_032_IBM_EXTFORCING.F90
+12	./WAVE/FDM_042_LS.F90
+4	./WAVE/INCLUDE_FFT.FI
+4	./WAVE/FDM_123_WALLMODEL_POWERLAW.F90
+140	./WAVE/FDM_030_IBM.o
+4	./WAVE/FDM_044_PRESCRIBEWAVE.F90
+4	./WAVE/FDM_080_FFT.F90
+4	./WAVE/FDM_091_SEDIMENT.F90
+12	./WAVE/FDM_300_ASSIMILATION.o
+148	./WAVE/FDM_060_STATS_TS.o
+4	./WAVE/aegean_stream.sh
+4	./WAVE/INCLUDE_LES.FI
+4	./WAVE/INCLUDE_IO.FI
+4	./WAVE/Makefile
+4	./WAVE/DYE.IN
+4	./WAVE/INCLUDE_WAVEGENERATOR.FI
+8	./WAVE/FDM_303_MEANFLUC_DECOMPOSITION.F90
+136	./WAVE/FDM_070_PARALLEL.o
+20	./WAVE/FDM_305_ASSIMILATION_VORT.o
+32	./WAVE/FDM_301_ASSIMILATION_GEOMETRY.F90
+4	./WAVE/WAVE
+4	./WAVE/INCLUDE_PARALLEL.FI
+112	./WAVE/FDM_033_IBM_INTFORCING.o
+8	./WAVE/FDM_030_IBM.F90
+22560	./WAVE/STATS/BASIC.H5
+4	./WAVE/STATS/STAT_STEP
+22568	./WAVE/STATS
+252	./WAVE/FDM_306_ASSIMILATION_TOTAL.o
+12	./WAVE/FDM_027_RK.o
+8	./WAVE/FDM_020_PRESOLVE.F90
+4	./WAVE/submit
+44	./WAVE/FDM_111_GERMANO.o
+8	./WAVE/FDM_999_FINALIZE.o
+76	./WAVE/FDM_090_DYE.o
+4	./WAVE/resga
+28	./WAVE/FDM_051_IO.F90
+8	./WAVE/FDM_061_STATS_TA.F90
+4	./WAVE/aga.sh
+16	./WAVE/FDM_022_WG.F90
+96	./WAVE/FDM_050_OUTPUT.o
+12	./WAVE/TAGS
+4	./WAVE/INCLUDE_ASSIMILATION.FI
+8	./WAVE/FDM_121_WALLMODEL_KANG.o
+4	./WAVE/PARAM.IN
+412	./WAVE/FDM_043_VOF.o
+8	./WAVE/FDM_090_DYE.F90
+8	./WAVE/INCLUDE_IBM.FI
+4	./WAVE/script.sh
+48	./WAVE/FDM_120_WALLMODEL_TBL.o
+4	./WAVE/INCLUDE_SINKPARAM.FI
+4	./WAVE/INCLUDE_PARAMETER.FI
+4	./WAVE/PARAM_Liu.IN
+76	./WAVE/FDM_021_RHS.F90
+84	./WAVE/FDM_303_MEANFLUC_DECOMPOSITION.o
+20	./WAVE/FDM_306_ASSIMILATION_TOTAL.F90
+8	./WAVE/FDM_100_LES.F90
+36	./WAVE/FDM_031_IBM_INIT.F90
+64	./WAVE/FDM_061_STATS_TA.o
+280	./WAVE/FDM_301_ASSIMILATION_GEOMETRY.o
+3600	./WAVE/TIME_SERIES/MAXUVW.DAT
+1544	./WAVE/TIME_SERIES/CDCF.DAT
+5148	./WAVE/TIME_SERIES
+4	./WAVE/FDM_300_ASSIMILATION.F90
+4	./WAVE/FDM_010_INIT_PARALLEL.F90
+12	./WAVE/FDM_050_OUTPUT.F90
+4	./WAVE/GATHERDATA/INCLUDE_IO.FI
+12	./WAVE/GATHERDATA/GATHER_IO.o
+12	./WAVE/GATHERDATA/tecio.f90
+4	./WAVE/GATHERDATA/GATHER_IO.F90
+152	./WAVE/GATHERDATA/GATHERDATA.o
+16	./WAVE/GATHERDATA/GATHERDATA.F90
+204	./WAVE/GATHERDATA
+40	./WAVE/FDM_044_PRESCRIBEWAVE.o
+4	./WAVE/INCLUDE_SCALAR.FI
+4	./WAVE/README.md
+16	./WAVE/FDM_025_PD_Liu.F90
+16	./WAVE/tags
+12	./WAVE/INCLUDE_COMMON.FI
+16772	./WAVE/wave
+24	./WAVE/POST_WAVY_WALL/POST_032_IO.F90
+4	./WAVE/POST_WAVY_WALL/POST_030_READFILE.F90
+4	./WAVE/POST_WAVY_WALL/POST_000_MAIN.F90
+4	./WAVE/POST_WAVY_WALL/tags
+8	./WAVE/POST_WAVY_WALL/INCLUDE_COMMON.FI
+4	./WAVE/POST_WAVY_WALL/POST_011_INIT_CONSTANTS.F90
+4	./WAVE/POST_WAVY_WALL/POST_999_FINALIZE.F90
+4	./WAVE/POST_WAVY_WALL/POST_040_WRITEFILE.F90
+4	./WAVE/POST_WAVY_WALL/POST_020_AVERAGE.F90
+4	./WAVE/POST_WAVY_WALL/POST_010_INIT_PARALLEL.F90
+68	./WAVE/POST_WAVY_WALL
+4	./WAVE/TRACER
+52	./WAVE/FDM_051_IO.o
+4	./WAVE/FDM_110_RNG.F90
+120	./WAVE/FDM_022_WG.o
+4	./WAVE/GRID.IN
+4	./WAVE/FDM_999_FINALIZE.F90
+184	./WAVE/FDM_025_PD.o
+52	./WAVE/FDM_122_WALLMODEL_ROMAN.o
+48	./WAVE/FDM_012_INIT_FIELD.F90
+12	./WAVE/FDM_200_PETSC_SOLVER.F90
+1556	./WAVE/results_aegean
+8	./WAVE/FDM_307_TRACER.F90
+4	./WAVE/FDM_305_ASSIMILATION_VORT.F90
+4	./WAVE/INCLUDE_STATS.FI
+100	./WAVE/FDM_100_LES.o
+16	./WAVE/FDM_060_STATS_TS.F90
+80	./WAVE/FDM_091_SEDIMENT.o
+52	./WAVE/FDM_307_TRACER.o
+196	./WAVE/FDM_302_WAVYVOR_DECOMPOSITION.o
+8	./WAVE/FDM_080_FFT.o
+8	./WAVE/FDM_120_WALLMODEL_TBL.F90
+16	./WAVE/FDM_026_PD_SPE.F90
+4	./WAVE/prof_step
+1116	./WAVE/post_skewness
+20	./WAVE/FDM_000_MAIN.o
+160	./WAVE/FDM_042_LS.o
+52	./WAVE/FDM_011_INIT_CONSTANTS.o
+56	./WAVE/FDM_200_PETSC_SOLVER.o
+4	./WAVE/MID/TIME.MID
+8	./WAVE/MID
+4	./WAVE/INCLUDE_POISSON.FI
+4	./WAVE/PRIO_GENERATE_GRID/Makefile
+12	./WAVE/PRIO_GENERATE_GRID/genegrid
+4	./WAVE/PRIO_GENERATE_GRID/GENEGRID.F90
+8	./WAVE/PRIO_GENERATE_GRID/GENEGRID.o
+32	./WAVE/PRIO_GENERATE_GRID
+53044	./WAVE
+4	./st135/GEOMETRY
+310272	./st135/DATA/V00008200.H5
+310272	./st135/DATA/V00008000.H5
+310272	./st135/DATA/V00001800.H5
+310272	./st135/DATA/V00003800.H5
+310272	./st135/DATA/V00011000.H5
+310272	./st135/DATA/V00015200.H5
+310272	./st135/DATA/V00000200.H5
+310272	./st135/DATA/V00009600.H5
+310272	./st135/DATA/V00005200.H5
+310272	./st135/DATA/V00012800.H5
+310272	./st135/DATA/V00011400.H5
+310272	./st135/DATA/V00012200.H5
+310272	./st135/DATA/V00014800.H5
+310272	./st135/DATA/V00007600.H5
+310272	./st135/DATA/V00006600.H5
+310272	./st135/DATA/V00013200.H5
+310272	./st135/DATA/V00015400.H5
+310272	./st135/DATA/V00005800.H5
+310272	./st135/DATA/V00016400.H5
+310272	./st135/DATA/V00005600.H5
+310272	./st135/DATA/V00009200.H5
+310272	./st135/DATA/V00001000.H5
+310272	./st135/DATA/V00014600.H5
+310272	./st135/DATA/V00005000.H5
+310272	./st135/DATA/V00016800.H5
+310272	./st135/DATA/V00009400.H5
+310272	./st135/DATA/V00000800.H5
+310272	./st135/DATA/V00007200.H5
+310272	./st135/DATA/V00010400.H5
+310272	./st135/DATA/V00012400.H5
+310272	./st135/DATA/V00010600.H5
+310272	./st135/DATA/V00007400.H5
+310272	./st135/DATA/V00007000.H5
+310272	./st135/DATA/V00002600.H5
+310272	./st135/DATA/V00002000.H5
+310272	./st135/DATA/V00010000.H5
+310272	./st135/DATA/V00006000.H5
+310272	./st135/DATA/V00004000.H5
+310272	./st135/DATA/V00013600.H5
+310272	./st135/DATA/V00010200.H5
+310272	./st135/DATA/V00004800.H5
+310272	./st135/DATA/V00013800.H5
+310272	./st135/DATA/V00012000.H5
+310272	./st135/DATA/V00001200.H5
+310272	./st135/DATA/V00013000.H5
+310272	./st135/DATA/V00007800.H5
+310272	./st135/DATA/V00001400.H5
+310272	./st135/DATA/V00016000.H5
+310272	./st135/DATA/V00009800.H5
+310272	./st135/DATA/V00000400.H5
+310272	./st135/DATA/V00011800.H5
+310272	./st135/DATA/V00015000.H5
+310272	./st135/DATA/V00003400.H5
+310272	./st135/DATA/V00017200.H5
+310272	./st135/DATA/V00015600.H5
+310272	./st135/DATA/V00011200.H5
+310272	./st135/DATA/V00004200.H5
+310272	./st135/DATA/V00012600.H5
+310272	./st135/DATA/V00006200.H5
+310272	./st135/DATA/V00003200.H5
+310272	./st135/DATA/V00008400.H5
+310272	./st135/DATA/V00002400.H5
+310272	./st135/DATA/V00004400.H5
+310272	./st135/DATA/V00009000.H5
+310272	./st135/DATA/V00008800.H5
+310272	./st135/DATA/V00000000.H5
+310272	./st135/DATA/V00006800.H5
+310272	./st135/DATA/V00000600.H5
+310272	./st135/DATA/V00015800.H5
+310272	./st135/DATA/V00014200.H5
+310272	./st135/DATA/V00014000.H5
+310272	./st135/DATA/V00003600.H5
+310272	./st135/DATA/V00016600.H5
+310272	./st135/DATA/V00001600.H5
+310272	./st135/DATA/V00014400.H5
+310272	./st135/DATA/V00002800.H5
+310272	./st135/DATA/V00011600.H5
+310272	./st135/DATA/V00005400.H5
+310272	./st135/DATA/V00017000.H5
+310272	./st135/DATA/V00013400.H5
+310272	./st135/DATA/V00006400.H5
+310272	./st135/DATA/V00003000.H5
+310272	./st135/DATA/V00008600.H5
+310272	./st135/DATA/V00010800.H5
+310272	./st135/DATA/V00002200.H5
+310272	./st135/DATA/V00004600.H5
+310272	./st135/DATA/V00016200.H5
+26993668	./st135/DATA
+4	./st135/aegean_stream.sh
+1788	./st135/sink.dat
+4	./st135/WAVE
+356440	./st135/STATS/BASIC.H5
+4	./st135/STATS/STAT_STEP
+356448	./st135/STATS
+896	./st135/test3vof.dat
+4	./st135/aga.sh
+4	./st135/PARAM.IN
+3292	./st135/TIME_SERIES/MAXUVW.DAT
+2016	./st135/TIME_SERIES/CDCF.DAT
+5312	./st135/TIME_SERIES
+16724	./st135/wave
+4	./st135/TRACER
+8	./st135/GRID.IN
+4744	./st135/results_aegean
+8	./st135/SURFACE/00002850.dat
+8	./st135/SURFACE/00003250.dat
+8	./st135/SURFACE/00005900.dat
+8	./st135/SURFACE/00010950.dat
+8	./st135/SURFACE/00016350.dat
+8	./st135/SURFACE/00010700.dat
+8	./st135/SURFACE/00016500.dat
+8	./st135/SURFACE/00012650.dat
+8	./st135/SURFACE/00009400.dat
+8	./st135/SURFACE/00009850.dat
+8	./st135/SURFACE/00013150.dat
+8	./st135/SURFACE/00014300.dat
+8	./st135/SURFACE/00007200.dat
+8	./st135/SURFACE/00013600.dat
+8	./st135/SURFACE/00004950.dat
+8	./st135/SURFACE/00004450.dat
+8	./st135/SURFACE/00009000.dat
+8	./st135/SURFACE/00014250.dat
+8	./st135/SURFACE/00009450.dat
+8	./st135/SURFACE/00011600.dat
+8	./st135/SURFACE/00002950.dat
+8	./st135/SURFACE/00001650.dat
+8	./st135/SURFACE/00010800.dat
+8	./st135/SURFACE/00006100.dat
+8	./st135/SURFACE/00015700.dat
+8	./st135/SURFACE/00016750.dat
+8	./st135/SURFACE/00015200.dat
+8	./st135/SURFACE/00016250.dat
+8	./st135/SURFACE/00011100.dat
+8	./st135/SURFACE/00004300.dat
+8	./st135/SURFACE/00012350.dat
+8	./st135/SURFACE/00005000.dat
+8	./st135/SURFACE/00006250.dat
+8	./st135/SURFACE/00007050.dat
+8	./st135/SURFACE/00012600.dat
+8	./st135/SURFACE/00001500.dat
+8	./st135/SURFACE/00011300.dat
+8	./st135/SURFACE/00003300.dat
+8	./st135/SURFACE/00007300.dat
+8	./st135/SURFACE/00004550.dat
+8	./st135/SURFACE/00007950.dat
+8	./st135/SURFACE/00008100.dat
+8	./st135/SURFACE/00014850.dat
+8	./st135/SURFACE/00007800.dat
+8	./st135/SURFACE/00005300.dat
+8	./st135/SURFACE/00005700.dat
+8	./st135/SURFACE/00004500.dat
+8	./st135/SURFACE/00003100.dat
+8	./st135/SURFACE/00008650.dat
+8	./st135/SURFACE/00007450.dat
+8	./st135/SURFACE/00013400.dat
+8	./st135/SURFACE/00004150.dat
+8	./st135/SURFACE/00016050.dat
+8	./st135/SURFACE/00006850.dat
+8	./st135/SURFACE/00009650.dat
+8	./st135/SURFACE/00000750.dat
+8	./st135/SURFACE/00000100.dat
+8	./st135/SURFACE/00002700.dat
+8	./st135/SURFACE/00005650.dat
+8	./st135/SURFACE/00003450.dat
+8	./st135/SURFACE/00009100.dat
+8	./st135/SURFACE/00010400.dat
+8	./st135/SURFACE/00009250.dat
+8	./st135/SURFACE/00012800.dat
+8	./st135/SURFACE/00000200.dat
+8	./st135/SURFACE/00011750.dat
+8	./st135/SURFACE/00000900.dat
+8	./st135/SURFACE/00001900.dat
+8	./st135/SURFACE/00008450.dat
+8	./st135/SURFACE/00010900.dat
+8	./st135/SURFACE/00012300.dat
+8	./st135/SURFACE/00010250.dat
+8	./st135/SURFACE/00004000.dat
+8	./st135/SURFACE/00014050.dat
+8	./st135/SURFACE/00016650.dat
+8	./st135/SURFACE/00002900.dat
+8	./st135/SURFACE/00005850.dat
+8	./st135/SURFACE/00009750.dat
+8	./st135/SURFACE/00002800.dat
+8	./st135/SURFACE/00014450.dat
+8	./st135/SURFACE/00012250.dat
+8	./st135/SURFACE/00017000.dat
+8	./st135/SURFACE/00001700.dat
+8	./st135/SURFACE/00006400.dat
+8	./st135/SURFACE/00015050.dat
+8	./st135/SURFACE/00016300.dat
+8	./st135/SURFACE/00006550.dat
+8	./st135/SURFACE/00003950.dat
+8	./st135/SURFACE/00002200.dat
+8	./st135/SURFACE/00010450.dat
+8	./st135/SURFACE/00011150.dat
+8	./st135/SURFACE/00015350.dat
+8	./st135/SURFACE/00004750.dat
+8	./st135/SURFACE/00000850.dat
+8	./st135/SURFACE/00004350.dat
+8	./st135/SURFACE/00007500.dat
+8	./st135/SURFACE/00013300.dat
+8	./st135/SURFACE/00002000.dat
+8	./st135/SURFACE/00013350.dat
+8	./st135/SURFACE/00016450.dat
+8	./st135/SURFACE/00007700.dat
+8	./st135/SURFACE/00011700.dat
+8	./st135/SURFACE/00002350.dat
+8	./st135/SURFACE/00004100.dat
+8	./st135/SURFACE/00006300.dat
+8	./st135/SURFACE/00014100.dat
+8	./st135/SURFACE/00002550.dat
+8	./st135/SURFACE/00015300.dat
+8	./st135/SURFACE/00001100.dat
+8	./st135/SURFACE/00016100.dat
+8	./st135/SURFACE/00005750.dat
+8	./st135/SURFACE/00002500.dat
+8	./st135/SURFACE/00008800.dat
+8	./st135/SURFACE/00015150.dat
+8	./st135/SURFACE/00011650.dat
+8	./st135/SURFACE/00003700.dat
+8	./st135/SURFACE/00005400.dat
+8	./st135/SURFACE/00008750.dat
+8	./st135/SURFACE/00011950.dat
+8	./st135/SURFACE/00011550.dat
+8	./st135/SURFACE/00005500.dat
+8	./st135/SURFACE/00009950.dat
+8	./st135/SURFACE/00009150.dat
+8	./st135/SURFACE/00007000.dat
+8	./st135/SURFACE/00013100.dat
+8	./st135/SURFACE/00015250.dat
+8	./st135/SURFACE/00003150.dat
+8	./st135/SURFACE/00010150.dat
+8	./st135/SURFACE/00017050.dat
+8	./st135/SURFACE/00004700.dat
+8	./st135/SURFACE/00016800.dat
+8	./st135/SURFACE/00000400.dat
+8	./st135/SURFACE/00006450.dat
+8	./st135/SURFACE/00004650.dat
+8	./st135/SURFACE/00007750.dat
+8	./st135/SURFACE/00006350.dat
+8	./st135/SURFACE/00009200.dat
+8	./st135/SURFACE/00004900.dat
+8	./st135/SURFACE/00012750.dat
+8	./st135/SURFACE/00000150.dat
+8	./st135/SURFACE/00008000.dat
+8	./st135/SURFACE/00010500.dat
+8	./st135/SURFACE/00007100.dat
+8	./st135/SURFACE/00009700.dat
+8	./st135/SURFACE/00004250.dat
+8	./st135/SURFACE/00015800.dat
+8	./st135/SURFACE/00001550.dat
+8	./st135/SURFACE/00010550.dat
+8	./st135/SURFACE/00013500.dat
+8	./st135/SURFACE/00005200.dat
+8	./st135/SURFACE/00012450.dat
+8	./st135/SURFACE/00014800.dat
+8	./st135/SURFACE/00011350.dat
+8	./st135/SURFACE/00002300.dat
+8	./st135/SURFACE/00014000.dat
+8	./st135/SURFACE/00007250.dat
+8	./st135/SURFACE/00002650.dat
+8	./st135/SURFACE/00006600.dat
+8	./st135/SURFACE/00011400.dat
+8	./st135/SURFACE/00013650.dat
+8	./st135/SURFACE/00006950.dat
+8	./st135/SURFACE/00006000.dat
+8	./st135/SURFACE/00012050.dat
+8	./st135/SURFACE/00006750.dat
+8	./st135/SURFACE/00003850.dat
+8	./st135/SURFACE/00008150.dat
+8	./st135/SURFACE/00001050.dat
+8	./st135/SURFACE/00007600.dat
+8	./st135/SURFACE/00000600.dat
+8	./st135/SURFACE/00013700.dat
+8	./st135/SURFACE/00000700.dat
+8	./st135/SURFACE/00007350.dat
+8	./st135/SURFACE/00003600.dat
+8	./st135/SURFACE/00000450.dat
+8	./st135/SURFACE/00001000.dat
+8	./st135/SURFACE/00009900.dat
+8	./st135/SURFACE/00000350.dat
+8	./st135/SURFACE/00010650.dat
+8	./st135/SURFACE/00017100.dat
+8	./st135/SURFACE/00001600.dat
+8	./st135/SURFACE/00005550.dat
+8	./st135/SURFACE/00000050.dat
+8	./st135/SURFACE/00002250.dat
+8	./st135/SURFACE/00005050.dat
+8	./st135/SURFACE/00008950.dat
+8	./st135/SURFACE/00000650.dat
+8	./st135/SURFACE/00003750.dat
+8	./st135/SURFACE/00006700.dat
+8	./st135/SURFACE/00004050.dat
+8	./st135/SURFACE/00008350.dat
+8	./st135/SURFACE/00011800.dat
+8	./st135/SURFACE/00010050.dat
+8	./st135/SURFACE/00002750.dat
+8	./st135/SURFACE/00015850.dat
+8	./st135/SURFACE/00002150.dat
+8	./st135/SURFACE/00016550.dat
+8	./st135/SURFACE/00011000.dat
+8	./st135/SURFACE/00015750.dat
+8	./st135/SURFACE/00002600.dat
+8	./st135/SURFACE/00007150.dat
+8	./st135/SURFACE/00012100.dat
+8	./st135/SURFACE/00000550.dat
+8	./st135/SURFACE/00016600.dat
+8	./st135/SURFACE/00017150.dat
+8	./st135/SURFACE/00016850.dat
+8	./st135/SURFACE/00009300.dat
+8	./st135/SURFACE/00010200.dat
+8	./st135/SURFACE/00014650.dat
+8	./st135/SURFACE/00013450.dat
+8	./st135/SURFACE/00007850.dat
+8	./st135/SURFACE/00003350.dat
+8	./st135/SURFACE/00001350.dat
+8	./st135/SURFACE/00016900.dat
+8	./st135/SURFACE/00009550.dat
+8	./st135/SURFACE/00015550.dat
+8	./st135/SURFACE/00009600.dat
+8	./st135/SURFACE/00006800.dat
+8	./st135/SURFACE/00014150.dat
+8	./st135/SURFACE/00001150.dat
+8	./st135/SURFACE/00014900.dat
+8	./st135/SURFACE/00012000.dat
+8	./st135/SURFACE/00006500.dat
+8	./st135/SURFACE/00015400.dat
+8	./st135/SURFACE/00015500.dat
+8	./st135/SURFACE/00015900.dat
+8	./st135/SURFACE/00007400.dat
+8	./st135/SURFACE/00008900.dat
+8	./st135/SURFACE/00016400.dat
+8	./st135/SURFACE/00009500.dat
+8	./st135/SURFACE/00014500.dat
+8	./st135/SURFACE/00008600.dat
+8	./st135/SURFACE/00015950.dat
+8	./st135/SURFACE/00010750.dat
+8	./st135/SURFACE/00008550.dat
+8	./st135/SURFACE/00006650.dat
+8	./st135/SURFACE/00013000.dat
+8	./st135/SURFACE/00003050.dat
+8	./st135/SURFACE/00014700.dat
+8	./st135/SURFACE/00001750.dat
+8	./st135/SURFACE/00006900.dat
+8	./st135/SURFACE/00001250.dat
+8	./st135/SURFACE/00014750.dat
+8	./st135/SURFACE/00010350.dat
+8	./st135/SURFACE/00005600.dat
+8	./st135/SURFACE/00004200.dat
+8	./st135/SURFACE/00015100.dat
+8	./st135/SURFACE/00001800.dat
+8	./st135/SURFACE/00009350.dat
+8	./st135/SURFACE/00008250.dat
+8	./st135/SURFACE/00012150.dat
+8	./st135/SURFACE/00000250.dat
+8	./st135/SURFACE/00012500.dat
+8	./st135/SURFACE/00006050.dat
+8	./st135/SURFACE/00011850.dat
+8	./st135/SURFACE/00012950.dat
+8	./st135/SURFACE/00011450.dat
+8	./st135/SURFACE/00000950.dat
+8	./st135/SURFACE/00015600.dat
+8	./st135/SURFACE/00013050.dat
+8	./st135/SURFACE/00005950.dat
+8	./st135/SURFACE/00016950.dat
+8	./st135/SURFACE/00010850.dat
+8	./st135/SURFACE/00013850.dat
+8	./st135/SURFACE/00004600.dat
+8	./st135/SURFACE/00013750.dat
+8	./st135/SURFACE/00009800.dat
+8	./st135/SURFACE/00002100.dat
+8	./st135/SURFACE/00002050.dat
+8	./st135/SURFACE/00014200.dat
+8	./st135/SURFACE/00009050.dat
+8	./st135/SURFACE/00005350.dat
+8	./st135/SURFACE/00014400.dat
+8	./st135/SURFACE/00001450.dat
+8	./st135/SURFACE/00001200.dat
+8	./st135/SURFACE/00011050.dat
+8	./st135/SURFACE/00013200.dat
+8	./st135/SURFACE/00016200.dat
+8	./st135/SURFACE/00011250.dat
+8	./st135/SURFACE/00003400.dat
+8	./st135/SURFACE/00014550.dat
+8	./st135/SURFACE/00008700.dat
+8	./st135/SURFACE/00005250.dat
+8	./st135/SURFACE/00003650.dat
+8	./st135/SURFACE/00014600.dat
+8	./st135/SURFACE/00002400.dat
+8	./st135/SURFACE/00011200.dat
+8	./st135/SURFACE/00008050.dat
+8	./st135/SURFACE/00001850.dat
+8	./st135/SURFACE/00006200.dat
+8	./st135/SURFACE/00007900.dat
+8	./st135/SURFACE/00013950.dat
+8	./st135/SURFACE/00013900.dat
+8	./st135/SURFACE/00000300.dat
+8	./st135/SURFACE/00013800.dat
+8	./st135/SURFACE/00008400.dat
+8	./st135/SURFACE/00007650.dat
+8	./st135/SURFACE/00010100.dat
+8	./st135/SURFACE/00010300.dat
+8	./st135/SURFACE/00004400.dat
+8	./st135/SURFACE/00012900.dat
+8	./st135/SURFACE/00005800.dat
+8	./st135/SURFACE/00003200.dat
+8	./st135/SURFACE/00015450.dat
+8	./st135/SURFACE/00011900.dat
+8	./st135/SURFACE/00002450.dat
+8	./st135/SURFACE/00016150.dat
+8	./st135/SURFACE/00005150.dat
+8	./st135/SURFACE/00014950.dat
+8	./st135/SURFACE/00005100.dat
+8	./st135/SURFACE/00015000.dat
+8	./st135/SURFACE/00003000.dat
+8	./st135/SURFACE/00012700.dat
+8	./st135/SURFACE/00005450.dat
+8	./st135/SURFACE/00016700.dat
+8	./st135/SURFACE/00004800.dat
+8	./st135/SURFACE/00001300.dat
+8	./st135/SURFACE/00008300.dat
+8	./st135/SURFACE/00003500.dat
+8	./st135/SURFACE/00012550.dat
+8	./st135/SURFACE/00008850.dat
+8	./st135/SURFACE/00008500.dat
+8	./st135/SURFACE/00000500.dat
+8	./st135/SURFACE/00015650.dat
+8	./st135/SURFACE/00010000.dat
+8	./st135/SURFACE/00006150.dat
+8	./st135/SURFACE/00003550.dat
+8	./st135/SURFACE/00007550.dat
+8	./st135/SURFACE/00011500.dat
+8	./st135/SURFACE/00012200.dat
+8	./st135/SURFACE/00003900.dat
+8	./st135/SURFACE/00013550.dat
+8	./st135/SURFACE/00012400.dat
+8	./st135/SURFACE/00012850.dat
+8	./st135/SURFACE/00010600.dat
+8	./st135/SURFACE/00013250.dat
+0	./st135/SURFACE/00017200.dat
+8	./st135/SURFACE/00008200.dat
+8	./st135/SURFACE/00014350.dat
+8	./st135/SURFACE/00001950.dat
+8	./st135/SURFACE/00004850.dat
+8	./st135/SURFACE/00001400.dat
+8	./st135/SURFACE/00000800.dat
+8	./st135/SURFACE/00003800.dat
+8	./st135/SURFACE/00016000.dat
+2764	./st135/SURFACE
+4	./st135/prof_step
+4	./st135/MID/TIME.MID
+8	./st135/MID
+27382392	./st135
+912	./IBM15/libtecio.a
+du: cannot access `./IBM15/INCLUDE/INCLUDE_FFT.FI': Permission denied
+du: cannot access `./IBM15/INCLUDE/INCLUDE_CINTERFACE.FI': Permission denied
+du: cannot access `./IBM15/INCLUDE/INCLUDE_LES.FI': Permission denied
+du: cannot access `./IBM15/INCLUDE/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM15/INCLUDE/INCLUDE_WAVEGENERATOR.FI': Permission denied
+du: cannot access `./IBM15/INCLUDE/INCLUDE_PARALLEL.FI': Permission denied
+du: cannot access `./IBM15/INCLUDE/INCLUDE_PETSC.FI': Permission denied
+du: cannot access `./IBM15/INCLUDE/INCLUDE_ASSIMILATION.FI': Permission denied
+du: cannot access `./IBM15/INCLUDE/INCLUDE_IBM.FI': Permission denied
+du: cannot access `./IBM15/INCLUDE/variables_new.h': Permission denied
+du: cannot access `./IBM15/INCLUDE/INCLUDE_PARAMETER.FI': Permission denied
+du: cannot access `./IBM15/INCLUDE/mpm_vars_new.h': Permission denied
+du: cannot access `./IBM15/INCLUDE/INCLUDE_SCALAR.FI': Permission denied
+du: cannot access `./IBM15/INCLUDE/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM15/INCLUDE/INCLUDE_STATS.FI': Permission denied
+du: cannot access `./IBM15/INCLUDE/INCLUDE_POISSON.FI': Permission denied
+4	./IBM15/INCLUDE
+4	./IBM15/vorcenterp.sh
+340	./IBM15/GEOMETRY/PSI.0074
+340	./IBM15/GEOMETRY/PSI.0012
+340	./IBM15/GEOMETRY/PSI.0026
+340	./IBM15/GEOMETRY/PSI.0048
+340	./IBM15/GEOMETRY/PSI.0054
+340	./IBM15/GEOMETRY/PSI.0084
+340	./IBM15/GEOMETRY/PSI.0019
+340	./IBM15/GEOMETRY/PSI.0066
+340	./IBM15/GEOMETRY/PSI.0015
+340	./IBM15/GEOMETRY/PSI.0094
+340	./IBM15/GEOMETRY/PSI.0088
+340	./IBM15/GEOMETRY/PSI.0032
+340	./IBM15/GEOMETRY/PSI.0081
+340	./IBM15/GEOMETRY/PSI.0005
+340	./IBM15/GEOMETRY/PSI.0007
+340	./IBM15/GEOMETRY/PSI.0050
+340	./IBM15/GEOMETRY/PSI.0098
+340	./IBM15/GEOMETRY/PSI.0021
+340	./IBM15/GEOMETRY/PSI.0079
+340	./IBM15/GEOMETRY/PSI.0043
+340	./IBM15/GEOMETRY/PSI.0104
+340	./IBM15/GEOMETRY/PSI.0060
+340	./IBM15/GEOMETRY/PSI.0061
+340	./IBM15/GEOMETRY/PSI.0095
+340	./IBM15/GEOMETRY/PSI.0082
+340	./IBM15/GEOMETRY/PSI.0080
+340	./IBM15/GEOMETRY/PSI.0087
+340	./IBM15/GEOMETRY/PSI.0027
+340	./IBM15/GEOMETRY/PSI.0023
+340	./IBM15/GEOMETRY/PSI.0003
+340	./IBM15/GEOMETRY/PSI.0014
+340	./IBM15/GEOMETRY/PSI.0062
+340	./IBM15/GEOMETRY/PSI.0086
+340	./IBM15/GEOMETRY/PSI.0008
+340	./IBM15/GEOMETRY/PSI.0058
+340	./IBM15/GEOMETRY/PSI.0034
+340	./IBM15/GEOMETRY/PSI.0120
+340	./IBM15/GEOMETRY/PSI.0089
+340	./IBM15/GEOMETRY/PSI.0118
+340	./IBM15/GEOMETRY/PSI.0044
+340	./IBM15/GEOMETRY/PSI.0125
+340	./IBM15/GEOMETRY/PSI.0036
+340	./IBM15/GEOMETRY/PSI.0052
+340	./IBM15/GEOMETRY/PSI.0031
+340	./IBM15/GEOMETRY/PSI.0076
+340	./IBM15/GEOMETRY/PSI.0037
+340	./IBM15/GEOMETRY/PSI.0024
+340	./IBM15/GEOMETRY/PSI.0100
+340	./IBM15/GEOMETRY/PSI.0030
+340	./IBM15/GEOMETRY/PSI.0069
+340	./IBM15/GEOMETRY/PSI.0075
+340	./IBM15/GEOMETRY/PSI.0068
+340	./IBM15/GEOMETRY/PSI.0002
+340	./IBM15/GEOMETRY/PSI.0000
+340	./IBM15/GEOMETRY/PSI.0020
+340	./IBM15/GEOMETRY/PSI.0010
+340	./IBM15/GEOMETRY/PSI.0110
+340	./IBM15/GEOMETRY/PSI.0124
+340	./IBM15/GEOMETRY/PSI.0051
+340	./IBM15/GEOMETRY/PSI.0121
+340	./IBM15/GEOMETRY/PSI.0116
+340	./IBM15/GEOMETRY/PSI.0053
+340	./IBM15/GEOMETRY/PSI.0073
+340	./IBM15/GEOMETRY/PSI.0018
+340	./IBM15/GEOMETRY/PSI.0106
+340	./IBM15/GEOMETRY/PSI.0004
+340	./IBM15/GEOMETRY/PSI.0035
+340	./IBM15/GEOMETRY/PSI.0083
+340	./IBM15/GEOMETRY/PSI.0013
+340	./IBM15/GEOMETRY/PSI.0022
+340	./IBM15/GEOMETRY/PSI.0101
+340	./IBM15/GEOMETRY/PSI.0122
+340	./IBM15/GEOMETRY/PSI.0016
+340	./IBM15/GEOMETRY/PSI.0119
+340	./IBM15/GEOMETRY/PSI.0067
+340	./IBM15/GEOMETRY/PSI.0072
+340	./IBM15/GEOMETRY/PSI.0112
+340	./IBM15/GEOMETRY/PSI.0039
+340	./IBM15/GEOMETRY/PSI.0017
+340	./IBM15/GEOMETRY/PSI.0097
+340	./IBM15/GEOMETRY/PSI.0107
+340	./IBM15/GEOMETRY/PSI.0108
+340	./IBM15/GEOMETRY/PSI.0123
+340	./IBM15/GEOMETRY/PSI.0063
+340	./IBM15/GEOMETRY/PSI.0102
+340	./IBM15/GEOMETRY/PSI.0047
+340	./IBM15/GEOMETRY/PSI.0045
+340	./IBM15/GEOMETRY/PSI.0070
+340	./IBM15/GEOMETRY/PSI.0038
+340	./IBM15/GEOMETRY/PSI.0127
+340	./IBM15/GEOMETRY/PSI.0056
+340	./IBM15/GEOMETRY/PSI.0078
+340	./IBM15/GEOMETRY/PSI.0126
+340	./IBM15/GEOMETRY/PSI.0046
+340	./IBM15/GEOMETRY/PSI.0064
+340	./IBM15/GEOMETRY/PSI.0096
+340	./IBM15/GEOMETRY/PSI.0077
+340	./IBM15/GEOMETRY/PSI.0025
+340	./IBM15/GEOMETRY/PSI.0040
+340	./IBM15/GEOMETRY/PSI.0011
+340	./IBM15/GEOMETRY/PSI.0041
+340	./IBM15/GEOMETRY/PSI.0109
+340	./IBM15/GEOMETRY/PSI.0090
+340	./IBM15/GEOMETRY/PSI.0042
+340	./IBM15/GEOMETRY/PSI.0105
+340	./IBM15/GEOMETRY/PSI.0009
+340	./IBM15/GEOMETRY/PSI.0028
+340	./IBM15/GEOMETRY/PSI.0114
+340	./IBM15/GEOMETRY/PSI.0006
+340	./IBM15/GEOMETRY/PSI.0033
+340	./IBM15/GEOMETRY/PSI.0055
+340	./IBM15/GEOMETRY/PSI.0071
+340	./IBM15/GEOMETRY/PSI.0113
+340	./IBM15/GEOMETRY/PSI.0049
+340	./IBM15/GEOMETRY/PSI.0103
+340	./IBM15/GEOMETRY/PSI.0001
+340	./IBM15/GEOMETRY/PSI.0099
+340	./IBM15/GEOMETRY/PSI.0065
+340	./IBM15/GEOMETRY/PSI.0111
+340	./IBM15/GEOMETRY/PSI.0059
+340	./IBM15/GEOMETRY/PSI.0085
+340	./IBM15/GEOMETRY/PSI.0029
+340	./IBM15/GEOMETRY/PSI.0057
+340	./IBM15/GEOMETRY/PSI.0115
+340	./IBM15/GEOMETRY/PSI.0117
+340	./IBM15/GEOMETRY/PSI.0091
+340	./IBM15/GEOMETRY/PSI.0092
+340	./IBM15/GEOMETRY/PSI.0093
+43532	./IBM15/GEOMETRY
+du: cannot access `./IBM15/CALCULATE/FDM_026_PD_SPE.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_043_VOF.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_123_WALLMODEL_POWERLAW.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_023_SMOOTHING.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_027_RK.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_302_WAVYVOR_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_033_IBM_INTFORCING.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_010_INIT_PARALLEL.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_110_RNG.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_025_PD.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_070_PARALLEL.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_121_WALLMODEL_KANG.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_304_ASSIMILATION_WAVY.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_032_IBM_EXTFORCING.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_111_GERMANO.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_023_SMOOTHING.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_122_WALLMODEL_ROMAN.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_304_ASSIMILATION_WAVY.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_000_MAIN.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_032_IBM_EXTFORCING.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_042_LS.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_123_WALLMODEL_POWERLAW.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_030_IBM.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_044_PRESCRIBEWAVE.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_080_FFT.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_020_PRESOLVE.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_091_SEDIMENT.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_300_ASSIMILATION.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_060_STATS_TS.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_303_MEANFLUC_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_070_PARALLEL.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_305_ASSIMILATION_VORT.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_301_ASSIMILATION_GEOMETRY.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_033_IBM_INTFORCING.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_030_IBM.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_306_ASSIMILATION_TOTAL.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_027_RK.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_020_PRESOLVE.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_021_RHS.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_111_GERMANO.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_999_FINALIZE.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_090_DYE.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_062_STRAINRATE.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_130_INT.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_051_IO.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_063_CIRCVELO.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_061_STATS_TA.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_062_STRAINRATE.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_022_WG.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_050_OUTPUT.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_121_WALLMODEL_KANG.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_043_VOF.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_090_DYE.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_130_INT.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_120_WALLMODEL_TBL.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_021_RHS.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_303_MEANFLUC_DECOMPOSITION.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_306_ASSIMILATION_TOTAL.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_100_LES.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_031_IBM_INIT.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_061_STATS_TA.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_301_ASSIMILATION_GEOMETRY.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_300_ASSIMILATION.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_010_INIT_PARALLEL.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_050_OUTPUT.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_044_PRESCRIBEWAVE.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/tags': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_051_IO.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_110_RNG.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_022_WG.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_025_PD.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_122_WALLMODEL_ROMAN.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_012_INIT_FIELD.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_200_PETSC_SOLVER.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_307_TRACER.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_001_FSTRANSFER.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_305_ASSIMILATION_VORT.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_100_LES.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_060_STATS_TS.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_091_SEDIMENT.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_307_TRACER.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_031_IBM_INIT.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_302_WAVYVOR_DECOMPOSITION.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_080_FFT.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_120_WALLMODEL_TBL.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_026_PD_SPE.F90': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_012_INIT_FIELD.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_063_CIRCVELO.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_000_MAIN.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_042_LS.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_011_INIT_CONSTANTS.o': Permission denied
+du: cannot access `./IBM15/CALCULATE/FDM_200_PETSC_SOLVER.o': Permission denied
+12	./IBM15/CALCULATE
+8	./IBM15/volume.dat
+433440	./IBM15/DATA/V00037000.H5
+433440	./IBM15/DATA/V00024200.H5
+433440	./IBM15/DATA/V00030400.H5
+433440	./IBM15/DATA/V00008200.H5
+433440	./IBM15/DATA/V00036400.H5
+433440	./IBM15/DATA/V00008000.H5
+433440	./IBM15/DATA/V00059200.H5
+433440	./IBM15/DATA/V00054400.H5
+433440	./IBM15/DATA/V00019000.H5
+433440	./IBM15/DATA/V00001800.H5
+433440	./IBM15/DATA/V00053600.H5
+433440	./IBM15/DATA/V00056800.H5
+433440	./IBM15/DATA/V00003800.H5
+433440	./IBM15/DATA/V00024400.H5
+433440	./IBM15/DATA/V00022200.H5
+433440	./IBM15/DATA/V00050400.H5
+433440	./IBM15/DATA/V00033400.H5
+433440	./IBM15/DATA/V00031000.H5
+433440	./IBM15/DATA/V00034800.H5
+433440	./IBM15/DATA/V00018600.H5
+433440	./IBM15/DATA/V00030800.H5
+433440	./IBM15/DATA/V00030200.H5
+433440	./IBM15/DATA/V00011000.H5
+433440	./IBM15/DATA/V00019200.H5
+433440	./IBM15/DATA/V00039400.H5
+433440	./IBM15/DATA/V00052400.H5
+433440	./IBM15/DATA/V00027800.H5
+433440	./IBM15/DATA/V00030000.H5
+433440	./IBM15/DATA/V00026200.H5
+433440	./IBM15/DATA/V00042200.H5
+433440	./IBM15/DATA/V00018000.H5
+433440	./IBM15/DATA/V00052600.H5
+433440	./IBM15/DATA/V00050600.H5
+433440	./IBM15/DATA/V00055800.H5
+433440	./IBM15/DATA/V00039600.H5
+433440	./IBM15/DATA/V00015200.H5
+433440	./IBM15/DATA/V00000200.H5
+433440	./IBM15/DATA/V00056200.H5
+433440	./IBM15/DATA/V00009600.H5
+433440	./IBM15/DATA/V00027400.H5
+433440	./IBM15/DATA/V00048600.H5
+433440	./IBM15/DATA/V00049600.H5
+433440	./IBM15/DATA/V00033000.H5
+433440	./IBM15/DATA/V00045800.H5
+433440	./IBM15/DATA/V00027200.H5
+433440	./IBM15/DATA/V00023600.H5
+433440	./IBM15/DATA/V00048200.H5
+433440	./IBM15/DATA/V00018800.H5
+433440	./IBM15/DATA/V00040600.H5
+433440	./IBM15/DATA/V00037600.H5
+433440	./IBM15/DATA/V00025800.H5
+433440	./IBM15/DATA/V00005200.H5
+433440	./IBM15/DATA/V00021800.H5
+433440	./IBM15/DATA/V00012800.H5
+433440	./IBM15/DATA/V00040800.H5
+433440	./IBM15/DATA/V00023400.H5
+433440	./IBM15/DATA/V00011400.H5
+433440	./IBM15/DATA/V00042800.H5
+433440	./IBM15/DATA/V00055200.H5
+433440	./IBM15/DATA/V00036000.H5
+433440	./IBM15/DATA/V00012200.H5
+433440	./IBM15/DATA/V00055400.H5
+433440	./IBM15/DATA/V00043000.H5
+433440	./IBM15/DATA/V00019800.H5
+433440	./IBM15/DATA/V00014800.H5
+433440	./IBM15/DATA/V00007600.H5
+433440	./IBM15/DATA/V00041600.H5
+433440	./IBM15/DATA/V00006600.H5
+433440	./IBM15/DATA/V00036800.H5
+433440	./IBM15/DATA/V00013200.H5
+433440	./IBM15/DATA/V00033600.H5
+433440	./IBM15/DATA/V00018200.H5
+433440	./IBM15/DATA/V00041000.H5
+433440	./IBM15/DATA/V00024600.H5
+433440	./IBM15/DATA/V00019600.H5
+433440	./IBM15/DATA/V00054000.H5
+433440	./IBM15/DATA/V00049000.H5
+433440	./IBM15/DATA/V00041400.H5
+433440	./IBM15/DATA/V00042600.H5
+433440	./IBM15/DATA/V00035800.H5
+433440	./IBM15/DATA/V00038800.H5
+433440	./IBM15/DATA/V00020800.H5
+433440	./IBM15/DATA/V00037400.H5
+433440	./IBM15/DATA/V00026600.H5
+433440	./IBM15/DATA/V00027000.H5
+433440	./IBM15/DATA/V00051200.H5
+433440	./IBM15/DATA/V00021200.H5
+433440	./IBM15/DATA/V00015400.H5
+433440	./IBM15/DATA/V00005800.H5
+433440	./IBM15/DATA/V00044800.H5
+433440	./IBM15/DATA/V00044200.H5
+433440	./IBM15/DATA/V00016400.H5
+433440	./IBM15/DATA/V00029200.H5
+433440	./IBM15/DATA/V00038000.H5
+433440	./IBM15/DATA/V00005600.H5
+433440	./IBM15/DATA/V00033800.H5
+433440	./IBM15/DATA/V00054600.H5
+433440	./IBM15/DATA/V00025200.H5
+433440	./IBM15/DATA/V00058800.H5
+433440	./IBM15/DATA/V00032600.H5
+433440	./IBM15/DATA/V00047400.H5
+433440	./IBM15/DATA/V00009200.H5
+433440	./IBM15/DATA/V00001000.H5
+433440	./IBM15/DATA/V00014600.H5
+433440	./IBM15/DATA/V00005000.H5
+433440	./IBM15/DATA/V00016800.H5
+433440	./IBM15/DATA/V00038200.H5
+433440	./IBM15/DATA/V00051600.H5
+433440	./IBM15/DATA/V00009400.H5
+433440	./IBM15/DATA/V00059600.H5
+433440	./IBM15/DATA/V00049400.H5
+433440	./IBM15/DATA/V00000800.H5
+433440	./IBM15/DATA/V00007200.H5
+433440	./IBM15/DATA/V00052200.H5
+433440	./IBM15/DATA/V00010400.H5
+433440	./IBM15/DATA/V00012400.H5
+433440	./IBM15/DATA/V00044000.H5
+433440	./IBM15/DATA/V00025600.H5
+433440	./IBM15/DATA/V00010600.H5
+433440	./IBM15/DATA/V00047800.H5
+433440	./IBM15/DATA/V00029800.H5
+433440	./IBM15/DATA/V00007400.H5
+433440	./IBM15/DATA/V00034000.H5
+433440	./IBM15/DATA/V00041200.H5
+433440	./IBM15/DATA/V00028000.H5
+433440	./IBM15/DATA/V00040000.H5
+433440	./IBM15/DATA/V00007000.H5
+433440	./IBM15/DATA/V00002600.H5
+433440	./IBM15/DATA/V00031400.H5
+433440	./IBM15/DATA/V00002000.H5
+433440	./IBM15/DATA/V00010000.H5
+433440	./IBM15/DATA/V00006000.H5
+433440	./IBM15/DATA/V00053200.H5
+433440	./IBM15/DATA/V00004000.H5
+433440	./IBM15/DATA/V00048000.H5
+433440	./IBM15/DATA/V00050800.H5
+433440	./IBM15/DATA/V00029000.H5
+433440	./IBM15/DATA/V00046800.H5
+433440	./IBM15/DATA/V00043800.H5
+433440	./IBM15/DATA/V00013600.H5
+433440	./IBM15/DATA/V00040200.H5
+433440	./IBM15/DATA/V00051000.H5
+433440	./IBM15/DATA/V00010200.H5
+433440	./IBM15/DATA/V00004800.H5
+433440	./IBM15/DATA/V00058000.H5
+433440	./IBM15/DATA/V00034400.H5
+433440	./IBM15/DATA/V00013800.H5
+433440	./IBM15/DATA/V00027600.H5
+433440	./IBM15/DATA/V00017600.H5
+433440	./IBM15/DATA/V00040400.H5
+433440	./IBM15/DATA/V00012000.H5
+433440	./IBM15/DATA/V00031200.H5
+433440	./IBM15/DATA/V00028600.H5
+433440	./IBM15/DATA/V00056600.H5
+433440	./IBM15/DATA/V00001200.H5
+433440	./IBM15/DATA/V00039200.H5
+433440	./IBM15/DATA/V00013000.H5
+433440	./IBM15/DATA/V00058600.H5
+433440	./IBM15/DATA/V00007800.H5
+433440	./IBM15/DATA/V00001400.H5
+433440	./IBM15/DATA/V00047200.H5
+433440	./IBM15/DATA/V00029400.H5
+433440	./IBM15/DATA/V00020600.H5
+433440	./IBM15/DATA/V00022400.H5
+433440	./IBM15/DATA/V00016000.H5
+433440	./IBM15/DATA/V00044600.H5
+433440	./IBM15/DATA/V00039800.H5
+433440	./IBM15/DATA/V00009800.H5
+433440	./IBM15/DATA/V00031800.H5
+433440	./IBM15/DATA/V00000400.H5
+433440	./IBM15/DATA/V00057600.H5
+433440	./IBM15/DATA/V00011800.H5
+433440	./IBM15/DATA/V00015000.H5
+433440	./IBM15/DATA/V00058400.H5
+433440	./IBM15/DATA/V00052800.H5
+433440	./IBM15/DATA/V00056400.H5
+433440	./IBM15/DATA/V00045600.H5
+433440	./IBM15/DATA/V00053000.H5
+433440	./IBM15/DATA/V00024000.H5
+433440	./IBM15/DATA/V00003400.H5
+433440	./IBM15/DATA/V00029600.H5
+433440	./IBM15/DATA/V00051800.H5
+433440	./IBM15/DATA/V00017200.H5
+433440	./IBM15/DATA/V00021400.H5
+433440	./IBM15/DATA/V00057800.H5
+433440	./IBM15/DATA/V00020200.H5
+433440	./IBM15/DATA/V00045000.H5
+433440	./IBM15/DATA/V00044400.H5
+433440	./IBM15/DATA/V00023000.H5
+433440	./IBM15/DATA/V00048400.H5
+433440	./IBM15/DATA/V00015600.H5
+433440	./IBM15/DATA/V00011200.H5
+433440	./IBM15/DATA/V00032800.H5
+433440	./IBM15/DATA/V00025400.H5
+433440	./IBM15/DATA/V00023200.H5
+433440	./IBM15/DATA/V00024800.H5
+433440	./IBM15/DATA/V00050200.H5
+433440	./IBM15/DATA/V00055600.H5
+433440	./IBM15/DATA/V00026400.H5
+433440	./IBM15/DATA/V00054800.H5
+433440	./IBM15/DATA/V00035600.H5
+433440	./IBM15/DATA/V00004200.H5
+433440	./IBM15/DATA/V00057400.H5
+433440	./IBM15/DATA/V00012600.H5
+433440	./IBM15/DATA/V00035000.H5
+433440	./IBM15/DATA/V00023800.H5
+433440	./IBM15/DATA/V00006200.H5
+433440	./IBM15/DATA/V00003200.H5
+433440	./IBM15/DATA/V00059400.H5
+433440	./IBM15/DATA/V00035400.H5
+433440	./IBM15/DATA/V00037800.H5
+433440	./IBM15/DATA/V00008400.H5
+433440	./IBM15/DATA/V00053400.H5
+433440	./IBM15/DATA/V00002400.H5
+433440	./IBM15/DATA/V00004400.H5
+433440	./IBM15/DATA/V00018400.H5
+433440	./IBM15/DATA/V00009000.H5
+433440	./IBM15/DATA/V00028800.H5
+433440	./IBM15/DATA/V00020000.H5
+433440	./IBM15/DATA/V00033200.H5
+433440	./IBM15/DATA/V00022600.H5
+433440	./IBM15/DATA/V00043200.H5
+433440	./IBM15/DATA/V00060200.H5
+433440	./IBM15/DATA/V00051400.H5
+433440	./IBM15/DATA/V00008800.H5
+433440	./IBM15/DATA/V00032200.H5
+433440	./IBM15/DATA/V00000000.H5
+433440	./IBM15/DATA/V00006800.H5
+433440	./IBM15/DATA/V00041800.H5
+433440	./IBM15/DATA/V00017800.H5
+433440	./IBM15/DATA/V00000600.H5
+433440	./IBM15/DATA/V00047600.H5
+433440	./IBM15/DATA/V00042000.H5
+433440	./IBM15/DATA/V00015800.H5
+433440	./IBM15/DATA/V00052000.H5
+433440	./IBM15/DATA/V00032400.H5
+433440	./IBM15/DATA/V00014200.H5
+433440	./IBM15/DATA/V00014000.H5
+433440	./IBM15/DATA/V00036200.H5
+433440	./IBM15/DATA/V00022800.H5
+433440	./IBM15/DATA/V00003600.H5
+433440	./IBM15/DATA/V00016600.H5
+433440	./IBM15/DATA/V00050000.H5
+433440	./IBM15/DATA/V00035200.H5
+433440	./IBM15/DATA/V00030600.H5
+433440	./IBM15/DATA/V00001600.H5
+433440	./IBM15/DATA/V00028400.H5
+433440	./IBM15/DATA/V00022000.H5
+433440	./IBM15/DATA/V00014400.H5
+433440	./IBM15/DATA/V00020400.H5
+433440	./IBM15/DATA/V00043600.H5
+433440	./IBM15/DATA/V00046200.H5
+433440	./IBM15/DATA/V00002800.H5
+433440	./IBM15/DATA/V00049800.H5
+433440	./IBM15/DATA/V00046400.H5
+433440	./IBM15/DATA/V00048800.H5
+433440	./IBM15/DATA/V00017400.H5
+433440	./IBM15/DATA/V00036600.H5
+433440	./IBM15/DATA/V00055000.H5
+433440	./IBM15/DATA/V00032000.H5
+433440	./IBM15/DATA/V00057200.H5
+433440	./IBM15/DATA/V00021000.H5
+433440	./IBM15/DATA/V00054200.H5
+433440	./IBM15/DATA/V00049200.H5
+433440	./IBM15/DATA/V00060000.H5
+433440	./IBM15/DATA/V00026000.H5
+433440	./IBM15/DATA/V00011600.H5
+433440	./IBM15/DATA/V00005400.H5
+433440	./IBM15/DATA/V00026800.H5
+433440	./IBM15/DATA/V00037200.H5
+433440	./IBM15/DATA/V00038400.H5
+433440	./IBM15/DATA/V00017000.H5
+433440	./IBM15/DATA/V00019400.H5
+433440	./IBM15/DATA/V00025000.H5
+433440	./IBM15/DATA/V00043400.H5
+433440	./IBM15/DATA/V00031600.H5
+433440	./IBM15/DATA/V00046000.H5
+433440	./IBM15/DATA/V00042400.H5
+433440	./IBM15/DATA/V00013400.H5
+433440	./IBM15/DATA/V00057000.H5
+433440	./IBM15/DATA/V00046600.H5
+433440	./IBM15/DATA/V00038600.H5
+433440	./IBM15/DATA/V00006400.H5
+433440	./IBM15/DATA/V00003000.H5
+433440	./IBM15/DATA/V00045200.H5
+433440	./IBM15/DATA/V00059000.H5
+433440	./IBM15/DATA/V00008600.H5
+433440	./IBM15/DATA/V00053800.H5
+433440	./IBM15/DATA/V00010800.H5
+433440	./IBM15/DATA/V00002200.H5
+433440	./IBM15/DATA/V00021600.H5
+433440	./IBM15/DATA/V00059800.H5
+433440	./IBM15/DATA/V00034200.H5
+433440	./IBM15/DATA/V00058200.H5
+433440	./IBM15/DATA/V00056000.H5
+433440	./IBM15/DATA/V00047000.H5
+433440	./IBM15/DATA/V00039000.H5
+433440	./IBM15/DATA/V00028200.H5
+433440	./IBM15/DATA/V00004600.H5
+433440	./IBM15/DATA/V00034600.H5
+433440	./IBM15/DATA/V00016200.H5
+433440	./IBM15/DATA/V00045400.H5
+130898900	./IBM15/DATA
+du: cannot access `./IBM15/POST_BASIC/POST_020_STATS.F90': Permission denied
+du: cannot access `./IBM15/POST_BASIC/POST_030_READFILE.F90': Permission denied
+du: cannot access `./IBM15/POST_BASIC/POST_031_PARALLEL.F90': Permission denied
+du: cannot access `./IBM15/POST_BASIC/POST_000_MAIN.F90': Permission denied
+du: cannot access `./IBM15/POST_BASIC/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM15/POST_BASIC/POST_040_AVERAGE.F90': Permission denied
+du: cannot access `./IBM15/POST_BASIC/POST_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM15/POST_BASIC/POST_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM15/POST_BASIC/POST_050_WRITEFILE.F90': Permission denied
+du: cannot access `./IBM15/POST_BASIC/POST_010_INIT_PARALLEL.F90': Permission denied
+4	./IBM15/POST_BASIC
+464	./IBM15/gatherdata
+12	./IBM15/POST_TKE/TKEDATA_IBM.F90
+4	./IBM15/POST_TKE/TKE_IO.F90
+4	./IBM15/POST_TKE/INCLUDE_IO.FI
+8	./IBM15/POST_TKE/TKEPRE.F90
+4	./IBM15/POST_TKE/TKEPS.F90
+12	./IBM15/POST_TKE/tecio.f90
+48	./IBM15/POST_TKE
+4	./IBM15/aegean_stream.sh
+8	./IBM15/Makefile
+281248	./IBM15/VORCENTER_PRE/00029800.DAT
+281248	./IBM15/VORCENTER_PRE/00052000.DAT
+281248	./IBM15/VORCENTER_PRE/00011000.DAT
+281248	./IBM15/VORCENTER_PRE/00044200.DAT
+281248	./IBM15/VORCENTER_PRE/00024600.DAT
+281248	./IBM15/VORCENTER_PRE/00031800.DAT
+281248	./IBM15/VORCENTER_PRE/00033200.DAT
+281248	./IBM15/VORCENTER_PRE/00059000.DAT
+281248	./IBM15/VORCENTER_PRE/00015200.DAT
+281248	./IBM15/VORCENTER_PRE/00056000.DAT
+281248	./IBM15/VORCENTER_PRE/00036000.DAT
+281248	./IBM15/VORCENTER_PRE/00013800.DAT
+281248	./IBM15/VORCENTER_PRE/00016800.DAT
+281248	./IBM15/VORCENTER_PRE/00055000.DAT
+281248	./IBM15/VORCENTER_PRE/00059600.DAT
+281248	./IBM15/VORCENTER_PRE/00027000.DAT
+281248	./IBM15/VORCENTER_PRE/00049600.DAT
+281248	./IBM15/VORCENTER_PRE/00048400.DAT
+281248	./IBM15/VORCENTER_PRE/00021400.DAT
+281248	./IBM15/VORCENTER_PRE/00049400.DAT
+281248	./IBM15/VORCENTER_PRE/00040000.DAT
+281248	./IBM15/VORCENTER_PRE/00007800.DAT
+281248	./IBM15/VORCENTER_PRE/00022000.DAT
+281244	./IBM15/VORCENTER_PRE/00048200.DAT
+281248	./IBM15/VORCENTER_PRE/00014600.DAT
+281248	./IBM15/VORCENTER_PRE/00033000.DAT
+281248	./IBM15/VORCENTER_PRE/00034200.DAT
+281248	./IBM15/VORCENTER_PRE/00028000.DAT
+281248	./IBM15/VORCENTER_PRE/00032800.DAT
+281248	./IBM15/VORCENTER_PRE/00007400.DAT
+281248	./IBM15/VORCENTER_PRE/00024400.DAT
+281248	./IBM15/VORCENTER_PRE/00016400.DAT
+281248	./IBM15/VORCENTER_PRE/00058400.DAT
+281248	./IBM15/VORCENTER_PRE/00048600.DAT
+281248	./IBM15/VORCENTER_PRE/00006400.DAT
+281248	./IBM15/VORCENTER_PRE/00059400.DAT
+281248	./IBM15/VORCENTER_PRE/00053400.DAT
+281248	./IBM15/VORCENTER_PRE/00006600.DAT
+281248	./IBM15/VORCENTER_PRE/00045400.DAT
+281248	./IBM15/VORCENTER_PRE/00016200.DAT
+281248	./IBM15/VORCENTER_PRE/00005600.DAT
+281248	./IBM15/VORCENTER_PRE/00026400.DAT
+281248	./IBM15/VORCENTER_PRE/00021200.DAT
+281248	./IBM15/VORCENTER_PRE/00023400.DAT
+281248	./IBM15/VORCENTER_PRE/00027600.DAT
+281248	./IBM15/VORCENTER_PRE/00045000.DAT
+281248	./IBM15/VORCENTER_PRE/00018800.DAT
+281248	./IBM15/VORCENTER_PRE/00044800.DAT
+281248	./IBM15/VORCENTER_PRE/00058200.DAT
+281248	./IBM15/VORCENTER_PRE/00043400.DAT
+281248	./IBM15/VORCENTER_PRE/00022400.DAT
+281248	./IBM15/VORCENTER_PRE/00026800.DAT
+281248	./IBM15/VORCENTER_PRE/00042800.DAT
+281248	./IBM15/VORCENTER_PRE/00004600.DAT
+281248	./IBM15/VORCENTER_PRE/00019400.DAT
+281248	./IBM15/VORCENTER_PRE/00029600.DAT
+281248	./IBM15/VORCENTER_PRE/00046400.DAT
+281248	./IBM15/VORCENTER_PRE/00004800.DAT
+281248	./IBM15/VORCENTER_PRE/00040200.DAT
+281248	./IBM15/VORCENTER_PRE/00039200.DAT
+281248	./IBM15/VORCENTER_PRE/00056600.DAT
+281248	./IBM15/VORCENTER_PRE/00024000.DAT
+281248	./IBM15/VORCENTER_PRE/00024800.DAT
+281248	./IBM15/VORCENTER_PRE/00033800.DAT
+281248	./IBM15/VORCENTER_PRE/00057600.DAT
+281248	./IBM15/VORCENTER_PRE/00002000.DAT
+281248	./IBM15/VORCENTER_PRE/00041400.DAT
+281248	./IBM15/VORCENTER_PRE/00012400.DAT
+281248	./IBM15/VORCENTER_PRE/00000200.DAT
+281248	./IBM15/VORCENTER_PRE/00008200.DAT
+281248	./IBM15/VORCENTER_PRE/00035200.DAT
+281248	./IBM15/VORCENTER_PRE/00020200.DAT
+281248	./IBM15/VORCENTER_PRE/00029200.DAT
+281248	./IBM15/VORCENTER_PRE/00041800.DAT
+281248	./IBM15/VORCENTER_PRE/00053000.DAT
+281248	./IBM15/VORCENTER_PRE/00035400.DAT
+281248	./IBM15/VORCENTER_PRE/00009400.DAT
+281248	./IBM15/VORCENTER_PRE/00054800.DAT
+281248	./IBM15/VORCENTER_PRE/00020600.DAT
+281248	./IBM15/VORCENTER_PRE/00031000.DAT
+281248	./IBM15/VORCENTER_PRE/00057000.DAT
+281248	./IBM15/VORCENTER_PRE/00045800.DAT
+281248	./IBM15/VORCENTER_PRE/00020400.DAT
+281248	./IBM15/VORCENTER_PRE/00011600.DAT
+281248	./IBM15/VORCENTER_PRE/00042600.DAT
+281248	./IBM15/VORCENTER_PRE/00002200.DAT
+281248	./IBM15/VORCENTER_PRE/00023200.DAT
+281248	./IBM15/VORCENTER_PRE/00037400.DAT
+281248	./IBM15/VORCENTER_PRE/00028400.DAT
+281248	./IBM15/VORCENTER_PRE/00032600.DAT
+281248	./IBM15/VORCENTER_PRE/00038000.DAT
+281248	./IBM15/VORCENTER_PRE/00046600.DAT
+281248	./IBM15/VORCENTER_PRE/00056800.DAT
+281248	./IBM15/VORCENTER_PRE/00034400.DAT
+281248	./IBM15/VORCENTER_PRE/00025600.DAT
+281248	./IBM15/VORCENTER_PRE/00030800.DAT
+281248	./IBM15/VORCENTER_PRE/00008800.DAT
+281248	./IBM15/VORCENTER_PRE/00049800.DAT
+281248	./IBM15/VORCENTER_PRE/00003200.DAT
+281248	./IBM15/VORCENTER_PRE/00015400.DAT
+281248	./IBM15/VORCENTER_PRE/00001800.DAT
+281248	./IBM15/VORCENTER_PRE/00050400.DAT
+281248	./IBM15/VORCENTER_PRE/00029000.DAT
+281248	./IBM15/VORCENTER_PRE/00043800.DAT
+281248	./IBM15/VORCENTER_PRE/00002400.DAT
+281248	./IBM15/VORCENTER_PRE/00052600.DAT
+281248	./IBM15/VORCENTER_PRE/00040800.DAT
+281248	./IBM15/VORCENTER_PRE/00017800.DAT
+281248	./IBM15/VORCENTER_PRE/00045600.DAT
+281248	./IBM15/VORCENTER_PRE/00002600.DAT
+281248	./IBM15/VORCENTER_PRE/00015800.DAT
+281248	./IBM15/VORCENTER_PRE/00037000.DAT
+281248	./IBM15/VORCENTER_PRE/00059200.DAT
+281248	./IBM15/VORCENTER_PRE/00049200.DAT
+281248	./IBM15/VORCENTER_PRE/00051800.DAT
+281248	./IBM15/VORCENTER_PRE/00011200.DAT
+281248	./IBM15/VORCENTER_PRE/00056200.DAT
+281248	./IBM15/VORCENTER_PRE/00054200.DAT
+281248	./IBM15/VORCENTER_PRE/00030600.DAT
+281248	./IBM15/VORCENTER_PRE/00036600.DAT
+281248	./IBM15/VORCENTER_PRE/00047000.DAT
+281248	./IBM15/VORCENTER_PRE/00054000.DAT
+281248	./IBM15/VORCENTER_PRE/00030200.DAT
+281248	./IBM15/VORCENTER_PRE/00032400.DAT
+281248	./IBM15/VORCENTER_PRE/00009800.DAT
+281248	./IBM15/VORCENTER_PRE/00053600.DAT
+281248	./IBM15/VORCENTER_PRE/00001200.DAT
+281248	./IBM15/VORCENTER_PRE/00010000.DAT
+281248	./IBM15/VORCENTER_PRE/00051400.DAT
+281248	./IBM15/VORCENTER_PRE/00051600.DAT
+281248	./IBM15/VORCENTER_PRE/00001000.DAT
+281248	./IBM15/VORCENTER_PRE/00046200.DAT
+281248	./IBM15/VORCENTER_PRE/00014400.DAT
+281248	./IBM15/VORCENTER_PRE/00046000.DAT
+281248	./IBM15/VORCENTER_PRE/00034600.DAT
+281248	./IBM15/VORCENTER_PRE/00020800.DAT
+281248	./IBM15/VORCENTER_PRE/00022600.DAT
+281248	./IBM15/VORCENTER_PRE/00037200.DAT
+281248	./IBM15/VORCENTER_PRE/00001600.DAT
+281248	./IBM15/VORCENTER_PRE/00004400.DAT
+281248	./IBM15/VORCENTER_PRE/00010600.DAT
+281248	./IBM15/VORCENTER_PRE/00037800.DAT
+281248	./IBM15/VORCENTER_PRE/00047600.DAT
+281248	./IBM15/VORCENTER_PRE/00018000.DAT
+281248	./IBM15/VORCENTER_PRE/00055200.DAT
+281248	./IBM15/VORCENTER_PRE/00052800.DAT
+281248	./IBM15/VORCENTER_PRE/00048800.DAT
+281248	./IBM15/VORCENTER_PRE/00043200.DAT
+281248	./IBM15/VORCENTER_PRE/00052200.DAT
+281248	./IBM15/VORCENTER_PRE/00014200.DAT
+281248	./IBM15/VORCENTER_PRE/00034800.DAT
+281248	./IBM15/VORCENTER_PRE/00057800.DAT
+281248	./IBM15/VORCENTER_PRE/00047800.DAT
+281248	./IBM15/VORCENTER_PRE/00055600.DAT
+281248	./IBM15/VORCENTER_PRE/00001400.DAT
+281248	./IBM15/VORCENTER_PRE/00006800.DAT
+281248	./IBM15/VORCENTER_PRE/00003600.DAT
+281248	./IBM15/VORCENTER_PRE/00050600.DAT
+281248	./IBM15/VORCENTER_PRE/00026200.DAT
+281248	./IBM15/VORCENTER_PRE/00027400.DAT
+281248	./IBM15/VORCENTER_PRE/00042000.DAT
+281248	./IBM15/VORCENTER_PRE/00028800.DAT
+281248	./IBM15/VORCENTER_PRE/00031200.DAT
+281248	./IBM15/VORCENTER_PRE/00058800.DAT
+281248	./IBM15/VORCENTER_PRE/00016600.DAT
+281248	./IBM15/VORCENTER_PRE/00036800.DAT
+281248	./IBM15/VORCENTER_PRE/00007200.DAT
+281248	./IBM15/VORCENTER_PRE/00032200.DAT
+281248	./IBM15/VORCENTER_PRE/00044400.DAT
+281248	./IBM15/VORCENTER_PRE/00033600.DAT
+281248	./IBM15/VORCENTER_PRE/00031600.DAT
+281248	./IBM15/VORCENTER_PRE/00058000.DAT
+281248	./IBM15/VORCENTER_PRE/00030000.DAT
+281248	./IBM15/VORCENTER_PRE/00017000.DAT
+281248	./IBM15/VORCENTER_PRE/00054600.DAT
+281248	./IBM15/VORCENTER_PRE/00042200.DAT
+281248	./IBM15/VORCENTER_PRE/00026000.DAT
+281248	./IBM15/VORCENTER_PRE/00023600.DAT
+281248	./IBM15/VORCENTER_PRE/00040400.DAT
+281248	./IBM15/VORCENTER_PRE/00050000.DAT
+281248	./IBM15/VORCENTER_PRE/00041200.DAT
+281248	./IBM15/VORCENTER_PRE/00028600.DAT
+281248	./IBM15/VORCENTER_PRE/00038800.DAT
+281248	./IBM15/VORCENTER_PRE/00039400.DAT
+281248	./IBM15/VORCENTER_PRE/00025400.DAT
+281248	./IBM15/VORCENTER_PRE/00040600.DAT
+281248	./IBM15/VORCENTER_PRE/00010800.DAT
+281248	./IBM15/VORCENTER_PRE/00039800.DAT
+281248	./IBM15/VORCENTER_PRE/00057400.DAT
+281248	./IBM15/VORCENTER_PRE/00053200.DAT
+281248	./IBM15/VORCENTER_PRE/00025200.DAT
+281248	./IBM15/VORCENTER_PRE/00007600.DAT
+281248	./IBM15/VORCENTER_PRE/00020000.DAT
+281248	./IBM15/VORCENTER_PRE/00000800.DAT
+281248	./IBM15/VORCENTER_PRE/00048000.DAT
+281248	./IBM15/VORCENTER_PRE/00018400.DAT
+281248	./IBM15/VORCENTER_PRE/00043600.DAT
+281248	./IBM15/VORCENTER_PRE/00024200.DAT
+281248	./IBM15/VORCENTER_PRE/00005800.DAT
+281248	./IBM15/VORCENTER_PRE/00012000.DAT
+281248	./IBM15/VORCENTER_PRE/00000400.DAT
+281248	./IBM15/VORCENTER_PRE/00006000.DAT
+281248	./IBM15/VORCENTER_PRE/00008600.DAT
+281248	./IBM15/VORCENTER_PRE/00003800.DAT
+281248	./IBM15/VORCENTER_PRE/00027200.DAT
+281248	./IBM15/VORCENTER_PRE/00047400.DAT
+281248	./IBM15/VORCENTER_PRE/00021600.DAT
+281248	./IBM15/VORCENTER_PRE/00013000.DAT
+281248	./IBM15/VORCENTER_PRE/00013200.DAT
+281248	./IBM15/VORCENTER_PRE/00000600.DAT
+281248	./IBM15/VORCENTER_PRE/00015000.DAT
+281248	./IBM15/VORCENTER_PRE/00004000.DAT
+281248	./IBM15/VORCENTER_PRE/00041600.DAT
+281248	./IBM15/VORCENTER_PRE/00036200.DAT
+281248	./IBM15/VORCENTER_PRE/00019800.DAT
+281248	./IBM15/VORCENTER_PRE/00035000.DAT
+281248	./IBM15/VORCENTER_PRE/00012800.DAT
+281248	./IBM15/VORCENTER_PRE/00038400.DAT
+281248	./IBM15/VORCENTER_PRE/00004200.DAT
+281248	./IBM15/VORCENTER_PRE/00010200.DAT
+281248	./IBM15/VORCENTER_PRE/00041000.DAT
+281248	./IBM15/VORCENTER_PRE/00011400.DAT
+281248	./IBM15/VORCENTER_PRE/00023800.DAT
+281248	./IBM15/VORCENTER_PRE/00045200.DAT
+281248	./IBM15/VORCENTER_PRE/00032000.DAT
+281248	./IBM15/VORCENTER_PRE/00026600.DAT
+281248	./IBM15/VORCENTER_PRE/00037600.DAT
+281248	./IBM15/VORCENTER_PRE/00038600.DAT
+281248	./IBM15/VORCENTER_PRE/00005000.DAT
+281248	./IBM15/VORCENTER_PRE/00050200.DAT
+281248	./IBM15/VORCENTER_PRE/00005200.DAT
+281248	./IBM15/VORCENTER_PRE/00023000.DAT
+281248	./IBM15/VORCENTER_PRE/00039600.DAT
+281248	./IBM15/VORCENTER_PRE/00047200.DAT
+281248	./IBM15/VORCENTER_PRE/00019600.DAT
+281248	./IBM15/VORCENTER_PRE/00028200.DAT
+281248	./IBM15/VORCENTER_PRE/00021000.DAT
+281248	./IBM15/VORCENTER_PRE/00010400.DAT
+281248	./IBM15/VORCENTER_PRE/00011800.DAT
+281248	./IBM15/VORCENTER_PRE/00017600.DAT
+281248	./IBM15/VORCENTER_PRE/00018600.DAT
+281248	./IBM15/VORCENTER_PRE/00012200.DAT
+281248	./IBM15/VORCENTER_PRE/00033400.DAT
+281248	./IBM15/VORCENTER_PRE/00049000.DAT
+281248	./IBM15/VORCENTER_PRE/00019200.DAT
+281248	./IBM15/VORCENTER_PRE/00054400.DAT
+281248	./IBM15/VORCENTER_PRE/00012600.DAT
+281248	./IBM15/VORCENTER_PRE/00005400.DAT
+281248	./IBM15/VORCENTER_PRE/00017400.DAT
+281248	./IBM15/VORCENTER_PRE/00003000.DAT
+281248	./IBM15/VORCENTER_PRE/00009600.DAT
+281248	./IBM15/VORCENTER_PRE/00016000.DAT
+281248	./IBM15/VORCENTER_PRE/00030400.DAT
+281248	./IBM15/VORCENTER_PRE/00014000.DAT
+281248	./IBM15/VORCENTER_PRE/00014800.DAT
+281248	./IBM15/VORCENTER_PRE/00038200.DAT
+281248	./IBM15/VORCENTER_PRE/00055400.DAT
+281248	./IBM15/VORCENTER_PRE/00035600.DAT
+281248	./IBM15/VORCENTER_PRE/00043000.DAT
+281248	./IBM15/VORCENTER_PRE/00031400.DAT
+281248	./IBM15/VORCENTER_PRE/00013600.DAT
+281248	./IBM15/VORCENTER_PRE/00057200.DAT
+281248	./IBM15/VORCENTER_PRE/00021800.DAT
+281248	./IBM15/VORCENTER_PRE/00018200.DAT
+281248	./IBM15/VORCENTER_PRE/00025800.DAT
+281248	./IBM15/VORCENTER_PRE/00042400.DAT
+281248	./IBM15/VORCENTER_PRE/00015600.DAT
+281248	./IBM15/VORCENTER_PRE/00039000.DAT
+281248	./IBM15/VORCENTER_PRE/00056400.DAT
+281248	./IBM15/VORCENTER_PRE/00053800.DAT
+281248	./IBM15/VORCENTER_PRE/00055800.DAT
+281248	./IBM15/VORCENTER_PRE/00035800.DAT
+281248	./IBM15/VORCENTER_PRE/00000000.DAT
+281248	./IBM15/VORCENTER_PRE/00052400.DAT
+281248	./IBM15/VORCENTER_PRE/00044000.DAT
+281248	./IBM15/VORCENTER_PRE/00009000.DAT
+281248	./IBM15/VORCENTER_PRE/00008400.DAT
+281248	./IBM15/VORCENTER_PRE/00006200.DAT
+281248	./IBM15/VORCENTER_PRE/00017200.DAT
+281248	./IBM15/VORCENTER_PRE/00029400.DAT
+281248	./IBM15/VORCENTER_PRE/00050800.DAT
+281248	./IBM15/VORCENTER_PRE/00007000.DAT
+281248	./IBM15/VORCENTER_PRE/00013400.DAT
+281248	./IBM15/VORCENTER_PRE/00051200.DAT
+281248	./IBM15/VORCENTER_PRE/00051000.DAT
+281248	./IBM15/VORCENTER_PRE/00019000.DAT
+281248	./IBM15/VORCENTER_PRE/00034000.DAT
+281248	./IBM15/VORCENTER_PRE/00022200.DAT
+281248	./IBM15/VORCENTER_PRE/00002800.DAT
+281248	./IBM15/VORCENTER_PRE/00025000.DAT
+281248	./IBM15/VORCENTER_PRE/00008000.DAT
+281248	./IBM15/VORCENTER_PRE/00036400.DAT
+281248	./IBM15/VORCENTER_PRE/00009200.DAT
+281248	./IBM15/VORCENTER_PRE/00003400.DAT
+281248	./IBM15/VORCENTER_PRE/00027800.DAT
+281248	./IBM15/VORCENTER_PRE/00022800.DAT
+281248	./IBM15/VORCENTER_PRE/00046800.DAT
+281248	./IBM15/VORCENTER_PRE/00058600.DAT
+281248	./IBM15/VORCENTER_PRE/00044600.DAT
+84093168	./IBM15/VORCENTER_PRE
+4	./IBM15/WAVE
+4	./IBM15/RESTART_SOLID
+475944	./IBM15/STATS/BASIC.H5
+4	./IBM15/STATS/STAT_STEP
+475952	./IBM15/STATS
+4	./IBM15/vor.sh
+du: cannot access `./IBM15/batchrun/main.py': Permission denied
+du: cannot access `./IBM15/batchrun/grid.py': Permission denied
+du: cannot access `./IBM15/batchrun/param.py': Permission denied
+du: cannot access `./IBM15/batchrun/compile.py': Permission denied
+du: cannot access `./IBM15/batchrun/control.py': Permission denied
+du: cannot access `./IBM15/batchrun/directory.py': Permission denied
+du: cannot access `./IBM15/batchrun/ReadMe.md': Permission denied
+du: cannot access `./IBM15/batchrun/script.py': Permission denied
+4	./IBM15/batchrun
+4	./IBM15/resga
+7852	./IBM15/sour.dat
+4	./IBM15/aga.sh
+du: cannot access `./IBM15/POST/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM15/POST/post': Permission denied
+du: cannot access `./IBM15/POST/POST_TKE.F90': Permission denied
+du: cannot access `./IBM15/POST/POST_SURFACE.F90': Permission denied
+du: cannot access `./IBM15/POST/POST_IO.F90': Permission denied
+4	./IBM15/POST
+4	./IBM15/PARAM.IN
+4	./IBM15/CIRC_VELO
+4	./IBM15/vorcenter.sh
+11508	./IBM15/TIME_SERIES/MAXUVW.DAT
+2116	./IBM15/TIME_SERIES/YTIP.DAT
+7100	./IBM15/TIME_SERIES/CDCF.DAT
+20728	./IBM15/TIME_SERIES
+du: cannot access `./IBM15/GATHERDATA/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM15/GATHERDATA/GATHER_IO.o': Permission denied
+du: cannot access `./IBM15/GATHERDATA/tecio.f90': Permission denied
+du: cannot access `./IBM15/GATHERDATA/GATHER_IO.F90': Permission denied
+du: cannot access `./IBM15/GATHERDATA/GATHERDATA.o': Permission denied
+du: cannot access `./IBM15/GATHERDATA/GATHERDATA.F90': Permission denied
+4	./IBM15/GATHERDATA
+du: cannot access `./IBM15/POST_VORTEX/FDM_064_VORENSTROPHY.F90': Permission denied
+du: cannot access `./IBM15/POST_VORTEX/VORTEXP.F90': Permission denied
+du: cannot access `./IBM15/POST_VORTEX/VORDYNAMIC.F90': Permission denied
+du: cannot access `./IBM15/POST_VORTEX/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM15/POST_VORTEX/POST_VORTEX.F90': Permission denied
+du: cannot access `./IBM15/POST_VORTEX/VORMAX.F90': Permission denied
+du: cannot access `./IBM15/POST_VORTEX/tecio.f90': Permission denied
+du: cannot access `./IBM15/POST_VORTEX/VORTEX_IO.F90': Permission denied
+du: cannot access `./IBM15/POST_VORTEX/VORTEX_IBM.F90': Permission denied
+du: cannot access `./IBM15/POST_VORTEX/tags': Permission denied
+du: cannot access `./IBM15/POST_VORTEX/VORTEX.F90': Permission denied
+du: cannot access `./IBM15/POST_VORTEX/VORTEX_X.F90': Permission denied
+du: cannot access `./IBM15/POST_VORTEX/VORDYNAMIC_TH.F90': Permission denied
+du: cannot access `./IBM15/POST_VORTEX/VORDYNAMIC_Y.F90': Permission denied
+4	./IBM15/POST_VORTEX
+17660	./IBM15/wave
+du: cannot access `./IBM15/POST_WAVY_WALL/POST_030_READFILE.F90': Permission denied
+du: cannot access `./IBM15/POST_WAVY_WALL/POST_000_MAIN.F90': Permission denied
+du: cannot access `./IBM15/POST_WAVY_WALL/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM15/POST_WAVY_WALL/POST_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM15/POST_WAVY_WALL/POST_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM15/POST_WAVY_WALL/POST_040_WRITEFILE.F90': Permission denied
+du: cannot access `./IBM15/POST_WAVY_WALL/POST_020_AVERAGE.F90': Permission denied
+du: cannot access `./IBM15/POST_WAVY_WALL/POST_010_INIT_PARALLEL.F90': Permission denied
+4	./IBM15/POST_WAVY_WALL
+4	./IBM15/TRACER
+8	./IBM15/GRID.IN
+8	./IBM15/INSTANTANEOUS/vortex_3.mcr
+24	./IBM15/INSTANTANEOUS/vortex_3pre.lay
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/4600.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/5400.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/6000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/26600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/45400.png
+24	./IBM15/INSTANTANEOUS/figure_vortex_3/2200.png
+20	./IBM15/INSTANTANEOUS/figure_vortex_3/200.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/9000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/23000.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/10200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/17400.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/2400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/51800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/15000.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/10800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/19600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/47200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/18600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/50400.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/6800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/29800.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/54600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/47800.png
+24	./IBM15/INSTANTANEOUS/figure_vortex_3/1400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/50000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/46400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/23600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/25600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/17200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/14000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/35200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/37600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/29000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/13200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/56000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/21800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/26200.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/6400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/48600.png
+24	./IBM15/INSTANTANEOUS/figure_vortex_3/600.png
+24	./IBM15/INSTANTANEOUS/figure_vortex_3/800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/20000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/30400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/49600.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/10600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/49800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/41200.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/55000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/13400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/45000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/15600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/43400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/32800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/36400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/20400.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/9600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/40400.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/11200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/29200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/15200.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/37800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/33400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/56400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/13800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/39800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/37200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/34800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/51200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/27800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/22000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/44800.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/4200.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/8800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/42800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/47000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/11400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/38400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/15400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/35000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/27600.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/8600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/12600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/39400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/25000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/19800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/31400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/26400.png
+24	./IBM15/INSTANTANEOUS/figure_vortex_3/1000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/22400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/41800.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/53800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/12200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/58800.png
+24	./IBM15/INSTANTANEOUS/figure_vortex_3/3000.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/4000.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/4400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/21600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/30800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/57400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/38200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/15800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/40600.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/54800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/40000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/23400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/58000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/24600.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/9800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/37000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/24800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/32400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/25400.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/53600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/51400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/17600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/13000.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/5800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/12400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/57800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/43000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/27200.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/7000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/42400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/59000.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/55200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/50800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/58400.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/7400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/28600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/59200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/23800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/52800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/11800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/34200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/58600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/18400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/38800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/29600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/56200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/52000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/28400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/24200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/24400.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/54200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/16800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/14800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/24000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/34400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/33000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/30600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/39600.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/6200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/48800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/12000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/23200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/14600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/48000.png
+24	./IBM15/INSTANTANEOUS/figure_vortex_3/1800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/42600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/17800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/49400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/48400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/52400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/43200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/47600.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/8200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/34600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/12800.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/7600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/16200.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/11000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/53400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/44400.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/3200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/20200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/30200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/46000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/16600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/39000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/19000.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/8000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/22200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/31800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/25800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/59400.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/5200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/21400.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/9200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/17000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/22800.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/54400.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/53000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/30000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/36000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/18000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/45600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/27000.png
+24	./IBM15/INSTANTANEOUS/figure_vortex_3/400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/26800.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/6600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/33200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/58200.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/5000.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/10000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/13600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/49000.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/2600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/33800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/57000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/41400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/45800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/36600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/47400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/40800.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/55400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/20600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/26000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/43800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/25200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/38000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/56600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/19200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/32600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/36800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/28000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/50600.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/3800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/57200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/19400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/48200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/46800.png
+24	./IBM15/INSTANTANEOUS/figure_vortex_3/2800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/31000.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/3600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/28800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/27400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/49200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/39200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/43600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/14200.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/4800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/51000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/35600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/42200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/18200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/16400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/31200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/37400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/21200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/38600.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/5600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/44600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/20800.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/55800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/31600.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/8400.png
+24	./IBM15/INSTANTANEOUS/figure_vortex_3/1600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/52200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/33600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/59600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/28200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/53200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/34000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/42000.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/10400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/35800.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/7200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/18800.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/7800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/16000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/57600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/22600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/51600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/41000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/32200.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/9400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/50200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/35400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/44200.png
+24	./IBM15/INSTANTANEOUS/figure_vortex_3/2000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/21000.png
+28	./IBM15/INSTANTANEOUS/figure_vortex_3/3400.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/54000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/46600.png
+24	./IBM15/INSTANTANEOUS/figure_vortex_3/1200.png
+40	./IBM15/INSTANTANEOUS/figure_vortex_3/55600.png
+32	./IBM15/INSTANTANEOUS/figure_vortex_3/11600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/41600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/14400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/56800.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/46200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/36200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/52600.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/45200.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/32000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/29400.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/44000.png
+36	./IBM15/INSTANTANEOUS/figure_vortex_3/40200.png
+10368	./IBM15/INSTANTANEOUS/figure_vortex_3
+76	./IBM15/INSTANTANEOUS/batch.log
+10496	./IBM15/INSTANTANEOUS
+6348	./IBM15/results_aegean
+28	./IBM15/SURFACE/00033050.dat
+28	./IBM15/SURFACE/00039800.dat
+28	./IBM15/SURFACE/00024400.dat
+28	./IBM15/SURFACE/00035300.dat
+28	./IBM15/SURFACE/00002850.dat
+28	./IBM15/SURFACE/00046450.dat
+28	./IBM15/SURFACE/00025200.dat
+28	./IBM15/SURFACE/00047800.dat
+28	./IBM15/SURFACE/00047900.dat
+28	./IBM15/SURFACE/00048750.dat
+28	./IBM15/SURFACE/00003250.dat
+28	./IBM15/SURFACE/00048050.dat
+28	./IBM15/SURFACE/00031850.dat
+28	./IBM15/SURFACE/00005900.dat
+28	./IBM15/SURFACE/00056750.dat
+28	./IBM15/SURFACE/00010950.dat
+28	./IBM15/SURFACE/00052550.dat
+28	./IBM15/SURFACE/00016350.dat
+28	./IBM15/SURFACE/00010700.dat
+28	./IBM15/SURFACE/00028100.dat
+28	./IBM15/SURFACE/00032950.dat
+28	./IBM15/SURFACE/00057600.dat
+28	./IBM15/SURFACE/00041300.dat
+28	./IBM15/SURFACE/00016500.dat
+28	./IBM15/SURFACE/00012650.dat
+28	./IBM15/SURFACE/00009400.dat
+28	./IBM15/SURFACE/00047100.dat
+28	./IBM15/SURFACE/00056450.dat
+28	./IBM15/SURFACE/00052300.dat
+28	./IBM15/SURFACE/00058600.dat
+28	./IBM15/SURFACE/00053000.dat
+28	./IBM15/SURFACE/00018950.dat
+28	./IBM15/SURFACE/00043250.dat
+28	./IBM15/SURFACE/00024900.dat
+28	./IBM15/SURFACE/00032650.dat
+28	./IBM15/SURFACE/00009850.dat
+28	./IBM15/SURFACE/00040800.dat
+28	./IBM15/SURFACE/00035500.dat
+28	./IBM15/SURFACE/00034200.dat
+28	./IBM15/SURFACE/00051500.dat
+28	./IBM15/SURFACE/00013150.dat
+28	./IBM15/SURFACE/00019950.dat
+28	./IBM15/SURFACE/00029450.dat
+28	./IBM15/SURFACE/00028750.dat
+28	./IBM15/SURFACE/00026250.dat
+28	./IBM15/SURFACE/00031550.dat
+28	./IBM15/SURFACE/00032900.dat
+28	./IBM15/SURFACE/00052450.dat
+28	./IBM15/SURFACE/00014300.dat
+28	./IBM15/SURFACE/00042450.dat
+28	./IBM15/SURFACE/00007200.dat
+28	./IBM15/SURFACE/00058800.dat
+28	./IBM15/SURFACE/00031350.dat
+28	./IBM15/SURFACE/00021400.dat
+28	./IBM15/SURFACE/00055000.dat
+28	./IBM15/SURFACE/00018550.dat
+28	./IBM15/SURFACE/00053200.dat
+28	./IBM15/SURFACE/00013600.dat
+28	./IBM15/SURFACE/00004950.dat
+28	./IBM15/SURFACE/00004450.dat
+28	./IBM15/SURFACE/00050300.dat
+28	./IBM15/SURFACE/00033900.dat
+28	./IBM15/SURFACE/00020800.dat
+28	./IBM15/SURFACE/00009000.dat
+28	./IBM15/SURFACE/00014250.dat
+28	./IBM15/SURFACE/00024300.dat
+28	./IBM15/SURFACE/00036750.dat
+28	./IBM15/SURFACE/00040300.dat
+28	./IBM15/SURFACE/00043700.dat
+28	./IBM15/SURFACE/00035450.dat
+28	./IBM15/SURFACE/00009450.dat
+28	./IBM15/SURFACE/00052400.dat
+28	./IBM15/SURFACE/00039950.dat
+28	./IBM15/SURFACE/00011600.dat
+28	./IBM15/SURFACE/00051900.dat
+28	./IBM15/SURFACE/00002950.dat
+28	./IBM15/SURFACE/00001650.dat
+28	./IBM15/SURFACE/00026050.dat
+28	./IBM15/SURFACE/00039200.dat
+28	./IBM15/SURFACE/00034350.dat
+28	./IBM15/SURFACE/00041700.dat
+28	./IBM15/SURFACE/00058500.dat
+28	./IBM15/SURFACE/00047050.dat
+28	./IBM15/SURFACE/00026900.dat
+28	./IBM15/SURFACE/00030550.dat
+28	./IBM15/SURFACE/00054450.dat
+28	./IBM15/SURFACE/00042850.dat
+28	./IBM15/SURFACE/00010800.dat
+28	./IBM15/SURFACE/00028900.dat
+28	./IBM15/SURFACE/00034750.dat
+28	./IBM15/SURFACE/00024350.dat
+28	./IBM15/SURFACE/00006100.dat
+28	./IBM15/SURFACE/00015700.dat
+28	./IBM15/SURFACE/00048000.dat
+28	./IBM15/SURFACE/00049150.dat
+28	./IBM15/SURFACE/00016750.dat
+28	./IBM15/SURFACE/00040600.dat
+28	./IBM15/SURFACE/00015200.dat
+28	./IBM15/SURFACE/00046500.dat
+28	./IBM15/SURFACE/00016250.dat
+28	./IBM15/SURFACE/00011100.dat
+28	./IBM15/SURFACE/00004300.dat
+28	./IBM15/SURFACE/00049550.dat
+28	./IBM15/SURFACE/00012350.dat
+28	./IBM15/SURFACE/00021000.dat
+28	./IBM15/SURFACE/00048100.dat
+28	./IBM15/SURFACE/00022300.dat
+28	./IBM15/SURFACE/00042050.dat
+28	./IBM15/SURFACE/00033950.dat
+28	./IBM15/SURFACE/00052800.dat
+28	./IBM15/SURFACE/00057850.dat
+28	./IBM15/SURFACE/00005000.dat
+28	./IBM15/SURFACE/00037300.dat
+28	./IBM15/SURFACE/00030450.dat
+28	./IBM15/SURFACE/00041550.dat
+28	./IBM15/SURFACE/00059150.dat
+28	./IBM15/SURFACE/00006250.dat
+28	./IBM15/SURFACE/00040250.dat
+28	./IBM15/SURFACE/00037400.dat
+28	./IBM15/SURFACE/00019300.dat
+28	./IBM15/SURFACE/00044300.dat
+28	./IBM15/SURFACE/00053550.dat
+28	./IBM15/SURFACE/00023300.dat
+28	./IBM15/SURFACE/00048550.dat
+28	./IBM15/SURFACE/00007050.dat
+28	./IBM15/SURFACE/00012600.dat
+28	./IBM15/SURFACE/00037600.dat
+28	./IBM15/SURFACE/00040650.dat
+28	./IBM15/SURFACE/00026200.dat
+28	./IBM15/SURFACE/00044900.dat
+28	./IBM15/SURFACE/00055550.dat
+28	./IBM15/SURFACE/00033400.dat
+28	./IBM15/SURFACE/00001500.dat
+28	./IBM15/SURFACE/00036900.dat
+28	./IBM15/SURFACE/00037350.dat
+28	./IBM15/SURFACE/00011300.dat
+28	./IBM15/SURFACE/00042300.dat
+28	./IBM15/SURFACE/00023200.dat
+28	./IBM15/SURFACE/00056400.dat
+28	./IBM15/SURFACE/00047000.dat
+28	./IBM15/SURFACE/00059650.dat
+28	./IBM15/SURFACE/00049200.dat
+28	./IBM15/SURFACE/00003300.dat
+28	./IBM15/SURFACE/00007300.dat
+28	./IBM15/SURFACE/00017400.dat
+28	./IBM15/SURFACE/00004550.dat
+28	./IBM15/SURFACE/00007950.dat
+28	./IBM15/SURFACE/00056000.dat
+28	./IBM15/SURFACE/00022000.dat
+28	./IBM15/SURFACE/00008100.dat
+28	./IBM15/SURFACE/00059800.dat
+28	./IBM15/SURFACE/00027700.dat
+28	./IBM15/SURFACE/00034700.dat
+28	./IBM15/SURFACE/00050800.dat
+28	./IBM15/SURFACE/00014850.dat
+28	./IBM15/SURFACE/00039650.dat
+28	./IBM15/SURFACE/00007800.dat
+28	./IBM15/SURFACE/00005300.dat
+28	./IBM15/SURFACE/00018000.dat
+28	./IBM15/SURFACE/00005700.dat
+28	./IBM15/SURFACE/00020300.dat
+28	./IBM15/SURFACE/00004500.dat
+28	./IBM15/SURFACE/00018800.dat
+28	./IBM15/SURFACE/00017750.dat
+28	./IBM15/SURFACE/00003100.dat
+28	./IBM15/SURFACE/00056300.dat
+28	./IBM15/SURFACE/00018400.dat
+28	./IBM15/SURFACE/00054950.dat
+28	./IBM15/SURFACE/00050500.dat
+28	./IBM15/SURFACE/00043200.dat
+28	./IBM15/SURFACE/00035100.dat
+28	./IBM15/SURFACE/00041600.dat
+28	./IBM15/SURFACE/00034400.dat
+28	./IBM15/SURFACE/00023250.dat
+28	./IBM15/SURFACE/00008650.dat
+28	./IBM15/SURFACE/00023150.dat
+28	./IBM15/SURFACE/00007450.dat
+28	./IBM15/SURFACE/00043950.dat
+28	./IBM15/SURFACE/00053950.dat
+28	./IBM15/SURFACE/00029250.dat
+28	./IBM15/SURFACE/00013400.dat
+28	./IBM15/SURFACE/00004150.dat
+28	./IBM15/SURFACE/00041050.dat
+28	./IBM15/SURFACE/00016050.dat
+28	./IBM15/SURFACE/00036650.dat
+28	./IBM15/SURFACE/00025700.dat
+28	./IBM15/SURFACE/00051200.dat
+28	./IBM15/SURFACE/00036350.dat
+28	./IBM15/SURFACE/00020650.dat
+28	./IBM15/SURFACE/00050100.dat
+28	./IBM15/SURFACE/00058700.dat
+28	./IBM15/SURFACE/00006850.dat
+28	./IBM15/SURFACE/00046300.dat
+28	./IBM15/SURFACE/00039400.dat
+28	./IBM15/SURFACE/00037450.dat
+28	./IBM15/SURFACE/00058650.dat
+28	./IBM15/SURFACE/00046950.dat
+28	./IBM15/SURFACE/00027000.dat
+28	./IBM15/SURFACE/00009650.dat
+28	./IBM15/SURFACE/00000750.dat
+28	./IBM15/SURFACE/00046900.dat
+28	./IBM15/SURFACE/00019750.dat
+28	./IBM15/SURFACE/00041750.dat
+28	./IBM15/SURFACE/00030500.dat
+28	./IBM15/SURFACE/00057150.dat
+28	./IBM15/SURFACE/00040850.dat
+28	./IBM15/SURFACE/00000100.dat
+28	./IBM15/SURFACE/00028700.dat
+28	./IBM15/SURFACE/00002700.dat
+28	./IBM15/SURFACE/00040750.dat
+28	./IBM15/SURFACE/00038500.dat
+28	./IBM15/SURFACE/00005650.dat
+28	./IBM15/SURFACE/00043050.dat
+28	./IBM15/SURFACE/00041500.dat
+28	./IBM15/SURFACE/00003450.dat
+28	./IBM15/SURFACE/00042550.dat
+28	./IBM15/SURFACE/00009100.dat
+28	./IBM15/SURFACE/00041800.dat
+28	./IBM15/SURFACE/00051550.dat
+28	./IBM15/SURFACE/00056200.dat
+28	./IBM15/SURFACE/00052750.dat
+28	./IBM15/SURFACE/00019150.dat
+28	./IBM15/SURFACE/00010400.dat
+28	./IBM15/SURFACE/00009250.dat
+28	./IBM15/SURFACE/00034600.dat
+28	./IBM15/SURFACE/00037100.dat
+28	./IBM15/SURFACE/00012800.dat
+28	./IBM15/SURFACE/00024050.dat
+28	./IBM15/SURFACE/00052350.dat
+28	./IBM15/SURFACE/00047150.dat
+28	./IBM15/SURFACE/00028550.dat
+28	./IBM15/SURFACE/00050050.dat
+28	./IBM15/SURFACE/00029000.dat
+28	./IBM15/SURFACE/00055500.dat
+28	./IBM15/SURFACE/00028850.dat
+28	./IBM15/SURFACE/00021800.dat
+28	./IBM15/SURFACE/00000200.dat
+28	./IBM15/SURFACE/00049450.dat
+28	./IBM15/SURFACE/00049000.dat
+28	./IBM15/SURFACE/00030400.dat
+28	./IBM15/SURFACE/00011750.dat
+28	./IBM15/SURFACE/00029350.dat
+28	./IBM15/SURFACE/00025950.dat
+28	./IBM15/SURFACE/00033850.dat
+28	./IBM15/SURFACE/00000900.dat
+28	./IBM15/SURFACE/00029200.dat
+28	./IBM15/SURFACE/00001900.dat
+28	./IBM15/SURFACE/00057100.dat
+28	./IBM15/SURFACE/00054850.dat
+28	./IBM15/SURFACE/00046050.dat
+28	./IBM15/SURFACE/00008450.dat
+28	./IBM15/SURFACE/00018500.dat
+28	./IBM15/SURFACE/00023850.dat
+28	./IBM15/SURFACE/00025250.dat
+28	./IBM15/SURFACE/00041150.dat
+28	./IBM15/SURFACE/00026000.dat
+28	./IBM15/SURFACE/00050550.dat
+28	./IBM15/SURFACE/00030850.dat
+28	./IBM15/SURFACE/00045500.dat
+28	./IBM15/SURFACE/00038450.dat
+28	./IBM15/SURFACE/00030050.dat
+28	./IBM15/SURFACE/00056250.dat
+28	./IBM15/SURFACE/00054700.dat
+28	./IBM15/SURFACE/00010900.dat
+28	./IBM15/SURFACE/00051000.dat
+28	./IBM15/SURFACE/00012300.dat
+28	./IBM15/SURFACE/00048500.dat
+28	./IBM15/SURFACE/00039100.dat
+28	./IBM15/SURFACE/00020150.dat
+28	./IBM15/SURFACE/00043300.dat
+28	./IBM15/SURFACE/00010250.dat
+28	./IBM15/SURFACE/00004000.dat
+28	./IBM15/SURFACE/00041950.dat
+28	./IBM15/SURFACE/00042650.dat
+28	./IBM15/SURFACE/00014050.dat
+28	./IBM15/SURFACE/00036050.dat
+28	./IBM15/SURFACE/00054250.dat
+28	./IBM15/SURFACE/00052050.dat
+28	./IBM15/SURFACE/00023450.dat
+28	./IBM15/SURFACE/00019450.dat
+28	./IBM15/SURFACE/00016650.dat
+28	./IBM15/SURFACE/00048950.dat
+28	./IBM15/SURFACE/00002900.dat
+28	./IBM15/SURFACE/00052000.dat
+28	./IBM15/SURFACE/00035850.dat
+28	./IBM15/SURFACE/00058450.dat
+28	./IBM15/SURFACE/00045200.dat
+28	./IBM15/SURFACE/00058750.dat
+28	./IBM15/SURFACE/00024000.dat
+28	./IBM15/SURFACE/00018100.dat
+28	./IBM15/SURFACE/00047450.dat
+28	./IBM15/SURFACE/00054400.dat
+28	./IBM15/SURFACE/00045950.dat
+28	./IBM15/SURFACE/00005850.dat
+28	./IBM15/SURFACE/00057650.dat
+28	./IBM15/SURFACE/00009750.dat
+28	./IBM15/SURFACE/00039300.dat
+28	./IBM15/SURFACE/00031950.dat
+28	./IBM15/SURFACE/00057000.dat
+28	./IBM15/SURFACE/00035650.dat
+28	./IBM15/SURFACE/00047750.dat
+28	./IBM15/SURFACE/00002800.dat
+28	./IBM15/SURFACE/00044600.dat
+28	./IBM15/SURFACE/00014450.dat
+28	./IBM15/SURFACE/00012250.dat
+28	./IBM15/SURFACE/00050850.dat
+28	./IBM15/SURFACE/00017000.dat
+28	./IBM15/SURFACE/00001700.dat
+28	./IBM15/SURFACE/00029300.dat
+28	./IBM15/SURFACE/00038550.dat
+28	./IBM15/SURFACE/00057700.dat
+28	./IBM15/SURFACE/00044700.dat
+28	./IBM15/SURFACE/00006400.dat
+28	./IBM15/SURFACE/00015050.dat
+28	./IBM15/SURFACE/00029850.dat
+28	./IBM15/SURFACE/00029400.dat
+28	./IBM15/SURFACE/00046000.dat
+28	./IBM15/SURFACE/00016300.dat
+28	./IBM15/SURFACE/00006550.dat
+28	./IBM15/SURFACE/00003950.dat
+28	./IBM15/SURFACE/00002200.dat
+28	./IBM15/SURFACE/00021350.dat
+28	./IBM15/SURFACE/00036450.dat
+28	./IBM15/SURFACE/00039500.dat
+28	./IBM15/SURFACE/00045850.dat
+28	./IBM15/SURFACE/00027800.dat
+28	./IBM15/SURFACE/00032100.dat
+28	./IBM15/SURFACE/00051050.dat
+28	./IBM15/SURFACE/00060150.dat
+28	./IBM15/SURFACE/00019700.dat
+28	./IBM15/SURFACE/00010450.dat
+28	./IBM15/SURFACE/00011150.dat
+28	./IBM15/SURFACE/00015350.dat
+28	./IBM15/SURFACE/00032150.dat
+28	./IBM15/SURFACE/00004750.dat
+28	./IBM15/SURFACE/00000850.dat
+28	./IBM15/SURFACE/00048800.dat
+28	./IBM15/SURFACE/00048350.dat
+28	./IBM15/SURFACE/00023550.dat
+28	./IBM15/SURFACE/00053500.dat
+28	./IBM15/SURFACE/00054000.dat
+28	./IBM15/SURFACE/00034100.dat
+28	./IBM15/SURFACE/00020600.dat
+28	./IBM15/SURFACE/00043000.dat
+28	./IBM15/SURFACE/00022050.dat
+28	./IBM15/SURFACE/00037050.dat
+28	./IBM15/SURFACE/00004350.dat
+28	./IBM15/SURFACE/00047500.dat
+28	./IBM15/SURFACE/00044500.dat
+28	./IBM15/SURFACE/00007500.dat
+28	./IBM15/SURFACE/00052500.dat
+28	./IBM15/SURFACE/00035250.dat
+28	./IBM15/SURFACE/00033700.dat
+28	./IBM15/SURFACE/00046700.dat
+28	./IBM15/SURFACE/00013300.dat
+28	./IBM15/SURFACE/00050900.dat
+28	./IBM15/SURFACE/00002000.dat
+28	./IBM15/SURFACE/00059100.dat
+28	./IBM15/SURFACE/00023900.dat
+28	./IBM15/SURFACE/00013350.dat
+28	./IBM15/SURFACE/00050450.dat
+28	./IBM15/SURFACE/00034850.dat
+28	./IBM15/SURFACE/00037750.dat
+28	./IBM15/SURFACE/00016450.dat
+28	./IBM15/SURFACE/00031750.dat
+28	./IBM15/SURFACE/00039250.dat
+28	./IBM15/SURFACE/00007700.dat
+28	./IBM15/SURFACE/00023800.dat
+28	./IBM15/SURFACE/00011700.dat
+28	./IBM15/SURFACE/00024500.dat
+28	./IBM15/SURFACE/00054600.dat
+28	./IBM15/SURFACE/00034150.dat
+28	./IBM15/SURFACE/00018050.dat
+28	./IBM15/SURFACE/00002350.dat
+28	./IBM15/SURFACE/00024700.dat
+28	./IBM15/SURFACE/00025150.dat
+28	./IBM15/SURFACE/00053050.dat
+28	./IBM15/SURFACE/00017650.dat
+28	./IBM15/SURFACE/00017800.dat
+28	./IBM15/SURFACE/00040200.dat
+28	./IBM15/SURFACE/00049900.dat
+28	./IBM15/SURFACE/00027200.dat
+28	./IBM15/SURFACE/00004100.dat
+28	./IBM15/SURFACE/00040950.dat
+28	./IBM15/SURFACE/00059900.dat
+28	./IBM15/SURFACE/00038200.dat
+28	./IBM15/SURFACE/00036100.dat
+28	./IBM15/SURFACE/00029950.dat
+28	./IBM15/SURFACE/00006300.dat
+28	./IBM15/SURFACE/00014100.dat
+28	./IBM15/SURFACE/00017950.dat
+28	./IBM15/SURFACE/00002550.dat
+28	./IBM15/SURFACE/00015300.dat
+28	./IBM15/SURFACE/00001100.dat
+28	./IBM15/SURFACE/00045600.dat
+28	./IBM15/SURFACE/00016100.dat
+28	./IBM15/SURFACE/00025900.dat
+28	./IBM15/SURFACE/00005750.dat
+28	./IBM15/SURFACE/00054550.dat
+28	./IBM15/SURFACE/00036300.dat
+28	./IBM15/SURFACE/00021950.dat
+28	./IBM15/SURFACE/00048900.dat
+28	./IBM15/SURFACE/00022450.dat
+28	./IBM15/SURFACE/00002500.dat
+28	./IBM15/SURFACE/00037850.dat
+28	./IBM15/SURFACE/00035600.dat
+28	./IBM15/SURFACE/00023000.dat
+28	./IBM15/SURFACE/00051600.dat
+28	./IBM15/SURFACE/00008800.dat
+28	./IBM15/SURFACE/00023950.dat
+28	./IBM15/SURFACE/00045750.dat
+28	./IBM15/SURFACE/00037700.dat
+28	./IBM15/SURFACE/00028800.dat
+28	./IBM15/SURFACE/00015150.dat
+28	./IBM15/SURFACE/00011650.dat
+28	./IBM15/SURFACE/00043150.dat
+28	./IBM15/SURFACE/00059750.dat
+28	./IBM15/SURFACE/00055950.dat
+28	./IBM15/SURFACE/00030000.dat
+28	./IBM15/SURFACE/00003700.dat
+28	./IBM15/SURFACE/00031450.dat
+28	./IBM15/SURFACE/00037900.dat
+28	./IBM15/SURFACE/00053850.dat
+28	./IBM15/SURFACE/00039550.dat
+28	./IBM15/SURFACE/00031400.dat
+28	./IBM15/SURFACE/00045150.dat
+28	./IBM15/SURFACE/00032350.dat
+28	./IBM15/SURFACE/00005400.dat
+28	./IBM15/SURFACE/00008750.dat
+28	./IBM15/SURFACE/00043650.dat
+28	./IBM15/SURFACE/00021050.dat
+28	./IBM15/SURFACE/00054750.dat
+28	./IBM15/SURFACE/00011950.dat
+28	./IBM15/SURFACE/00017550.dat
+28	./IBM15/SURFACE/00011550.dat
+28	./IBM15/SURFACE/00022850.dat
+28	./IBM15/SURFACE/00005500.dat
+28	./IBM15/SURFACE/00009950.dat
+28	./IBM15/SURFACE/00024450.dat
+28	./IBM15/SURFACE/00055300.dat
+24	./IBM15/SURFACE/00060200.dat
+28	./IBM15/SURFACE/00009150.dat
+28	./IBM15/SURFACE/00007000.dat
+28	./IBM15/SURFACE/00044750.dat
+28	./IBM15/SURFACE/00024950.dat
+28	./IBM15/SURFACE/00034250.dat
+28	./IBM15/SURFACE/00048250.dat
+28	./IBM15/SURFACE/00028950.dat
+28	./IBM15/SURFACE/00013100.dat
+28	./IBM15/SURFACE/00051650.dat
+28	./IBM15/SURFACE/00031700.dat
+28	./IBM15/SURFACE/00017300.dat
+28	./IBM15/SURFACE/00039750.dat
+28	./IBM15/SURFACE/00015250.dat
+28	./IBM15/SURFACE/00059450.dat
+28	./IBM15/SURFACE/00003150.dat
+28	./IBM15/SURFACE/00010150.dat
+28	./IBM15/SURFACE/00049650.dat
+28	./IBM15/SURFACE/00017050.dat
+28	./IBM15/SURFACE/00021550.dat
+28	./IBM15/SURFACE/00041000.dat
+28	./IBM15/SURFACE/00053750.dat
+28	./IBM15/SURFACE/00029750.dat
+28	./IBM15/SURFACE/00059300.dat
+28	./IBM15/SURFACE/00004700.dat
+28	./IBM15/SURFACE/00028200.dat
+28	./IBM15/SURFACE/00016800.dat
+28	./IBM15/SURFACE/00032550.dat
+28	./IBM15/SURFACE/00000400.dat
+28	./IBM15/SURFACE/00058200.dat
+28	./IBM15/SURFACE/00017350.dat
+28	./IBM15/SURFACE/00035700.dat
+28	./IBM15/SURFACE/00038300.dat
+28	./IBM15/SURFACE/00006450.dat
+28	./IBM15/SURFACE/00048700.dat
+28	./IBM15/SURFACE/00004650.dat
+28	./IBM15/SURFACE/00048400.dat
+28	./IBM15/SURFACE/00048600.dat
+28	./IBM15/SURFACE/00017850.dat
+28	./IBM15/SURFACE/00029100.dat
+28	./IBM15/SURFACE/00007750.dat
+28	./IBM15/SURFACE/00055700.dat
+28	./IBM15/SURFACE/00056350.dat
+28	./IBM15/SURFACE/00006350.dat
+28	./IBM15/SURFACE/00020050.dat
+28	./IBM15/SURFACE/00009200.dat
+28	./IBM15/SURFACE/00058350.dat
+28	./IBM15/SURFACE/00058150.dat
+28	./IBM15/SURFACE/00031050.dat
+28	./IBM15/SURFACE/00030300.dat
+28	./IBM15/SURFACE/00004900.dat
+28	./IBM15/SURFACE/00059000.dat
+28	./IBM15/SURFACE/00022950.dat
+28	./IBM15/SURFACE/00012750.dat
+28	./IBM15/SURFACE/00059050.dat
+28	./IBM15/SURFACE/00046750.dat
+28	./IBM15/SURFACE/00000150.dat
+28	./IBM15/SURFACE/00025350.dat
+28	./IBM15/SURFACE/00026500.dat
+28	./IBM15/SURFACE/00008000.dat
+28	./IBM15/SURFACE/00053450.dat
+28	./IBM15/SURFACE/00010500.dat
+28	./IBM15/SURFACE/00034000.dat
+28	./IBM15/SURFACE/00021450.dat
+28	./IBM15/SURFACE/00037200.dat
+28	./IBM15/SURFACE/00020900.dat
+28	./IBM15/SURFACE/00020700.dat
+28	./IBM15/SURFACE/00007100.dat
+28	./IBM15/SURFACE/00009700.dat
+28	./IBM15/SURFACE/00048650.dat
+28	./IBM15/SURFACE/00047300.dat
+28	./IBM15/SURFACE/00038000.dat
+28	./IBM15/SURFACE/00055250.dat
+28	./IBM15/SURFACE/00021650.dat
+28	./IBM15/SURFACE/00004250.dat
+28	./IBM15/SURFACE/00015800.dat
+28	./IBM15/SURFACE/00059950.dat
+28	./IBM15/SURFACE/00049100.dat
+28	./IBM15/SURFACE/00001550.dat
+28	./IBM15/SURFACE/00052250.dat
+28	./IBM15/SURFACE/00019800.dat
+28	./IBM15/SURFACE/00051400.dat
+28	./IBM15/SURFACE/00010550.dat
+28	./IBM15/SURFACE/00021750.dat
+28	./IBM15/SURFACE/00025550.dat
+28	./IBM15/SURFACE/00028300.dat
+28	./IBM15/SURFACE/00013500.dat
+28	./IBM15/SURFACE/00025100.dat
+28	./IBM15/SURFACE/00005200.dat
+28	./IBM15/SURFACE/00027550.dat
+28	./IBM15/SURFACE/00012450.dat
+28	./IBM15/SURFACE/00014800.dat
+28	./IBM15/SURFACE/00011350.dat
+28	./IBM15/SURFACE/00059850.dat
+28	./IBM15/SURFACE/00055900.dat
+28	./IBM15/SURFACE/00035150.dat
+28	./IBM15/SURFACE/00002300.dat
+28	./IBM15/SURFACE/00052850.dat
+28	./IBM15/SURFACE/00041850.dat
+28	./IBM15/SURFACE/00014000.dat
+28	./IBM15/SURFACE/00007250.dat
+28	./IBM15/SURFACE/00029900.dat
+28	./IBM15/SURFACE/00058950.dat
+28	./IBM15/SURFACE/00053650.dat
+28	./IBM15/SURFACE/00002650.dat
+28	./IBM15/SURFACE/00049750.dat
+28	./IBM15/SURFACE/00058400.dat
+28	./IBM15/SURFACE/00006600.dat
+28	./IBM15/SURFACE/00019850.dat
+28	./IBM15/SURFACE/00011400.dat
+28	./IBM15/SURFACE/00029150.dat
+28	./IBM15/SURFACE/00013650.dat
+28	./IBM15/SURFACE/00030200.dat
+28	./IBM15/SURFACE/00052150.dat
+28	./IBM15/SURFACE/00006950.dat
+28	./IBM15/SURFACE/00060050.dat
+28	./IBM15/SURFACE/00018900.dat
+28	./IBM15/SURFACE/00033750.dat
+28	./IBM15/SURFACE/00006000.dat
+28	./IBM15/SURFACE/00024150.dat
+28	./IBM15/SURFACE/00012050.dat
+28	./IBM15/SURFACE/00057750.dat
+28	./IBM15/SURFACE/00029050.dat
+28	./IBM15/SURFACE/00006750.dat
+28	./IBM15/SURFACE/00003850.dat
+28	./IBM15/SURFACE/00008150.dat
+28	./IBM15/SURFACE/00001050.dat
+28	./IBM15/SURFACE/00033550.dat
+28	./IBM15/SURFACE/00036000.dat
+28	./IBM15/SURFACE/00029650.dat
+28	./IBM15/SURFACE/00020450.dat
+28	./IBM15/SURFACE/00036950.dat
+28	./IBM15/SURFACE/00035900.dat
+28	./IBM15/SURFACE/00053600.dat
+28	./IBM15/SURFACE/00018600.dat
+28	./IBM15/SURFACE/00026800.dat
+28	./IBM15/SURFACE/00055650.dat
+28	./IBM15/SURFACE/00030650.dat
+28	./IBM15/SURFACE/00007600.dat
+28	./IBM15/SURFACE/00036500.dat
+28	./IBM15/SURFACE/00038650.dat
+28	./IBM15/SURFACE/00000600.dat
+28	./IBM15/SURFACE/00054900.dat
+28	./IBM15/SURFACE/00020000.dat
+28	./IBM15/SURFACE/00042150.dat
+28	./IBM15/SURFACE/00024600.dat
+28	./IBM15/SURFACE/00031600.dat
+28	./IBM15/SURFACE/00019600.dat
+28	./IBM15/SURFACE/00013700.dat
+28	./IBM15/SURFACE/00041200.dat
+28	./IBM15/SURFACE/00052100.dat
+28	./IBM15/SURFACE/00000700.dat
+28	./IBM15/SURFACE/00049300.dat
+28	./IBM15/SURFACE/00040000.dat
+28	./IBM15/SURFACE/00007350.dat
+28	./IBM15/SURFACE/00003600.dat
+28	./IBM15/SURFACE/00000450.dat
+28	./IBM15/SURFACE/00017450.dat
+28	./IBM15/SURFACE/00022100.dat
+28	./IBM15/SURFACE/00028250.dat
+28	./IBM15/SURFACE/00023700.dat
+28	./IBM15/SURFACE/00001000.dat
+28	./IBM15/SURFACE/00009900.dat
+28	./IBM15/SURFACE/00045400.dat
+28	./IBM15/SURFACE/00035400.dat
+28	./IBM15/SURFACE/00000350.dat
+28	./IBM15/SURFACE/00010650.dat
+28	./IBM15/SURFACE/00019500.dat
+28	./IBM15/SURFACE/00025000.dat
+28	./IBM15/SURFACE/00028600.dat
+28	./IBM15/SURFACE/00017100.dat
+28	./IBM15/SURFACE/00019400.dat
+28	./IBM15/SURFACE/00027100.dat
+28	./IBM15/SURFACE/00033200.dat
+28	./IBM15/SURFACE/00001600.dat
+28	./IBM15/SURFACE/00047650.dat
+28	./IBM15/SURFACE/00032300.dat
+28	./IBM15/SURFACE/00057800.dat
+28	./IBM15/SURFACE/00005550.dat
+28	./IBM15/SURFACE/00018150.dat
+28	./IBM15/SURFACE/00017600.dat
+28	./IBM15/SURFACE/00021900.dat
+28	./IBM15/SURFACE/00021300.dat
+28	./IBM15/SURFACE/00034650.dat
+28	./IBM15/SURFACE/00027450.dat
+28	./IBM15/SURFACE/00056150.dat
+28	./IBM15/SURFACE/00029800.dat
+28	./IBM15/SURFACE/00021200.dat
+28	./IBM15/SURFACE/00000050.dat
+28	./IBM15/SURFACE/00059250.dat
+28	./IBM15/SURFACE/00032850.dat
+28	./IBM15/SURFACE/00038950.dat
+28	./IBM15/SURFACE/00002250.dat
+28	./IBM15/SURFACE/00005050.dat
+28	./IBM15/SURFACE/00022500.dat
+28	./IBM15/SURFACE/00020950.dat
+28	./IBM15/SURFACE/00008950.dat
+28	./IBM15/SURFACE/00038350.dat
+28	./IBM15/SURFACE/00000650.dat
+28	./IBM15/SURFACE/00028050.dat
+28	./IBM15/SURFACE/00050700.dat
+28	./IBM15/SURFACE/00022350.dat
+28	./IBM15/SURFACE/00039450.dat
+28	./IBM15/SURFACE/00050350.dat
+28	./IBM15/SURFACE/00003750.dat
+28	./IBM15/SURFACE/00020350.dat
+28	./IBM15/SURFACE/00026700.dat
+28	./IBM15/SURFACE/00046550.dat
+28	./IBM15/SURFACE/00036200.dat
+28	./IBM15/SURFACE/00022700.dat
+28	./IBM15/SURFACE/00059200.dat
+28	./IBM15/SURFACE/00043400.dat
+28	./IBM15/SURFACE/00052650.dat
+28	./IBM15/SURFACE/00024200.dat
+28	./IBM15/SURFACE/00051450.dat
+28	./IBM15/SURFACE/00030900.dat
+28	./IBM15/SURFACE/00056950.dat
+28	./IBM15/SURFACE/00035050.dat
+28	./IBM15/SURFACE/00053400.dat
+28	./IBM15/SURFACE/00043450.dat
+28	./IBM15/SURFACE/00006700.dat
+24	./IBM15/SURFACE/00044000.dat
+28	./IBM15/SURFACE/00027600.dat
+28	./IBM15/SURFACE/00004050.dat
+28	./IBM15/SURFACE/00058300.dat
+28	./IBM15/SURFACE/00008350.dat
+28	./IBM15/SURFACE/00054650.dat
+28	./IBM15/SURFACE/00039700.dat
+28	./IBM15/SURFACE/00040150.dat
+28	./IBM15/SURFACE/00032800.dat
+28	./IBM15/SURFACE/00011800.dat
+28	./IBM15/SURFACE/00010050.dat
+28	./IBM15/SURFACE/00020750.dat
+28	./IBM15/SURFACE/00057250.dat
+28	./IBM15/SURFACE/00035000.dat
+28	./IBM15/SURFACE/00027750.dat
+28	./IBM15/SURFACE/00002750.dat
+28	./IBM15/SURFACE/00019200.dat
+28	./IBM15/SURFACE/00019100.dat
+28	./IBM15/SURFACE/00015850.dat
+28	./IBM15/SURFACE/00044950.dat
+28	./IBM15/SURFACE/00002150.dat
+28	./IBM15/SURFACE/00016550.dat
+28	./IBM15/SURFACE/00034500.dat
+28	./IBM15/SURFACE/00025750.dat
+28	./IBM15/SURFACE/00050600.dat
+28	./IBM15/SURFACE/00042000.dat
+28	./IBM15/SURFACE/00025850.dat
+28	./IBM15/SURFACE/00042900.dat
+28	./IBM15/SURFACE/00021500.dat
+28	./IBM15/SURFACE/00011000.dat
+28	./IBM15/SURFACE/00025400.dat
+28	./IBM15/SURFACE/00032600.dat
+28	./IBM15/SURFACE/00015750.dat
+28	./IBM15/SURFACE/00042250.dat
+28	./IBM15/SURFACE/00049800.dat
+28	./IBM15/SURFACE/00002600.dat
+28	./IBM15/SURFACE/00020850.dat
+28	./IBM15/SURFACE/00056600.dat
+28	./IBM15/SURFACE/00029500.dat
+28	./IBM15/SURFACE/00021700.dat
+28	./IBM15/SURFACE/00035750.dat
+28	./IBM15/SURFACE/00041900.dat
+28	./IBM15/SURFACE/00018750.dat
+28	./IBM15/SURFACE/00056700.dat
+28	./IBM15/SURFACE/00044150.dat
+28	./IBM15/SURFACE/00007150.dat
+28	./IBM15/SURFACE/00022200.dat
+28	./IBM15/SURFACE/00036850.dat
+28	./IBM15/SURFACE/00012100.dat
+28	./IBM15/SURFACE/00032500.dat
+28	./IBM15/SURFACE/00000550.dat
+28	./IBM15/SURFACE/00044050.dat
+28	./IBM15/SURFACE/00036400.dat
+28	./IBM15/SURFACE/00055600.dat
+28	./IBM15/SURFACE/00028650.dat
+28	./IBM15/SURFACE/00019000.dat
+28	./IBM15/SURFACE/00037550.dat
+28	./IBM15/SURFACE/00025650.dat
+28	./IBM15/SURFACE/00016600.dat
+28	./IBM15/SURFACE/00022650.dat
+28	./IBM15/SURFACE/00043750.dat
+28	./IBM15/SURFACE/00017150.dat
+28	./IBM15/SURFACE/00032700.dat
+28	./IBM15/SURFACE/00016850.dat
+28	./IBM15/SURFACE/00052900.dat
+28	./IBM15/SURFACE/00025800.dat
+28	./IBM15/SURFACE/00033000.dat
+28	./IBM15/SURFACE/00055400.dat
+28	./IBM15/SURFACE/00031250.dat
+28	./IBM15/SURFACE/00031200.dat
+28	./IBM15/SURFACE/00021250.dat
+28	./IBM15/SURFACE/00009300.dat
+28	./IBM15/SURFACE/00048150.dat
+28	./IBM15/SURFACE/00044200.dat
+28	./IBM15/SURFACE/00010200.dat
+28	./IBM15/SURFACE/00050750.dat
+28	./IBM15/SURFACE/00027050.dat
+28	./IBM15/SURFACE/00036600.dat
+28	./IBM15/SURFACE/00020200.dat
+28	./IBM15/SURFACE/00059550.dat
+28	./IBM15/SURFACE/00035350.dat
+28	./IBM15/SURFACE/00017500.dat
+28	./IBM15/SURFACE/00040500.dat
+28	./IBM15/SURFACE/00038250.dat
+28	./IBM15/SURFACE/00039050.dat
+28	./IBM15/SURFACE/00030100.dat
+28	./IBM15/SURFACE/00023400.dat
+28	./IBM15/SURFACE/00022600.dat
+28	./IBM15/SURFACE/00018700.dat
+28	./IBM15/SURFACE/00014650.dat
+28	./IBM15/SURFACE/00047400.dat
+28	./IBM15/SURFACE/00033450.dat
+28	./IBM15/SURFACE/00019650.dat
+28	./IBM15/SURFACE/00027950.dat
+28	./IBM15/SURFACE/00029550.dat
+28	./IBM15/SURFACE/00056800.dat
+28	./IBM15/SURFACE/00013450.dat
+28	./IBM15/SURFACE/00019900.dat
+28	./IBM15/SURFACE/00026100.dat
+28	./IBM15/SURFACE/00026600.dat
+28	./IBM15/SURFACE/00007850.dat
+28	./IBM15/SURFACE/00050250.dat
+28	./IBM15/SURFACE/00003350.dat
+28	./IBM15/SURFACE/00001350.dat
+28	./IBM15/SURFACE/00036700.dat
+28	./IBM15/SURFACE/00049250.dat
+28	./IBM15/SURFACE/00016900.dat
+28	./IBM15/SURFACE/00046400.dat
+28	./IBM15/SURFACE/00039000.dat
+28	./IBM15/SURFACE/00039150.dat
+28	./IBM15/SURFACE/00027300.dat
+28	./IBM15/SURFACE/00025050.dat
+28	./IBM15/SURFACE/00038700.dat
+28	./IBM15/SURFACE/00019250.dat
+28	./IBM15/SURFACE/00009550.dat
+28	./IBM15/SURFACE/00015550.dat
+28	./IBM15/SURFACE/00009600.dat
+28	./IBM15/SURFACE/00056500.dat
+28	./IBM15/SURFACE/00046250.dat
+28	./IBM15/SURFACE/00049050.dat
+28	./IBM15/SURFACE/00031150.dat
+28	./IBM15/SURFACE/00036800.dat
+28	./IBM15/SURFACE/00045100.dat
+28	./IBM15/SURFACE/00006800.dat
+28	./IBM15/SURFACE/00058900.dat
+28	./IBM15/SURFACE/00032250.dat
+28	./IBM15/SURFACE/00020250.dat
+28	./IBM15/SURFACE/00024750.dat
+28	./IBM15/SURFACE/00014150.dat
+28	./IBM15/SURFACE/00046650.dat
+28	./IBM15/SURFACE/00001150.dat
+28	./IBM15/SURFACE/00038400.dat
+28	./IBM15/SURFACE/00041400.dat
+28	./IBM15/SURFACE/00045350.dat
+28	./IBM15/SURFACE/00027400.dat
+28	./IBM15/SURFACE/00014900.dat
+28	./IBM15/SURFACE/00032000.dat
+28	./IBM15/SURFACE/00026400.dat
+28	./IBM15/SURFACE/00022800.dat
+28	./IBM15/SURFACE/00012000.dat
+28	./IBM15/SURFACE/00058550.dat
+28	./IBM15/SURFACE/00040350.dat
+28	./IBM15/SURFACE/00006500.dat
+28	./IBM15/SURFACE/00054200.dat
+28	./IBM15/SURFACE/00026950.dat
+28	./IBM15/SURFACE/00042350.dat
+28	./IBM15/SURFACE/00030750.dat
+28	./IBM15/SURFACE/00056650.dat
+28	./IBM15/SURFACE/00020500.dat
+28	./IBM15/SURFACE/00026350.dat
+28	./IBM15/SURFACE/00031300.dat
+28	./IBM15/SURFACE/00031650.dat
+28	./IBM15/SURFACE/00053150.dat
+28	./IBM15/SURFACE/00045000.dat
+28	./IBM15/SURFACE/00055200.dat
+28	./IBM15/SURFACE/00050950.dat
+28	./IBM15/SURFACE/00015400.dat
+28	./IBM15/SURFACE/00050200.dat
+28	./IBM15/SURFACE/00053900.dat
+28	./IBM15/SURFACE/00015500.dat
+28	./IBM15/SURFACE/00059500.dat
+28	./IBM15/SURFACE/00015900.dat
+28	./IBM15/SURFACE/00047350.dat
+28	./IBM15/SURFACE/00030350.dat
+28	./IBM15/SURFACE/00040550.dat
+28	./IBM15/SURFACE/00027850.dat
+28	./IBM15/SURFACE/00007400.dat
+28	./IBM15/SURFACE/00043350.dat
+28	./IBM15/SURFACE/00037800.dat
+28	./IBM15/SURFACE/00054050.dat
+28	./IBM15/SURFACE/00008900.dat
+28	./IBM15/SURFACE/00021850.dat
+28	./IBM15/SURFACE/00033100.dat
+28	./IBM15/SURFACE/00047950.dat
+28	./IBM15/SURFACE/00016400.dat
+28	./IBM15/SURFACE/00043100.dat
+28	./IBM15/SURFACE/00035800.dat
+28	./IBM15/SURFACE/00045550.dat
+28	./IBM15/SURFACE/00009500.dat
+28	./IBM15/SURFACE/00014500.dat
+28	./IBM15/SURFACE/00045450.dat
+28	./IBM15/SURFACE/00008600.dat
+28	./IBM15/SURFACE/00015950.dat
+28	./IBM15/SURFACE/00010750.dat
+28	./IBM15/SURFACE/00046150.dat
+28	./IBM15/SURFACE/00051300.dat
+28	./IBM15/SURFACE/00026850.dat
+28	./IBM15/SURFACE/00008550.dat
+28	./IBM15/SURFACE/00027350.dat
+28	./IBM15/SURFACE/00018650.dat
+28	./IBM15/SURFACE/00022250.dat
+28	./IBM15/SURFACE/00006650.dat
+28	./IBM15/SURFACE/00042500.dat
+28	./IBM15/SURFACE/00040700.dat
+28	./IBM15/SURFACE/00013000.dat
+28	./IBM15/SURFACE/00059350.dat
+28	./IBM15/SURFACE/00054350.dat
+28	./IBM15/SURFACE/00057200.dat
+28	./IBM15/SURFACE/00003050.dat
+28	./IBM15/SURFACE/00014700.dat
+28	./IBM15/SURFACE/00059400.dat
+28	./IBM15/SURFACE/00033500.dat
+28	./IBM15/SURFACE/00001750.dat
+28	./IBM15/SURFACE/00037950.dat
+28	./IBM15/SURFACE/00006900.dat
+28	./IBM15/SURFACE/00031000.dat
+28	./IBM15/SURFACE/00038050.dat
+28	./IBM15/SURFACE/00039900.dat
+28	./IBM15/SURFACE/00042700.dat
+28	./IBM15/SURFACE/00032400.dat
+28	./IBM15/SURFACE/00052200.dat
+28	./IBM15/SURFACE/00027250.dat
+28	./IBM15/SURFACE/00026550.dat
+28	./IBM15/SURFACE/00041650.dat
+28	./IBM15/SURFACE/00001250.dat
+28	./IBM15/SURFACE/00023650.dat
+28	./IBM15/SURFACE/00022400.dat
+28	./IBM15/SURFACE/00014750.dat
+28	./IBM15/SURFACE/00030800.dat
+28	./IBM15/SURFACE/00037650.dat
+28	./IBM15/SURFACE/00032200.dat
+28	./IBM15/SURFACE/00034800.dat
+28	./IBM15/SURFACE/00044850.dat
+28	./IBM15/SURFACE/00038850.dat
+28	./IBM15/SURFACE/00024650.dat
+28	./IBM15/SURFACE/00024250.dat
+28	./IBM15/SURFACE/00010350.dat
+28	./IBM15/SURFACE/00054300.dat
+28	./IBM15/SURFACE/00028500.dat
+28	./IBM15/SURFACE/00018300.dat
+28	./IBM15/SURFACE/00005600.dat
+28	./IBM15/SURFACE/00039850.dat
+28	./IBM15/SURFACE/00056050.dat
+28	./IBM15/SURFACE/00042400.dat
+28	./IBM15/SURFACE/00004200.dat
+28	./IBM15/SURFACE/00035950.dat
+28	./IBM15/SURFACE/00048850.dat
+28	./IBM15/SURFACE/00015100.dat
+28	./IBM15/SURFACE/00001800.dat
+28	./IBM15/SURFACE/00017900.dat
+28	./IBM15/SURFACE/00018350.dat
+28	./IBM15/SURFACE/00027650.dat
+28	./IBM15/SURFACE/00053800.dat
+28	./IBM15/SURFACE/00045900.dat
+28	./IBM15/SURFACE/00009350.dat
+28	./IBM15/SURFACE/00037000.dat
+28	./IBM15/SURFACE/00051800.dat
+28	./IBM15/SURFACE/00033350.dat
+28	./IBM15/SURFACE/00055850.dat
+28	./IBM15/SURFACE/00043900.dat
+28	./IBM15/SURFACE/00028350.dat
+28	./IBM15/SURFACE/00008250.dat
+28	./IBM15/SURFACE/00012150.dat
+28	./IBM15/SURFACE/00055800.dat
+28	./IBM15/SURFACE/00000250.dat
+28	./IBM15/SURFACE/00012500.dat
+28	./IBM15/SURFACE/00035200.dat
+28	./IBM15/SURFACE/00045800.dat
+28	./IBM15/SURFACE/00022750.dat
+28	./IBM15/SURFACE/00052600.dat
+28	./IBM15/SURFACE/00044800.dat
+28	./IBM15/SURFACE/00051350.dat
+28	./IBM15/SURFACE/00038150.dat
+28	./IBM15/SURFACE/00024850.dat
+28	./IBM15/SURFACE/00053250.dat
+28	./IBM15/SURFACE/00053100.dat
+28	./IBM15/SURFACE/00006050.dat
+28	./IBM15/SURFACE/00054800.dat
+28	./IBM15/SURFACE/00053700.dat
+28	./IBM15/SURFACE/00060000.dat
+28	./IBM15/SURFACE/00033650.dat
+28	./IBM15/SURFACE/00011850.dat
+28	./IBM15/SURFACE/00042200.dat
+28	./IBM15/SURFACE/00012950.dat
+28	./IBM15/SURFACE/00058850.dat
+28	./IBM15/SURFACE/00046600.dat
+28	./IBM15/SURFACE/00040100.dat
+28	./IBM15/SURFACE/00051250.dat
+28	./IBM15/SURFACE/00020100.dat
+28	./IBM15/SURFACE/00019350.dat
+28	./IBM15/SURFACE/00057900.dat
+28	./IBM15/SURFACE/00035550.dat
+28	./IBM15/SURFACE/00045650.dat
+28	./IBM15/SURFACE/00030600.dat
+28	./IBM15/SURFACE/00057050.dat
+28	./IBM15/SURFACE/00011450.dat
+28	./IBM15/SURFACE/00028150.dat
+28	./IBM15/SURFACE/00000950.dat
+28	./IBM15/SURFACE/00057500.dat
+28	./IBM15/SURFACE/00049700.dat
+28	./IBM15/SURFACE/00056550.dat
+28	./IBM15/SURFACE/00025600.dat
+28	./IBM15/SURFACE/00015600.dat
+28	./IBM15/SURFACE/00013050.dat
+28	./IBM15/SURFACE/00023350.dat
+28	./IBM15/SURFACE/00053300.dat
+28	./IBM15/SURFACE/00028000.dat
+28	./IBM15/SURFACE/00037150.dat
+28	./IBM15/SURFACE/00038600.dat
+28	./IBM15/SURFACE/00048300.dat
+28	./IBM15/SURFACE/00043600.dat
+28	./IBM15/SURFACE/00005950.dat
+28	./IBM15/SURFACE/00033300.dat
+28	./IBM15/SURFACE/00016950.dat
+28	./IBM15/SURFACE/00010850.dat
+28	./IBM15/SURFACE/00042100.dat
+28	./IBM15/SURFACE/00017250.dat
+28	./IBM15/SURFACE/00050650.dat
+28	./IBM15/SURFACE/00013850.dat
+28	./IBM15/SURFACE/00047850.dat
+28	./IBM15/SURFACE/00004600.dat
+28	./IBM15/SURFACE/00060100.dat
+28	./IBM15/SURFACE/00013750.dat
+28	./IBM15/SURFACE/00009800.dat
+28	./IBM15/SURFACE/00025500.dat
+28	./IBM15/SURFACE/00017700.dat
+28	./IBM15/SURFACE/00024100.dat
+28	./IBM15/SURFACE/00030150.dat
+28	./IBM15/SURFACE/00002100.dat
+28	./IBM15/SURFACE/00002050.dat
+28	./IBM15/SURFACE/00019550.dat
+28	./IBM15/SURFACE/00034950.dat
+28	./IBM15/SURFACE/00014200.dat
+28	./IBM15/SURFACE/00009050.dat
+28	./IBM15/SURFACE/00026300.dat
+28	./IBM15/SURFACE/00005350.dat
+28	./IBM15/SURFACE/00020550.dat
+28	./IBM15/SURFACE/00020400.dat
+28	./IBM15/SURFACE/00014400.dat
+28	./IBM15/SURFACE/00039350.dat
+28	./IBM15/SURFACE/00033600.dat
+28	./IBM15/SURFACE/00058000.dat
+28	./IBM15/SURFACE/00023600.dat
+28	./IBM15/SURFACE/00001450.dat
+28	./IBM15/SURFACE/00023500.dat
+28	./IBM15/SURFACE/00001200.dat
+28	./IBM15/SURFACE/00011050.dat
+28	./IBM15/SURFACE/00013200.dat
+28	./IBM15/SURFACE/00049500.dat
+28	./IBM15/SURFACE/00026450.dat
+28	./IBM15/SURFACE/00057550.dat
+28	./IBM15/SURFACE/00025450.dat
+28	./IBM15/SURFACE/00016200.dat
+28	./IBM15/SURFACE/00026650.dat
+28	./IBM15/SURFACE/00043550.dat
+28	./IBM15/SURFACE/00034550.dat
+28	./IBM15/SURFACE/00011250.dat
+28	./IBM15/SURFACE/00003400.dat
+28	./IBM15/SURFACE/00014550.dat
+28	./IBM15/SURFACE/00045050.dat
+28	./IBM15/SURFACE/00008700.dat
+28	./IBM15/SURFACE/00046350.dat
+28	./IBM15/SURFACE/00005250.dat
+28	./IBM15/SURFACE/00003650.dat
+28	./IBM15/SURFACE/00038800.dat
+28	./IBM15/SURFACE/00058050.dat
+28	./IBM15/SURFACE/00058100.dat
+28	./IBM15/SURFACE/00031100.dat
+28	./IBM15/SURFACE/00014600.dat
+28	./IBM15/SURFACE/00002400.dat
+28	./IBM15/SURFACE/00049400.dat
+28	./IBM15/SURFACE/00011200.dat
+28	./IBM15/SURFACE/00037250.dat
+28	./IBM15/SURFACE/00008050.dat
+28	./IBM15/SURFACE/00044350.dat
+28	./IBM15/SURFACE/00055350.dat
+28	./IBM15/SURFACE/00056900.dat
+28	./IBM15/SURFACE/00026150.dat
+28	./IBM15/SURFACE/00033250.dat
+28	./IBM15/SURFACE/00001850.dat
+28	./IBM15/SURFACE/00042950.dat
+28	./IBM15/SURFACE/00028450.dat
+28	./IBM15/SURFACE/00006200.dat
+28	./IBM15/SURFACE/00052700.dat
+28	./IBM15/SURFACE/00024800.dat
+28	./IBM15/SURFACE/00029700.dat
+28	./IBM15/SURFACE/00048200.dat
+28	./IBM15/SURFACE/00007900.dat
+28	./IBM15/SURFACE/00055450.dat
+28	./IBM15/SURFACE/00052950.dat
+28	./IBM15/SURFACE/00041100.dat
+28	./IBM15/SURFACE/00040400.dat
+28	./IBM15/SURFACE/00013950.dat
+28	./IBM15/SURFACE/00042600.dat
+28	./IBM15/SURFACE/00022550.dat
+28	./IBM15/SURFACE/00013900.dat
+28	./IBM15/SURFACE/00040050.dat
+28	./IBM15/SURFACE/00000300.dat
+28	./IBM15/SURFACE/00030950.dat
+28	./IBM15/SURFACE/00013800.dat
+28	./IBM15/SURFACE/00021600.dat
+28	./IBM15/SURFACE/00027900.dat
+28	./IBM15/SURFACE/00008400.dat
+28	./IBM15/SURFACE/00051150.dat
+28	./IBM15/SURFACE/00018250.dat
+28	./IBM15/SURFACE/00057950.dat
+28	./IBM15/SURFACE/00007650.dat
+28	./IBM15/SURFACE/00044250.dat
+28	./IBM15/SURFACE/00047200.dat
+28	./IBM15/SURFACE/00010100.dat
+28	./IBM15/SURFACE/00010300.dat
+28	./IBM15/SURFACE/00004400.dat
+28	./IBM15/SURFACE/00047600.dat
+28	./IBM15/SURFACE/00055750.dat
+28	./IBM15/SURFACE/00053350.dat
+28	./IBM15/SURFACE/00040900.dat
+28	./IBM15/SURFACE/00043500.dat
+28	./IBM15/SURFACE/00056100.dat
+28	./IBM15/SURFACE/00012900.dat
+28	./IBM15/SURFACE/00049600.dat
+28	./IBM15/SURFACE/00059600.dat
+28	./IBM15/SURFACE/00057400.dat
+28	./IBM15/SURFACE/00046200.dat
+28	./IBM15/SURFACE/00021100.dat
+28	./IBM15/SURFACE/00005800.dat
+28	./IBM15/SURFACE/00045250.dat
+28	./IBM15/SURFACE/00003200.dat
+28	./IBM15/SURFACE/00056850.dat
+28	./IBM15/SURFACE/00015450.dat
+28	./IBM15/SURFACE/00047550.dat
+28	./IBM15/SURFACE/00011900.dat
+28	./IBM15/SURFACE/00059700.dat
+28	./IBM15/SURFACE/00023750.dat
+28	./IBM15/SURFACE/00002450.dat
+28	./IBM15/SURFACE/00040450.dat
+28	./IBM15/SURFACE/00049950.dat
+28	./IBM15/SURFACE/00016150.dat
+28	./IBM15/SURFACE/00034050.dat
+28	./IBM15/SURFACE/00031800.dat
+28	./IBM15/SURFACE/00039600.dat
+28	./IBM15/SURFACE/00023050.dat
+28	./IBM15/SURFACE/00005150.dat
+28	./IBM15/SURFACE/00014950.dat
+28	./IBM15/SURFACE/00005100.dat
+28	./IBM15/SURFACE/00015000.dat
+28	./IBM15/SURFACE/00031900.dat
+28	./IBM15/SURFACE/00019050.dat
+28	./IBM15/SURFACE/00033150.dat
+28	./IBM15/SURFACE/00041350.dat
+28	./IBM15/SURFACE/00003000.dat
+28	./IBM15/SURFACE/00012700.dat
+28	./IBM15/SURFACE/00046100.dat
+28	./IBM15/SURFACE/00032450.dat
+28	./IBM15/SURFACE/00005450.dat
+28	./IBM15/SURFACE/00016700.dat
+28	./IBM15/SURFACE/00044550.dat
+28	./IBM15/SURFACE/00032750.dat
+28	./IBM15/SURFACE/00004800.dat
+28	./IBM15/SURFACE/00024550.dat
+28	./IBM15/SURFACE/00055150.dat
+28	./IBM15/SURFACE/00046800.dat
+28	./IBM15/SURFACE/00058250.dat
+28	./IBM15/SURFACE/00038900.dat
+28	./IBM15/SURFACE/00023100.dat
+28	./IBM15/SURFACE/00054150.dat
+28	./IBM15/SURFACE/00001300.dat
+28	./IBM15/SURFACE/00036150.dat
+28	./IBM15/SURFACE/00008300.dat
+28	./IBM15/SURFACE/00003500.dat
+28	./IBM15/SURFACE/00012550.dat
+28	./IBM15/SURFACE/00054500.dat
+28	./IBM15/SURFACE/00008850.dat
+28	./IBM15/SURFACE/00043800.dat
+28	./IBM15/SURFACE/00008500.dat
+28	./IBM15/SURFACE/00049850.dat
+28	./IBM15/SURFACE/00038100.dat
+28	./IBM15/SURFACE/00051100.dat
+28	./IBM15/SURFACE/00018850.dat
+28	./IBM15/SURFACE/00018450.dat
+28	./IBM15/SURFACE/00027150.dat
+28	./IBM15/SURFACE/00000500.dat
+28	./IBM15/SURFACE/00044450.dat
+28	./IBM15/SURFACE/00022900.dat
+28	./IBM15/SURFACE/00026750.dat
+28	./IBM15/SURFACE/00034450.dat
+28	./IBM15/SURFACE/00036250.dat
+28	./IBM15/SURFACE/00038750.dat
+28	./IBM15/SURFACE/00057450.dat
+28	./IBM15/SURFACE/00015650.dat
+28	./IBM15/SURFACE/00044650.dat
+28	./IBM15/SURFACE/00010000.dat
+28	./IBM15/SURFACE/00036550.dat
+28	./IBM15/SURFACE/00050400.dat
+28	./IBM15/SURFACE/00006150.dat
+28	./IBM15/SURFACE/00055100.dat
+28	./IBM15/SURFACE/00034300.dat
+28	./IBM15/SURFACE/00003550.dat
+28	./IBM15/SURFACE/00007550.dat
+28	./IBM15/SURFACE/00043850.dat
+28	./IBM15/SURFACE/00011500.dat
+28	./IBM15/SURFACE/00012200.dat
+28	./IBM15/SURFACE/00044100.dat
+28	./IBM15/SURFACE/00003900.dat
+28	./IBM15/SURFACE/00033800.dat
+28	./IBM15/SURFACE/00013550.dat
+28	./IBM15/SURFACE/00041250.dat
+28	./IBM15/SURFACE/00047700.dat
+28	./IBM15/SURFACE/00054100.dat
+28	./IBM15/SURFACE/00051950.dat
+28	./IBM15/SURFACE/00050150.dat
+28	./IBM15/SURFACE/00051850.dat
+28	./IBM15/SURFACE/00045300.dat
+28	./IBM15/SURFACE/00046850.dat
+28	./IBM15/SURFACE/00055050.dat
+28	./IBM15/SURFACE/00012400.dat
+28	./IBM15/SURFACE/00032050.dat
+28	./IBM15/SURFACE/00031500.dat
+28	./IBM15/SURFACE/00027500.dat
+28	./IBM15/SURFACE/00037500.dat
+28	./IBM15/SURFACE/00012850.dat
+28	./IBM15/SURFACE/00010600.dat
+28	./IBM15/SURFACE/00057350.dat
+28	./IBM15/SURFACE/00018200.dat
+28	./IBM15/SURFACE/00013250.dat
+28	./IBM15/SURFACE/00034900.dat
+28	./IBM15/SURFACE/00049350.dat
+28	./IBM15/SURFACE/00041450.dat
+28	./IBM15/SURFACE/00051750.dat
+28	./IBM15/SURFACE/00017200.dat
+28	./IBM15/SURFACE/00008200.dat
+28	./IBM15/SURFACE/00014350.dat
+28	./IBM15/SURFACE/00022150.dat
+28	./IBM15/SURFACE/00042800.dat
+28	./IBM15/SURFACE/00042750.dat
+28	./IBM15/SURFACE/00048450.dat
+28	./IBM15/SURFACE/00030250.dat
+28	./IBM15/SURFACE/00001950.dat
+28	./IBM15/SURFACE/00004850.dat
+28	./IBM15/SURFACE/00025300.dat
+28	./IBM15/SURFACE/00044400.dat
+28	./IBM15/SURFACE/00051700.dat
+28	./IBM15/SURFACE/00057300.dat
+28	./IBM15/SURFACE/00001400.dat
+28	./IBM15/SURFACE/00028400.dat
+28	./IBM15/SURFACE/00045700.dat
+28	./IBM15/SURFACE/00000800.dat
+28	./IBM15/SURFACE/00003800.dat
+28	./IBM15/SURFACE/00050000.dat
+28	./IBM15/SURFACE/00021150.dat
+28	./IBM15/SURFACE/00029600.dat
+28	./IBM15/SURFACE/00016000.dat
+28	./IBM15/SURFACE/00030700.dat
+28	./IBM15/SURFACE/00047250.dat
+33776	./IBM15/SURFACE
+4	./IBM15/prof_step
+4	./IBM15/Beforemaking
+4	./IBM15/MID/TIME.MID
+8	./IBM15/MID
+du: cannot access `./IBM15/PRIO_GENERATE_GRID/Makefile': Permission denied
+du: cannot access `./IBM15/PRIO_GENERATE_GRID/genegrid': Permission denied
+du: cannot access `./IBM15/PRIO_GENERATE_GRID/GENEGRID.F90': Permission denied
+4	./IBM15/PRIO_GENERATE_GRID
+215609968	./IBM15
+912	./IBM14/libtecio.a
+du: cannot access `./IBM14/INCLUDE/INCLUDE_FFT.FI': Permission denied
+du: cannot access `./IBM14/INCLUDE/INCLUDE_CINTERFACE.FI': Permission denied
+du: cannot access `./IBM14/INCLUDE/INCLUDE_LES.FI': Permission denied
+du: cannot access `./IBM14/INCLUDE/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM14/INCLUDE/INCLUDE_WAVEGENERATOR.FI': Permission denied
+du: cannot access `./IBM14/INCLUDE/INCLUDE_PARALLEL.FI': Permission denied
+du: cannot access `./IBM14/INCLUDE/INCLUDE_PETSC.FI': Permission denied
+du: cannot access `./IBM14/INCLUDE/INCLUDE_ASSIMILATION.FI': Permission denied
+du: cannot access `./IBM14/INCLUDE/INCLUDE_IBM.FI': Permission denied
+du: cannot access `./IBM14/INCLUDE/variables_new.h': Permission denied
+du: cannot access `./IBM14/INCLUDE/INCLUDE_PARAMETER.FI': Permission denied
+du: cannot access `./IBM14/INCLUDE/mpm_vars_new.h': Permission denied
+du: cannot access `./IBM14/INCLUDE/INCLUDE_SCALAR.FI': Permission denied
+du: cannot access `./IBM14/INCLUDE/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM14/INCLUDE/INCLUDE_STATS.FI': Permission denied
+du: cannot access `./IBM14/INCLUDE/INCLUDE_POISSON.FI': Permission denied
+4	./IBM14/INCLUDE
+4	./IBM14/vorcenterp.sh
+452	./IBM14/GEOMETRY/PSI.0074
+452	./IBM14/GEOMETRY/PSI.0012
+452	./IBM14/GEOMETRY/PSI.0026
+452	./IBM14/GEOMETRY/PSI.0048
+452	./IBM14/GEOMETRY/PSI.0054
+452	./IBM14/GEOMETRY/PSI.0084
+452	./IBM14/GEOMETRY/PSI.0019
+452	./IBM14/GEOMETRY/PSI.0066
+452	./IBM14/GEOMETRY/PSI.0015
+452	./IBM14/GEOMETRY/PSI.0094
+452	./IBM14/GEOMETRY/PSI.0088
+452	./IBM14/GEOMETRY/PSI.0032
+452	./IBM14/GEOMETRY/PSI.0081
+452	./IBM14/GEOMETRY/PSI.0005
+452	./IBM14/GEOMETRY/PSI.0007
+452	./IBM14/GEOMETRY/PSI.0050
+452	./IBM14/GEOMETRY/PSI.0098
+452	./IBM14/GEOMETRY/PSI.0021
+452	./IBM14/GEOMETRY/PSI.0079
+452	./IBM14/GEOMETRY/PSI.0043
+452	./IBM14/GEOMETRY/PSI.0104
+452	./IBM14/GEOMETRY/PSI.0060
+452	./IBM14/GEOMETRY/PSI.0061
+452	./IBM14/GEOMETRY/PSI.0095
+452	./IBM14/GEOMETRY/PSI.0082
+452	./IBM14/GEOMETRY/PSI.0080
+452	./IBM14/GEOMETRY/PSI.0087
+452	./IBM14/GEOMETRY/PSI.0027
+452	./IBM14/GEOMETRY/PSI.0023
+452	./IBM14/GEOMETRY/PSI.0003
+452	./IBM14/GEOMETRY/PSI.0014
+452	./IBM14/GEOMETRY/PSI.0062
+452	./IBM14/GEOMETRY/PSI.0086
+452	./IBM14/GEOMETRY/PSI.0008
+452	./IBM14/GEOMETRY/PSI.0058
+452	./IBM14/GEOMETRY/PSI.0034
+452	./IBM14/GEOMETRY/PSI.0120
+452	./IBM14/GEOMETRY/PSI.0089
+452	./IBM14/GEOMETRY/PSI.0118
+452	./IBM14/GEOMETRY/PSI.0044
+452	./IBM14/GEOMETRY/PSI.0125
+452	./IBM14/GEOMETRY/PSI.0036
+452	./IBM14/GEOMETRY/PSI.0052
+452	./IBM14/GEOMETRY/PSI.0031
+452	./IBM14/GEOMETRY/PSI.0076
+452	./IBM14/GEOMETRY/PSI.0037
+452	./IBM14/GEOMETRY/PSI.0024
+452	./IBM14/GEOMETRY/PSI.0100
+452	./IBM14/GEOMETRY/PSI.0030
+452	./IBM14/GEOMETRY/PSI.0069
+452	./IBM14/GEOMETRY/PSI.0075
+452	./IBM14/GEOMETRY/PSI.0068
+452	./IBM14/GEOMETRY/PSI.0002
+452	./IBM14/GEOMETRY/PSI.0000
+452	./IBM14/GEOMETRY/PSI.0020
+452	./IBM14/GEOMETRY/PSI.0010
+452	./IBM14/GEOMETRY/PSI.0110
+452	./IBM14/GEOMETRY/PSI.0124
+452	./IBM14/GEOMETRY/PSI.0051
+452	./IBM14/GEOMETRY/PSI.0121
+452	./IBM14/GEOMETRY/PSI.0116
+452	./IBM14/GEOMETRY/PSI.0053
+452	./IBM14/GEOMETRY/PSI.0073
+452	./IBM14/GEOMETRY/PSI.0018
+452	./IBM14/GEOMETRY/PSI.0106
+452	./IBM14/GEOMETRY/PSI.0004
+452	./IBM14/GEOMETRY/PSI.0035
+452	./IBM14/GEOMETRY/PSI.0083
+452	./IBM14/GEOMETRY/PSI.0013
+452	./IBM14/GEOMETRY/PSI.0022
+452	./IBM14/GEOMETRY/PSI.0101
+452	./IBM14/GEOMETRY/PSI.0122
+452	./IBM14/GEOMETRY/PSI.0016
+452	./IBM14/GEOMETRY/PSI.0119
+452	./IBM14/GEOMETRY/PSI.0067
+452	./IBM14/GEOMETRY/PSI.0072
+452	./IBM14/GEOMETRY/PSI.0112
+452	./IBM14/GEOMETRY/PSI.0039
+452	./IBM14/GEOMETRY/PSI.0017
+452	./IBM14/GEOMETRY/PSI.0097
+452	./IBM14/GEOMETRY/PSI.0107
+452	./IBM14/GEOMETRY/PSI.0108
+452	./IBM14/GEOMETRY/PSI.0123
+452	./IBM14/GEOMETRY/PSI.0063
+452	./IBM14/GEOMETRY/PSI.0102
+452	./IBM14/GEOMETRY/PSI.0047
+452	./IBM14/GEOMETRY/PSI.0045
+452	./IBM14/GEOMETRY/PSI.0070
+452	./IBM14/GEOMETRY/PSI.0038
+452	./IBM14/GEOMETRY/PSI.0127
+452	./IBM14/GEOMETRY/PSI.0056
+452	./IBM14/GEOMETRY/PSI.0078
+452	./IBM14/GEOMETRY/PSI.0126
+452	./IBM14/GEOMETRY/PSI.0046
+452	./IBM14/GEOMETRY/PSI.0064
+452	./IBM14/GEOMETRY/PSI.0096
+452	./IBM14/GEOMETRY/PSI.0077
+452	./IBM14/GEOMETRY/PSI.0025
+452	./IBM14/GEOMETRY/PSI.0040
+452	./IBM14/GEOMETRY/PSI.0011
+452	./IBM14/GEOMETRY/PSI.0041
+452	./IBM14/GEOMETRY/PSI.0109
+452	./IBM14/GEOMETRY/PSI.0090
+452	./IBM14/GEOMETRY/PSI.0042
+452	./IBM14/GEOMETRY/PSI.0105
+452	./IBM14/GEOMETRY/PSI.0009
+452	./IBM14/GEOMETRY/PSI.0028
+452	./IBM14/GEOMETRY/PSI.0114
+452	./IBM14/GEOMETRY/PSI.0006
+452	./IBM14/GEOMETRY/PSI.0033
+452	./IBM14/GEOMETRY/PSI.0055
+452	./IBM14/GEOMETRY/PSI.0071
+452	./IBM14/GEOMETRY/PSI.0113
+452	./IBM14/GEOMETRY/PSI.0049
+452	./IBM14/GEOMETRY/PSI.0103
+452	./IBM14/GEOMETRY/PSI.0001
+452	./IBM14/GEOMETRY/PSI.0099
+452	./IBM14/GEOMETRY/PSI.0065
+452	./IBM14/GEOMETRY/PSI.0111
+452	./IBM14/GEOMETRY/PSI.0059
+452	./IBM14/GEOMETRY/PSI.0085
+452	./IBM14/GEOMETRY/PSI.0029
+452	./IBM14/GEOMETRY/PSI.0057
+452	./IBM14/GEOMETRY/PSI.0115
+452	./IBM14/GEOMETRY/PSI.0117
+452	./IBM14/GEOMETRY/PSI.0091
+452	./IBM14/GEOMETRY/PSI.0092
+452	./IBM14/GEOMETRY/PSI.0093
+57868	./IBM14/GEOMETRY
+du: cannot access `./IBM14/CALCULATE/FDM_026_PD_SPE.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_043_VOF.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_123_WALLMODEL_POWERLAW.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_023_SMOOTHING.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_027_RK.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_302_WAVYVOR_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_033_IBM_INTFORCING.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_010_INIT_PARALLEL.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_110_RNG.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_025_PD.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_070_PARALLEL.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_121_WALLMODEL_KANG.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_304_ASSIMILATION_WAVY.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_032_IBM_EXTFORCING.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_111_GERMANO.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_023_SMOOTHING.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_122_WALLMODEL_ROMAN.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_304_ASSIMILATION_WAVY.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_000_MAIN.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_032_IBM_EXTFORCING.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_042_LS.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_123_WALLMODEL_POWERLAW.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_030_IBM.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_044_PRESCRIBEWAVE.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_080_FFT.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_020_PRESOLVE.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_091_SEDIMENT.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_300_ASSIMILATION.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_060_STATS_TS.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_303_MEANFLUC_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_070_PARALLEL.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_305_ASSIMILATION_VORT.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_301_ASSIMILATION_GEOMETRY.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_033_IBM_INTFORCING.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_030_IBM.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_306_ASSIMILATION_TOTAL.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_027_RK.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_020_PRESOLVE.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_021_RHS.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_111_GERMANO.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_999_FINALIZE.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_090_DYE.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_062_STRAINRATE.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_130_INT.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_051_IO.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_063_CIRCVELO.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_061_STATS_TA.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_062_STRAINRATE.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_022_WG.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_050_OUTPUT.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_121_WALLMODEL_KANG.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_043_VOF.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_090_DYE.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_130_INT.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_120_WALLMODEL_TBL.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_021_RHS.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_303_MEANFLUC_DECOMPOSITION.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_306_ASSIMILATION_TOTAL.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_100_LES.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_031_IBM_INIT.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_061_STATS_TA.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_301_ASSIMILATION_GEOMETRY.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_300_ASSIMILATION.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_010_INIT_PARALLEL.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_050_OUTPUT.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_044_PRESCRIBEWAVE.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/tags': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_051_IO.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_110_RNG.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_022_WG.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_025_PD.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_122_WALLMODEL_ROMAN.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_012_INIT_FIELD.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_200_PETSC_SOLVER.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_307_TRACER.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_001_FSTRANSFER.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_305_ASSIMILATION_VORT.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_100_LES.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_060_STATS_TS.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_091_SEDIMENT.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_307_TRACER.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_031_IBM_INIT.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_302_WAVYVOR_DECOMPOSITION.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_080_FFT.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_120_WALLMODEL_TBL.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_026_PD_SPE.F90': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_012_INIT_FIELD.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_063_CIRCVELO.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_000_MAIN.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_042_LS.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_011_INIT_CONSTANTS.o': Permission denied
+du: cannot access `./IBM14/CALCULATE/FDM_200_PETSC_SOLVER.o': Permission denied
+12	./IBM14/CALCULATE
+8	./IBM14/volume.dat
+575056	./IBM14/DATA/V00053600.H5
+575056	./IBM14/DATA/V00050400.H5
+575056	./IBM14/DATA/V00052400.H5
+575056	./IBM14/DATA/V00052600.H5
+575056	./IBM14/DATA/V00050600.H5
+575052	./IBM14/DATA/V00054000.H5
+575056	./IBM14/DATA/V00051200.H5
+575056	./IBM14/DATA/V00051600.H5
+575056	./IBM14/DATA/V00052200.H5
+575056	./IBM14/DATA/V00053200.H5
+575056	./IBM14/DATA/V00050800.H5
+575056	./IBM14/DATA/V00051000.H5
+575056	./IBM14/DATA/V00052800.H5
+575056	./IBM14/DATA/V00053000.H5
+575056	./IBM14/DATA/V00051800.H5
+575056	./IBM14/DATA/V00050200.H5
+575056	./IBM14/DATA/V00053400.H5
+575056	./IBM14/DATA/V00051400.H5
+575056	./IBM14/DATA/V00052000.H5
+575056	./IBM14/DATA/V00050000.H5
+575056	./IBM14/DATA/V00053800.H5
+12076192	./IBM14/DATA
+du: cannot access `./IBM14/LIB/libtecio.a': Permission denied
+4	./IBM14/LIB
+du: cannot access `./IBM14/POST_BASIC/POST_020_STATS.F90': Permission denied
+du: cannot access `./IBM14/POST_BASIC/POST_030_READFILE.F90': Permission denied
+du: cannot access `./IBM14/POST_BASIC/POST_031_PARALLEL.F90': Permission denied
+du: cannot access `./IBM14/POST_BASIC/POST_000_MAIN.F90': Permission denied
+du: cannot access `./IBM14/POST_BASIC/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM14/POST_BASIC/POST_040_AVERAGE.F90': Permission denied
+du: cannot access `./IBM14/POST_BASIC/POST_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM14/POST_BASIC/POST_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM14/POST_BASIC/POST_050_WRITEFILE.F90': Permission denied
+du: cannot access `./IBM14/POST_BASIC/POST_010_INIT_PARALLEL.F90': Permission denied
+4	./IBM14/POST_BASIC
+464	./IBM14/gatherdata
+12	./IBM14/POST_TKE/TKEDATA_IBM.F90
+4	./IBM14/POST_TKE/TKE_IO.F90
+4	./IBM14/POST_TKE/INCLUDE_IO.FI
+8	./IBM14/POST_TKE/TKEPRE.F90
+4	./IBM14/POST_TKE/TKEPS.F90
+12	./IBM14/POST_TKE/tecio.f90
+48	./IBM14/POST_TKE
+4	./IBM14/aegean_stream.sh
+8	./IBM14/Makefile
+373184	./IBM14/VORCENTER_PRE/00029800.DAT
+373180	./IBM14/VORCENTER_PRE/00052000.DAT
+373184	./IBM14/VORCENTER_PRE/00011000.DAT
+373184	./IBM14/VORCENTER_PRE/00044200.DAT
+373184	./IBM14/VORCENTER_PRE/00024600.DAT
+373184	./IBM14/VORCENTER_PRE/00031800.DAT
+373184	./IBM14/VORCENTER_PRE/00033200.DAT
+373184	./IBM14/VORCENTER_PRE/00015200.DAT
+373196	./IBM14/VORCENTER_PRE/00036000.DAT
+373184	./IBM14/VORCENTER_PRE/00013800.DAT
+373184	./IBM14/VORCENTER_PRE/00016800.DAT
+373184	./IBM14/VORCENTER_PRE/00027000.DAT
+373184	./IBM14/VORCENTER_PRE/00048400.DAT
+373184	./IBM14/VORCENTER_PRE/00021400.DAT
+373184	./IBM14/VORCENTER_PRE/00040000.DAT
+373184	./IBM14/VORCENTER_PRE/00007800.DAT
+373184	./IBM14/VORCENTER_PRE/00022000.DAT
+373184	./IBM14/VORCENTER_PRE/00048200.DAT
+373184	./IBM14/VORCENTER_PRE/00014600.DAT
+373184	./IBM14/VORCENTER_PRE/00033000.DAT
+373196	./IBM14/VORCENTER_PRE/00034200.DAT
+373184	./IBM14/VORCENTER_PRE/00028000.DAT
+373184	./IBM14/VORCENTER_PRE/00032800.DAT
+373184	./IBM14/VORCENTER_PRE/00007400.DAT
+373184	./IBM14/VORCENTER_PRE/00024400.DAT
+373184	./IBM14/VORCENTER_PRE/00016400.DAT
+373184	./IBM14/VORCENTER_PRE/00006400.DAT
+373176	./IBM14/VORCENTER_PRE/00053400.DAT
+373184	./IBM14/VORCENTER_PRE/00006600.DAT
+373184	./IBM14/VORCENTER_PRE/00045400.DAT
+373184	./IBM14/VORCENTER_PRE/00016200.DAT
+373184	./IBM14/VORCENTER_PRE/00005600.DAT
+373184	./IBM14/VORCENTER_PRE/00026400.DAT
+373184	./IBM14/VORCENTER_PRE/00021200.DAT
+373184	./IBM14/VORCENTER_PRE/00023400.DAT
+373184	./IBM14/VORCENTER_PRE/00027600.DAT
+373184	./IBM14/VORCENTER_PRE/00045000.DAT
+373184	./IBM14/VORCENTER_PRE/00018800.DAT
+373184	./IBM14/VORCENTER_PRE/00044800.DAT
+373184	./IBM14/VORCENTER_PRE/00043400.DAT
+373184	./IBM14/VORCENTER_PRE/00022400.DAT
+373184	./IBM14/VORCENTER_PRE/00026800.DAT
+373184	./IBM14/VORCENTER_PRE/00042800.DAT
+373184	./IBM14/VORCENTER_PRE/00004600.DAT
+373184	./IBM14/VORCENTER_PRE/00019400.DAT
+373184	./IBM14/VORCENTER_PRE/00029600.DAT
+373184	./IBM14/VORCENTER_PRE/00046400.DAT
+373184	./IBM14/VORCENTER_PRE/00004800.DAT
+373184	./IBM14/VORCENTER_PRE/00040200.DAT
+373184	./IBM14/VORCENTER_PRE/00039200.DAT
+373184	./IBM14/VORCENTER_PRE/00024000.DAT
+373184	./IBM14/VORCENTER_PRE/00024800.DAT
+373196	./IBM14/VORCENTER_PRE/00033800.DAT
+373184	./IBM14/VORCENTER_PRE/00002000.DAT
+373184	./IBM14/VORCENTER_PRE/00041400.DAT
+373184	./IBM14/VORCENTER_PRE/00012400.DAT
+373184	./IBM14/VORCENTER_PRE/00000200.DAT
+373184	./IBM14/VORCENTER_PRE/00008200.DAT
+373192	./IBM14/VORCENTER_PRE/00035200.DAT
+373184	./IBM14/VORCENTER_PRE/00020200.DAT
+373184	./IBM14/VORCENTER_PRE/00029200.DAT
+373184	./IBM14/VORCENTER_PRE/00041800.DAT
+373180	./IBM14/VORCENTER_PRE/00053000.DAT
+373204	./IBM14/VORCENTER_PRE/00035400.DAT
+373184	./IBM14/VORCENTER_PRE/00009400.DAT
+373184	./IBM14/VORCENTER_PRE/00020600.DAT
+373184	./IBM14/VORCENTER_PRE/00031000.DAT
+373184	./IBM14/VORCENTER_PRE/00045800.DAT
+373184	./IBM14/VORCENTER_PRE/00020400.DAT
+373184	./IBM14/VORCENTER_PRE/00011600.DAT
+373184	./IBM14/VORCENTER_PRE/00042600.DAT
+373184	./IBM14/VORCENTER_PRE/00002200.DAT
+373184	./IBM14/VORCENTER_PRE/00023200.DAT
+373184	./IBM14/VORCENTER_PRE/00037400.DAT
+373184	./IBM14/VORCENTER_PRE/00028400.DAT
+373184	./IBM14/VORCENTER_PRE/00032600.DAT
+373184	./IBM14/VORCENTER_PRE/00038000.DAT
+373184	./IBM14/VORCENTER_PRE/00046600.DAT
+373196	./IBM14/VORCENTER_PRE/00034400.DAT
+373184	./IBM14/VORCENTER_PRE/00025600.DAT
+373184	./IBM14/VORCENTER_PRE/00030800.DAT
+373184	./IBM14/VORCENTER_PRE/00008800.DAT
+373184	./IBM14/VORCENTER_PRE/00003200.DAT
+373184	./IBM14/VORCENTER_PRE/00015400.DAT
+373184	./IBM14/VORCENTER_PRE/00001800.DAT
+373180	./IBM14/VORCENTER_PRE/00050400.DAT
+373184	./IBM14/VORCENTER_PRE/00029000.DAT
+373184	./IBM14/VORCENTER_PRE/00043800.DAT
+373184	./IBM14/VORCENTER_PRE/00002400.DAT
+373180	./IBM14/VORCENTER_PRE/00052600.DAT
+373184	./IBM14/VORCENTER_PRE/00040800.DAT
+373184	./IBM14/VORCENTER_PRE/00017800.DAT
+373184	./IBM14/VORCENTER_PRE/00045600.DAT
+373184	./IBM14/VORCENTER_PRE/00002600.DAT
+373184	./IBM14/VORCENTER_PRE/00015800.DAT
+373184	./IBM14/VORCENTER_PRE/00037000.DAT
+373180	./IBM14/VORCENTER_PRE/00051800.DAT
+373184	./IBM14/VORCENTER_PRE/00011200.DAT
+373184	./IBM14/VORCENTER_PRE/00030600.DAT
+373184	./IBM14/VORCENTER_PRE/00036600.DAT
+373184	./IBM14/VORCENTER_PRE/00047000.DAT
+373176	./IBM14/VORCENTER_PRE/00054000.DAT
+373184	./IBM14/VORCENTER_PRE/00030200.DAT
+373184	./IBM14/VORCENTER_PRE/00032400.DAT
+373184	./IBM14/VORCENTER_PRE/00009800.DAT
+373176	./IBM14/VORCENTER_PRE/00053600.DAT
+373184	./IBM14/VORCENTER_PRE/00001200.DAT
+373184	./IBM14/VORCENTER_PRE/00010000.DAT
+373180	./IBM14/VORCENTER_PRE/00051400.DAT
+373180	./IBM14/VORCENTER_PRE/00051600.DAT
+373184	./IBM14/VORCENTER_PRE/00001000.DAT
+373184	./IBM14/VORCENTER_PRE/00046200.DAT
+373184	./IBM14/VORCENTER_PRE/00014400.DAT
+373184	./IBM14/VORCENTER_PRE/00046000.DAT
+373196	./IBM14/VORCENTER_PRE/00034600.DAT
+373184	./IBM14/VORCENTER_PRE/00020800.DAT
+373184	./IBM14/VORCENTER_PRE/00022600.DAT
+373184	./IBM14/VORCENTER_PRE/00037200.DAT
+373184	./IBM14/VORCENTER_PRE/00001600.DAT
+373184	./IBM14/VORCENTER_PRE/00004400.DAT
+373184	./IBM14/VORCENTER_PRE/00010600.DAT
+373184	./IBM14/VORCENTER_PRE/00037800.DAT
+373184	./IBM14/VORCENTER_PRE/00047600.DAT
+373184	./IBM14/VORCENTER_PRE/00018000.DAT
+373180	./IBM14/VORCENTER_PRE/00052800.DAT
+373184	./IBM14/VORCENTER_PRE/00043200.DAT
+373180	./IBM14/VORCENTER_PRE/00052200.DAT
+373184	./IBM14/VORCENTER_PRE/00014200.DAT
+373196	./IBM14/VORCENTER_PRE/00034800.DAT
+373184	./IBM14/VORCENTER_PRE/00047800.DAT
+373184	./IBM14/VORCENTER_PRE/00001400.DAT
+373184	./IBM14/VORCENTER_PRE/00006800.DAT
+373184	./IBM14/VORCENTER_PRE/00003600.DAT
+373180	./IBM14/VORCENTER_PRE/00050600.DAT
+373184	./IBM14/VORCENTER_PRE/00026200.DAT
+373184	./IBM14/VORCENTER_PRE/00027400.DAT
+373184	./IBM14/VORCENTER_PRE/00042000.DAT
+373184	./IBM14/VORCENTER_PRE/00028800.DAT
+373184	./IBM14/VORCENTER_PRE/00031200.DAT
+373184	./IBM14/VORCENTER_PRE/00016600.DAT
+373184	./IBM14/VORCENTER_PRE/00036800.DAT
+373184	./IBM14/VORCENTER_PRE/00007200.DAT
+373184	./IBM14/VORCENTER_PRE/00032200.DAT
+373184	./IBM14/VORCENTER_PRE/00044400.DAT
+373196	./IBM14/VORCENTER_PRE/00033600.DAT
+373184	./IBM14/VORCENTER_PRE/00031600.DAT
+373184	./IBM14/VORCENTER_PRE/00030000.DAT
+373184	./IBM14/VORCENTER_PRE/00017000.DAT
+373184	./IBM14/VORCENTER_PRE/00042200.DAT
+373184	./IBM14/VORCENTER_PRE/00026000.DAT
+373184	./IBM14/VORCENTER_PRE/00023600.DAT
+373184	./IBM14/VORCENTER_PRE/00040400.DAT
+373180	./IBM14/VORCENTER_PRE/00050000.DAT
+373184	./IBM14/VORCENTER_PRE/00041200.DAT
+373184	./IBM14/VORCENTER_PRE/00028600.DAT
+373184	./IBM14/VORCENTER_PRE/00038800.DAT
+373184	./IBM14/VORCENTER_PRE/00039400.DAT
+373184	./IBM14/VORCENTER_PRE/00025400.DAT
+373184	./IBM14/VORCENTER_PRE/00040600.DAT
+373184	./IBM14/VORCENTER_PRE/00010800.DAT
+373184	./IBM14/VORCENTER_PRE/00039800.DAT
+373176	./IBM14/VORCENTER_PRE/00053200.DAT
+373184	./IBM14/VORCENTER_PRE/00025200.DAT
+373184	./IBM14/VORCENTER_PRE/00007600.DAT
+373184	./IBM14/VORCENTER_PRE/00020000.DAT
+373184	./IBM14/VORCENTER_PRE/00000800.DAT
+373184	./IBM14/VORCENTER_PRE/00048000.DAT
+373184	./IBM14/VORCENTER_PRE/00018400.DAT
+373184	./IBM14/VORCENTER_PRE/00043600.DAT
+373184	./IBM14/VORCENTER_PRE/00024200.DAT
+373184	./IBM14/VORCENTER_PRE/00005800.DAT
+373184	./IBM14/VORCENTER_PRE/00012000.DAT
+373184	./IBM14/VORCENTER_PRE/00000400.DAT
+373184	./IBM14/VORCENTER_PRE/00006000.DAT
+373184	./IBM14/VORCENTER_PRE/00008600.DAT
+373184	./IBM14/VORCENTER_PRE/00003800.DAT
+373184	./IBM14/VORCENTER_PRE/00027200.DAT
+373184	./IBM14/VORCENTER_PRE/00047400.DAT
+373184	./IBM14/VORCENTER_PRE/00021600.DAT
+373184	./IBM14/VORCENTER_PRE/00013000.DAT
+373184	./IBM14/VORCENTER_PRE/00013200.DAT
+373184	./IBM14/VORCENTER_PRE/00000600.DAT
+373184	./IBM14/VORCENTER_PRE/00015000.DAT
+373184	./IBM14/VORCENTER_PRE/00004000.DAT
+373184	./IBM14/VORCENTER_PRE/00041600.DAT
+373184	./IBM14/VORCENTER_PRE/00036200.DAT
+373184	./IBM14/VORCENTER_PRE/00019800.DAT
+373192	./IBM14/VORCENTER_PRE/00035000.DAT
+373184	./IBM14/VORCENTER_PRE/00012800.DAT
+373184	./IBM14/VORCENTER_PRE/00038400.DAT
+373184	./IBM14/VORCENTER_PRE/00004200.DAT
+373184	./IBM14/VORCENTER_PRE/00010200.DAT
+373184	./IBM14/VORCENTER_PRE/00041000.DAT
+373184	./IBM14/VORCENTER_PRE/00011400.DAT
+373184	./IBM14/VORCENTER_PRE/00023800.DAT
+373184	./IBM14/VORCENTER_PRE/00045200.DAT
+373184	./IBM14/VORCENTER_PRE/00032000.DAT
+373184	./IBM14/VORCENTER_PRE/00026600.DAT
+373184	./IBM14/VORCENTER_PRE/00037600.DAT
+373184	./IBM14/VORCENTER_PRE/00038600.DAT
+373184	./IBM14/VORCENTER_PRE/00005000.DAT
+373180	./IBM14/VORCENTER_PRE/00050200.DAT
+373184	./IBM14/VORCENTER_PRE/00005200.DAT
+373184	./IBM14/VORCENTER_PRE/00023000.DAT
+373184	./IBM14/VORCENTER_PRE/00039600.DAT
+373184	./IBM14/VORCENTER_PRE/00047200.DAT
+373184	./IBM14/VORCENTER_PRE/00019600.DAT
+373184	./IBM14/VORCENTER_PRE/00028200.DAT
+373184	./IBM14/VORCENTER_PRE/00021000.DAT
+373184	./IBM14/VORCENTER_PRE/00010400.DAT
+373184	./IBM14/VORCENTER_PRE/00011800.DAT
+373184	./IBM14/VORCENTER_PRE/00017600.DAT
+373184	./IBM14/VORCENTER_PRE/00018600.DAT
+373184	./IBM14/VORCENTER_PRE/00012200.DAT
+373184	./IBM14/VORCENTER_PRE/00033400.DAT
+373184	./IBM14/VORCENTER_PRE/00019200.DAT
+373184	./IBM14/VORCENTER_PRE/00012600.DAT
+373184	./IBM14/VORCENTER_PRE/00005400.DAT
+373184	./IBM14/VORCENTER_PRE/00017400.DAT
+373184	./IBM14/VORCENTER_PRE/00003000.DAT
+373184	./IBM14/VORCENTER_PRE/00009600.DAT
+373184	./IBM14/VORCENTER_PRE/00016000.DAT
+373184	./IBM14/VORCENTER_PRE/00030400.DAT
+373184	./IBM14/VORCENTER_PRE/00014000.DAT
+373184	./IBM14/VORCENTER_PRE/00014800.DAT
+373184	./IBM14/VORCENTER_PRE/00038200.DAT
+373196	./IBM14/VORCENTER_PRE/00035600.DAT
+373184	./IBM14/VORCENTER_PRE/00043000.DAT
+373184	./IBM14/VORCENTER_PRE/00031400.DAT
+373184	./IBM14/VORCENTER_PRE/00013600.DAT
+373184	./IBM14/VORCENTER_PRE/00021800.DAT
+373184	./IBM14/VORCENTER_PRE/00018200.DAT
+373184	./IBM14/VORCENTER_PRE/00025800.DAT
+373184	./IBM14/VORCENTER_PRE/00042400.DAT
+373184	./IBM14/VORCENTER_PRE/00015600.DAT
+373184	./IBM14/VORCENTER_PRE/00039000.DAT
+373176	./IBM14/VORCENTER_PRE/00053800.DAT
+373208	./IBM14/VORCENTER_PRE/00035800.DAT
+373184	./IBM14/VORCENTER_PRE/00000000.DAT
+373180	./IBM14/VORCENTER_PRE/00052400.DAT
+373184	./IBM14/VORCENTER_PRE/00044000.DAT
+373184	./IBM14/VORCENTER_PRE/00009000.DAT
+373184	./IBM14/VORCENTER_PRE/00008400.DAT
+373184	./IBM14/VORCENTER_PRE/00006200.DAT
+373184	./IBM14/VORCENTER_PRE/00017200.DAT
+373184	./IBM14/VORCENTER_PRE/00029400.DAT
+373180	./IBM14/VORCENTER_PRE/00050800.DAT
+373184	./IBM14/VORCENTER_PRE/00007000.DAT
+373184	./IBM14/VORCENTER_PRE/00013400.DAT
+373180	./IBM14/VORCENTER_PRE/00051200.DAT
+373180	./IBM14/VORCENTER_PRE/00051000.DAT
+373184	./IBM14/VORCENTER_PRE/00019000.DAT
+373196	./IBM14/VORCENTER_PRE/00034000.DAT
+373184	./IBM14/VORCENTER_PRE/00022200.DAT
+373184	./IBM14/VORCENTER_PRE/00002800.DAT
+373184	./IBM14/VORCENTER_PRE/00025000.DAT
+373184	./IBM14/VORCENTER_PRE/00008000.DAT
+373184	./IBM14/VORCENTER_PRE/00036400.DAT
+373184	./IBM14/VORCENTER_PRE/00009200.DAT
+373184	./IBM14/VORCENTER_PRE/00003400.DAT
+373184	./IBM14/VORCENTER_PRE/00027800.DAT
+373184	./IBM14/VORCENTER_PRE/00022800.DAT
+373184	./IBM14/VORCENTER_PRE/00046800.DAT
+373184	./IBM14/VORCENTER_PRE/00044600.DAT
+98520656	./IBM14/VORCENTER_PRE
+4	./IBM14/WAVE
+4	./IBM14/RESTART_SOLID
+631528	./IBM14/STATS/BASIC.H5
+4	./IBM14/STATS/STAT_STEP
+631536	./IBM14/STATS
+4	./IBM14/vor.sh
+du: cannot access `./IBM14/batchrun/main.py': Permission denied
+du: cannot access `./IBM14/batchrun/grid.py': Permission denied
+du: cannot access `./IBM14/batchrun/param.py': Permission denied
+du: cannot access `./IBM14/batchrun/compile.py': Permission denied
+du: cannot access `./IBM14/batchrun/control.py': Permission denied
+du: cannot access `./IBM14/batchrun/directory.py': Permission denied
+du: cannot access `./IBM14/batchrun/ReadMe.md': Permission denied
+du: cannot access `./IBM14/batchrun/script.py': Permission denied
+4	./IBM14/batchrun
+4	./IBM14/resga
+9940	./IBM14/sour.dat
+4	./IBM14/aga.sh
+du: cannot access `./IBM14/POST/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM14/POST/post': Permission denied
+du: cannot access `./IBM14/POST/POST_TKE.F90': Permission denied
+du: cannot access `./IBM14/POST/POST_SURFACE.F90': Permission denied
+du: cannot access `./IBM14/POST/POST_IO.F90': Permission denied
+4	./IBM14/POST
+4	./IBM14/PARAM.IN
+4	./IBM14/CIRC_VELO
+4	./IBM14/vorcenter.sh
+10648	./IBM14/TIME_SERIES/MAXUVW.DAT
+1904	./IBM14/TIME_SERIES/YTIP.DAT
+6392	./IBM14/TIME_SERIES/CDCF.DAT
+18948	./IBM14/TIME_SERIES
+du: cannot access `./IBM14/GATHERDATA/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM14/GATHERDATA/GATHER_IO.o': Permission denied
+du: cannot access `./IBM14/GATHERDATA/tecio.f90': Permission denied
+du: cannot access `./IBM14/GATHERDATA/GATHER_IO.F90': Permission denied
+du: cannot access `./IBM14/GATHERDATA/GATHERDATA.o': Permission denied
+du: cannot access `./IBM14/GATHERDATA/GATHERDATA.F90': Permission denied
+4	./IBM14/GATHERDATA
+du: cannot access `./IBM14/POST_VORTEX/FDM_064_VORENSTROPHY.F90': Permission denied
+du: cannot access `./IBM14/POST_VORTEX/VORTEXP.F90': Permission denied
+du: cannot access `./IBM14/POST_VORTEX/VORDYNAMIC.F90': Permission denied
+du: cannot access `./IBM14/POST_VORTEX/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM14/POST_VORTEX/POST_VORTEX.F90': Permission denied
+du: cannot access `./IBM14/POST_VORTEX/VORMAX.F90': Permission denied
+du: cannot access `./IBM14/POST_VORTEX/tecio.f90': Permission denied
+du: cannot access `./IBM14/POST_VORTEX/VORTEX_IO.F90': Permission denied
+du: cannot access `./IBM14/POST_VORTEX/VORTEX_IBM.F90': Permission denied
+du: cannot access `./IBM14/POST_VORTEX/tags': Permission denied
+du: cannot access `./IBM14/POST_VORTEX/VORTEX.F90': Permission denied
+du: cannot access `./IBM14/POST_VORTEX/VORTEX_X.F90': Permission denied
+du: cannot access `./IBM14/POST_VORTEX/VORDYNAMIC_TH.F90': Permission denied
+du: cannot access `./IBM14/POST_VORTEX/VORDYNAMIC_Y.F90': Permission denied
+4	./IBM14/POST_VORTEX
+17604	./IBM14/wave
+du: cannot access `./IBM14/POST_WAVY_WALL/POST_030_READFILE.F90': Permission denied
+du: cannot access `./IBM14/POST_WAVY_WALL/POST_000_MAIN.F90': Permission denied
+du: cannot access `./IBM14/POST_WAVY_WALL/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM14/POST_WAVY_WALL/POST_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM14/POST_WAVY_WALL/POST_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM14/POST_WAVY_WALL/POST_040_WRITEFILE.F90': Permission denied
+du: cannot access `./IBM14/POST_WAVY_WALL/POST_020_AVERAGE.F90': Permission denied
+du: cannot access `./IBM14/POST_WAVY_WALL/POST_010_INIT_PARALLEL.F90': Permission denied
+4	./IBM14/POST_WAVY_WALL
+4	./IBM14/TRACER
+8	./IBM14/GRID.IN
+319648	./IBM14/INSTANTANEOUS/3D00053200.plt
+319648	./IBM14/INSTANTANEOUS/3D00051600.plt
+319648	./IBM14/INSTANTANEOUS/3D00053800.plt
+319648	./IBM14/INSTANTANEOUS/3D00053000.plt
+319648	./IBM14/INSTANTANEOUS/3D00053400.plt
+319648	./IBM14/INSTANTANEOUS/3D00054000.plt
+319648	./IBM14/INSTANTANEOUS/3D00052400.plt
+319648	./IBM14/INSTANTANEOUS/3D00050400.plt
+319648	./IBM14/INSTANTANEOUS/3D00052800.plt
+319648	./IBM14/INSTANTANEOUS/3D00052000.plt
+319648	./IBM14/INSTANTANEOUS/3D00050800.plt
+319648	./IBM14/INSTANTANEOUS/3D00050200.plt
+319648	./IBM14/INSTANTANEOUS/3D00050000.plt
+319648	./IBM14/INSTANTANEOUS/3D00052200.plt
+319648	./IBM14/INSTANTANEOUS/3D00051400.plt
+319648	./IBM14/INSTANTANEOUS/3D00051800.plt
+319648	./IBM14/INSTANTANEOUS/3D00052600.plt
+319648	./IBM14/INSTANTANEOUS/3D00050600.plt
+319648	./IBM14/INSTANTANEOUS/3D00053600.plt
+319648	./IBM14/INSTANTANEOUS/3D00051200.plt
+319648	./IBM14/INSTANTANEOUS/3D00051000.plt
+6712612	./IBM14/INSTANTANEOUS
+2484	./IBM14/results_aegean
+32	./IBM14/SURFACE/00033050.dat
+32	./IBM14/SURFACE/00039800.dat
+32	./IBM14/SURFACE/00024400.dat
+32	./IBM14/SURFACE/00035300.dat
+32	./IBM14/SURFACE/00002850.dat
+32	./IBM14/SURFACE/00046450.dat
+32	./IBM14/SURFACE/00025200.dat
+32	./IBM14/SURFACE/00047800.dat
+32	./IBM14/SURFACE/00047900.dat
+32	./IBM14/SURFACE/00048750.dat
+32	./IBM14/SURFACE/00003250.dat
+32	./IBM14/SURFACE/00048050.dat
+32	./IBM14/SURFACE/00031850.dat
+32	./IBM14/SURFACE/00005900.dat
+32	./IBM14/SURFACE/00010950.dat
+32	./IBM14/SURFACE/00052550.dat
+32	./IBM14/SURFACE/00016350.dat
+32	./IBM14/SURFACE/00010700.dat
+32	./IBM14/SURFACE/00028100.dat
+32	./IBM14/SURFACE/00032950.dat
+32	./IBM14/SURFACE/00041300.dat
+32	./IBM14/SURFACE/00016500.dat
+32	./IBM14/SURFACE/00012650.dat
+32	./IBM14/SURFACE/00009400.dat
+32	./IBM14/SURFACE/00047100.dat
+32	./IBM14/SURFACE/00052300.dat
+32	./IBM14/SURFACE/00053000.dat
+32	./IBM14/SURFACE/00018950.dat
+32	./IBM14/SURFACE/00043250.dat
+32	./IBM14/SURFACE/00024900.dat
+32	./IBM14/SURFACE/00032650.dat
+32	./IBM14/SURFACE/00009850.dat
+32	./IBM14/SURFACE/00040800.dat
+32	./IBM14/SURFACE/00035500.dat
+32	./IBM14/SURFACE/00034200.dat
+32	./IBM14/SURFACE/00051500.dat
+32	./IBM14/SURFACE/00013150.dat
+32	./IBM14/SURFACE/00019950.dat
+32	./IBM14/SURFACE/00029450.dat
+32	./IBM14/SURFACE/00028750.dat
+32	./IBM14/SURFACE/00026250.dat
+32	./IBM14/SURFACE/00031550.dat
+32	./IBM14/SURFACE/00032900.dat
+32	./IBM14/SURFACE/00052450.dat
+32	./IBM14/SURFACE/00014300.dat
+32	./IBM14/SURFACE/00042450.dat
+32	./IBM14/SURFACE/00007200.dat
+32	./IBM14/SURFACE/00031350.dat
+32	./IBM14/SURFACE/00021400.dat
+32	./IBM14/SURFACE/00018550.dat
+32	./IBM14/SURFACE/00053200.dat
+32	./IBM14/SURFACE/00013600.dat
+32	./IBM14/SURFACE/00004950.dat
+32	./IBM14/SURFACE/00004450.dat
+32	./IBM14/SURFACE/00050300.dat
+32	./IBM14/SURFACE/00033900.dat
+32	./IBM14/SURFACE/00020800.dat
+32	./IBM14/SURFACE/00009000.dat
+32	./IBM14/SURFACE/00014250.dat
+32	./IBM14/SURFACE/00024300.dat
+32	./IBM14/SURFACE/00036750.dat
+32	./IBM14/SURFACE/00040300.dat
+32	./IBM14/SURFACE/00043700.dat
+32	./IBM14/SURFACE/00035450.dat
+32	./IBM14/SURFACE/00009450.dat
+32	./IBM14/SURFACE/00052400.dat
+32	./IBM14/SURFACE/00039950.dat
+32	./IBM14/SURFACE/00011600.dat
+32	./IBM14/SURFACE/00051900.dat
+32	./IBM14/SURFACE/00002950.dat
+32	./IBM14/SURFACE/00001650.dat
+32	./IBM14/SURFACE/00026050.dat
+32	./IBM14/SURFACE/00039200.dat
+32	./IBM14/SURFACE/00034350.dat
+32	./IBM14/SURFACE/00041700.dat
+32	./IBM14/SURFACE/00047050.dat
+32	./IBM14/SURFACE/00026900.dat
+32	./IBM14/SURFACE/00030550.dat
+32	./IBM14/SURFACE/00042850.dat
+32	./IBM14/SURFACE/00010800.dat
+32	./IBM14/SURFACE/00028900.dat
+32	./IBM14/SURFACE/00034750.dat
+32	./IBM14/SURFACE/00024350.dat
+32	./IBM14/SURFACE/00006100.dat
+32	./IBM14/SURFACE/00015700.dat
+32	./IBM14/SURFACE/00048000.dat
+32	./IBM14/SURFACE/00049150.dat
+32	./IBM14/SURFACE/00016750.dat
+32	./IBM14/SURFACE/00040600.dat
+32	./IBM14/SURFACE/00015200.dat
+32	./IBM14/SURFACE/00046500.dat
+32	./IBM14/SURFACE/00016250.dat
+32	./IBM14/SURFACE/00011100.dat
+32	./IBM14/SURFACE/00004300.dat
+32	./IBM14/SURFACE/00049550.dat
+32	./IBM14/SURFACE/00012350.dat
+32	./IBM14/SURFACE/00021000.dat
+32	./IBM14/SURFACE/00048100.dat
+32	./IBM14/SURFACE/00022300.dat
+32	./IBM14/SURFACE/00042050.dat
+32	./IBM14/SURFACE/00033950.dat
+32	./IBM14/SURFACE/00052800.dat
+32	./IBM14/SURFACE/00005000.dat
+32	./IBM14/SURFACE/00037300.dat
+32	./IBM14/SURFACE/00030450.dat
+32	./IBM14/SURFACE/00041550.dat
+32	./IBM14/SURFACE/00006250.dat
+32	./IBM14/SURFACE/00040250.dat
+32	./IBM14/SURFACE/00037400.dat
+32	./IBM14/SURFACE/00019300.dat
+32	./IBM14/SURFACE/00044300.dat
+32	./IBM14/SURFACE/00053550.dat
+32	./IBM14/SURFACE/00023300.dat
+32	./IBM14/SURFACE/00048550.dat
+32	./IBM14/SURFACE/00007050.dat
+32	./IBM14/SURFACE/00012600.dat
+32	./IBM14/SURFACE/00037600.dat
+32	./IBM14/SURFACE/00040650.dat
+32	./IBM14/SURFACE/00026200.dat
+32	./IBM14/SURFACE/00044900.dat
+32	./IBM14/SURFACE/00033400.dat
+32	./IBM14/SURFACE/00001500.dat
+32	./IBM14/SURFACE/00036900.dat
+32	./IBM14/SURFACE/00037350.dat
+32	./IBM14/SURFACE/00011300.dat
+32	./IBM14/SURFACE/00042300.dat
+32	./IBM14/SURFACE/00023200.dat
+32	./IBM14/SURFACE/00047000.dat
+32	./IBM14/SURFACE/00049200.dat
+32	./IBM14/SURFACE/00003300.dat
+32	./IBM14/SURFACE/00007300.dat
+32	./IBM14/SURFACE/00017400.dat
+32	./IBM14/SURFACE/00004550.dat
+32	./IBM14/SURFACE/00007950.dat
+32	./IBM14/SURFACE/00022000.dat
+32	./IBM14/SURFACE/00008100.dat
+32	./IBM14/SURFACE/00027700.dat
+32	./IBM14/SURFACE/00034700.dat
+32	./IBM14/SURFACE/00050800.dat
+32	./IBM14/SURFACE/00014850.dat
+32	./IBM14/SURFACE/00039650.dat
+32	./IBM14/SURFACE/00007800.dat
+32	./IBM14/SURFACE/00005300.dat
+32	./IBM14/SURFACE/00018000.dat
+32	./IBM14/SURFACE/00005700.dat
+32	./IBM14/SURFACE/00020300.dat
+32	./IBM14/SURFACE/00004500.dat
+32	./IBM14/SURFACE/00018800.dat
+32	./IBM14/SURFACE/00017750.dat
+32	./IBM14/SURFACE/00003100.dat
+32	./IBM14/SURFACE/00018400.dat
+32	./IBM14/SURFACE/00050500.dat
+32	./IBM14/SURFACE/00043200.dat
+32	./IBM14/SURFACE/00035100.dat
+32	./IBM14/SURFACE/00041600.dat
+32	./IBM14/SURFACE/00034400.dat
+32	./IBM14/SURFACE/00023250.dat
+32	./IBM14/SURFACE/00008650.dat
+32	./IBM14/SURFACE/00023150.dat
+32	./IBM14/SURFACE/00007450.dat
+32	./IBM14/SURFACE/00043950.dat
+32	./IBM14/SURFACE/00053950.dat
+32	./IBM14/SURFACE/00029250.dat
+32	./IBM14/SURFACE/00013400.dat
+32	./IBM14/SURFACE/00004150.dat
+32	./IBM14/SURFACE/00041050.dat
+32	./IBM14/SURFACE/00016050.dat
+32	./IBM14/SURFACE/00036650.dat
+32	./IBM14/SURFACE/00025700.dat
+32	./IBM14/SURFACE/00051200.dat
+32	./IBM14/SURFACE/00036350.dat
+32	./IBM14/SURFACE/00020650.dat
+32	./IBM14/SURFACE/00050100.dat
+32	./IBM14/SURFACE/00006850.dat
+32	./IBM14/SURFACE/00046300.dat
+32	./IBM14/SURFACE/00039400.dat
+32	./IBM14/SURFACE/00037450.dat
+32	./IBM14/SURFACE/00046950.dat
+32	./IBM14/SURFACE/00027000.dat
+32	./IBM14/SURFACE/00009650.dat
+32	./IBM14/SURFACE/00000750.dat
+32	./IBM14/SURFACE/00046900.dat
+32	./IBM14/SURFACE/00019750.dat
+32	./IBM14/SURFACE/00041750.dat
+32	./IBM14/SURFACE/00030500.dat
+32	./IBM14/SURFACE/00040850.dat
+32	./IBM14/SURFACE/00000100.dat
+32	./IBM14/SURFACE/00028700.dat
+32	./IBM14/SURFACE/00002700.dat
+32	./IBM14/SURFACE/00040750.dat
+32	./IBM14/SURFACE/00038500.dat
+32	./IBM14/SURFACE/00005650.dat
+32	./IBM14/SURFACE/00043050.dat
+32	./IBM14/SURFACE/00041500.dat
+32	./IBM14/SURFACE/00003450.dat
+32	./IBM14/SURFACE/00042550.dat
+32	./IBM14/SURFACE/00009100.dat
+32	./IBM14/SURFACE/00041800.dat
+32	./IBM14/SURFACE/00051550.dat
+32	./IBM14/SURFACE/00052750.dat
+32	./IBM14/SURFACE/00019150.dat
+32	./IBM14/SURFACE/00010400.dat
+32	./IBM14/SURFACE/00009250.dat
+32	./IBM14/SURFACE/00034600.dat
+32	./IBM14/SURFACE/00037100.dat
+32	./IBM14/SURFACE/00012800.dat
+32	./IBM14/SURFACE/00024050.dat
+32	./IBM14/SURFACE/00052350.dat
+32	./IBM14/SURFACE/00047150.dat
+32	./IBM14/SURFACE/00028550.dat
+32	./IBM14/SURFACE/00050050.dat
+32	./IBM14/SURFACE/00029000.dat
+32	./IBM14/SURFACE/00028850.dat
+32	./IBM14/SURFACE/00021800.dat
+32	./IBM14/SURFACE/00000200.dat
+32	./IBM14/SURFACE/00049450.dat
+32	./IBM14/SURFACE/00049000.dat
+24	./IBM14/SURFACE/00030400.dat
+32	./IBM14/SURFACE/00011750.dat
+32	./IBM14/SURFACE/00029350.dat
+32	./IBM14/SURFACE/00025950.dat
+32	./IBM14/SURFACE/00033850.dat
+32	./IBM14/SURFACE/00000900.dat
+32	./IBM14/SURFACE/00029200.dat
+32	./IBM14/SURFACE/00001900.dat
+32	./IBM14/SURFACE/00046050.dat
+32	./IBM14/SURFACE/00008450.dat
+32	./IBM14/SURFACE/00018500.dat
+32	./IBM14/SURFACE/00023850.dat
+32	./IBM14/SURFACE/00025250.dat
+32	./IBM14/SURFACE/00041150.dat
+32	./IBM14/SURFACE/00026000.dat
+32	./IBM14/SURFACE/00050550.dat
+32	./IBM14/SURFACE/00030850.dat
+32	./IBM14/SURFACE/00045500.dat
+32	./IBM14/SURFACE/00038450.dat
+32	./IBM14/SURFACE/00030050.dat
+32	./IBM14/SURFACE/00010900.dat
+32	./IBM14/SURFACE/00051000.dat
+32	./IBM14/SURFACE/00012300.dat
+32	./IBM14/SURFACE/00048500.dat
+32	./IBM14/SURFACE/00039100.dat
+32	./IBM14/SURFACE/00020150.dat
+32	./IBM14/SURFACE/00043300.dat
+32	./IBM14/SURFACE/00010250.dat
+32	./IBM14/SURFACE/00004000.dat
+32	./IBM14/SURFACE/00041950.dat
+32	./IBM14/SURFACE/00042650.dat
+32	./IBM14/SURFACE/00014050.dat
+32	./IBM14/SURFACE/00036050.dat
+32	./IBM14/SURFACE/00052050.dat
+32	./IBM14/SURFACE/00023450.dat
+32	./IBM14/SURFACE/00019450.dat
+32	./IBM14/SURFACE/00016650.dat
+32	./IBM14/SURFACE/00048950.dat
+32	./IBM14/SURFACE/00002900.dat
+32	./IBM14/SURFACE/00052000.dat
+32	./IBM14/SURFACE/00035850.dat
+32	./IBM14/SURFACE/00045200.dat
+32	./IBM14/SURFACE/00024000.dat
+32	./IBM14/SURFACE/00018100.dat
+32	./IBM14/SURFACE/00047450.dat
+32	./IBM14/SURFACE/00045950.dat
+32	./IBM14/SURFACE/00005850.dat
+32	./IBM14/SURFACE/00009750.dat
+32	./IBM14/SURFACE/00039300.dat
+32	./IBM14/SURFACE/00031950.dat
+32	./IBM14/SURFACE/00035650.dat
+32	./IBM14/SURFACE/00047750.dat
+32	./IBM14/SURFACE/00002800.dat
+32	./IBM14/SURFACE/00044600.dat
+32	./IBM14/SURFACE/00014450.dat
+32	./IBM14/SURFACE/00012250.dat
+32	./IBM14/SURFACE/00050850.dat
+32	./IBM14/SURFACE/00017000.dat
+32	./IBM14/SURFACE/00001700.dat
+32	./IBM14/SURFACE/00029300.dat
+32	./IBM14/SURFACE/00038550.dat
+32	./IBM14/SURFACE/00044700.dat
+32	./IBM14/SURFACE/00006400.dat
+32	./IBM14/SURFACE/00015050.dat
+32	./IBM14/SURFACE/00029850.dat
+32	./IBM14/SURFACE/00029400.dat
+32	./IBM14/SURFACE/00046000.dat
+32	./IBM14/SURFACE/00016300.dat
+32	./IBM14/SURFACE/00006550.dat
+32	./IBM14/SURFACE/00003950.dat
+32	./IBM14/SURFACE/00002200.dat
+32	./IBM14/SURFACE/00021350.dat
+32	./IBM14/SURFACE/00036450.dat
+32	./IBM14/SURFACE/00039500.dat
+32	./IBM14/SURFACE/00045850.dat
+32	./IBM14/SURFACE/00027800.dat
+32	./IBM14/SURFACE/00032100.dat
+32	./IBM14/SURFACE/00051050.dat
+32	./IBM14/SURFACE/00019700.dat
+32	./IBM14/SURFACE/00010450.dat
+32	./IBM14/SURFACE/00011150.dat
+32	./IBM14/SURFACE/00015350.dat
+32	./IBM14/SURFACE/00032150.dat
+32	./IBM14/SURFACE/00004750.dat
+32	./IBM14/SURFACE/00000850.dat
+32	./IBM14/SURFACE/00048800.dat
+32	./IBM14/SURFACE/00048350.dat
+32	./IBM14/SURFACE/00023550.dat
+32	./IBM14/SURFACE/00053500.dat
+32	./IBM14/SURFACE/00054000.dat
+32	./IBM14/SURFACE/00034100.dat
+32	./IBM14/SURFACE/00020600.dat
+32	./IBM14/SURFACE/00043000.dat
+32	./IBM14/SURFACE/00022050.dat
+32	./IBM14/SURFACE/00037050.dat
+32	./IBM14/SURFACE/00004350.dat
+32	./IBM14/SURFACE/00047500.dat
+32	./IBM14/SURFACE/00044500.dat
+32	./IBM14/SURFACE/00007500.dat
+32	./IBM14/SURFACE/00052500.dat
+32	./IBM14/SURFACE/00035250.dat
+32	./IBM14/SURFACE/00033700.dat
+32	./IBM14/SURFACE/00046700.dat
+32	./IBM14/SURFACE/00013300.dat
+32	./IBM14/SURFACE/00050900.dat
+32	./IBM14/SURFACE/00002000.dat
+32	./IBM14/SURFACE/00023900.dat
+32	./IBM14/SURFACE/00013350.dat
+32	./IBM14/SURFACE/00050450.dat
+32	./IBM14/SURFACE/00034850.dat
+32	./IBM14/SURFACE/00037750.dat
+32	./IBM14/SURFACE/00016450.dat
+32	./IBM14/SURFACE/00031750.dat
+32	./IBM14/SURFACE/00039250.dat
+32	./IBM14/SURFACE/00007700.dat
+32	./IBM14/SURFACE/00023800.dat
+32	./IBM14/SURFACE/00011700.dat
+32	./IBM14/SURFACE/00024500.dat
+32	./IBM14/SURFACE/00034150.dat
+32	./IBM14/SURFACE/00018050.dat
+32	./IBM14/SURFACE/00002350.dat
+32	./IBM14/SURFACE/00024700.dat
+32	./IBM14/SURFACE/00025150.dat
+32	./IBM14/SURFACE/00053050.dat
+32	./IBM14/SURFACE/00017650.dat
+32	./IBM14/SURFACE/00017800.dat
+32	./IBM14/SURFACE/00040200.dat
+32	./IBM14/SURFACE/00049900.dat
+32	./IBM14/SURFACE/00027200.dat
+32	./IBM14/SURFACE/00004100.dat
+32	./IBM14/SURFACE/00040950.dat
+32	./IBM14/SURFACE/00038200.dat
+32	./IBM14/SURFACE/00036100.dat
+32	./IBM14/SURFACE/00029950.dat
+32	./IBM14/SURFACE/00006300.dat
+32	./IBM14/SURFACE/00014100.dat
+32	./IBM14/SURFACE/00017950.dat
+32	./IBM14/SURFACE/00002550.dat
+32	./IBM14/SURFACE/00015300.dat
+32	./IBM14/SURFACE/00001100.dat
+32	./IBM14/SURFACE/00045600.dat
+32	./IBM14/SURFACE/00016100.dat
+32	./IBM14/SURFACE/00025900.dat
+32	./IBM14/SURFACE/00005750.dat
+32	./IBM14/SURFACE/00036300.dat
+32	./IBM14/SURFACE/00021950.dat
+32	./IBM14/SURFACE/00048900.dat
+32	./IBM14/SURFACE/00022450.dat
+32	./IBM14/SURFACE/00002500.dat
+32	./IBM14/SURFACE/00037850.dat
+32	./IBM14/SURFACE/00035600.dat
+32	./IBM14/SURFACE/00023000.dat
+32	./IBM14/SURFACE/00051600.dat
+32	./IBM14/SURFACE/00008800.dat
+32	./IBM14/SURFACE/00023950.dat
+32	./IBM14/SURFACE/00045750.dat
+32	./IBM14/SURFACE/00037700.dat
+32	./IBM14/SURFACE/00028800.dat
+32	./IBM14/SURFACE/00015150.dat
+32	./IBM14/SURFACE/00011650.dat
+32	./IBM14/SURFACE/00043150.dat
+32	./IBM14/SURFACE/00030000.dat
+32	./IBM14/SURFACE/00003700.dat
+32	./IBM14/SURFACE/00031450.dat
+32	./IBM14/SURFACE/00037900.dat
+32	./IBM14/SURFACE/00053850.dat
+32	./IBM14/SURFACE/00039550.dat
+32	./IBM14/SURFACE/00031400.dat
+32	./IBM14/SURFACE/00045150.dat
+32	./IBM14/SURFACE/00032350.dat
+32	./IBM14/SURFACE/00005400.dat
+32	./IBM14/SURFACE/00008750.dat
+32	./IBM14/SURFACE/00043650.dat
+32	./IBM14/SURFACE/00021050.dat
+32	./IBM14/SURFACE/00011950.dat
+32	./IBM14/SURFACE/00017550.dat
+32	./IBM14/SURFACE/00011550.dat
+32	./IBM14/SURFACE/00022850.dat
+32	./IBM14/SURFACE/00005500.dat
+32	./IBM14/SURFACE/00009950.dat
+32	./IBM14/SURFACE/00024450.dat
+32	./IBM14/SURFACE/00009150.dat
+32	./IBM14/SURFACE/00007000.dat
+32	./IBM14/SURFACE/00044750.dat
+32	./IBM14/SURFACE/00024950.dat
+32	./IBM14/SURFACE/00034250.dat
+32	./IBM14/SURFACE/00048250.dat
+32	./IBM14/SURFACE/00028950.dat
+32	./IBM14/SURFACE/00013100.dat
+32	./IBM14/SURFACE/00051650.dat
+32	./IBM14/SURFACE/00031700.dat
+32	./IBM14/SURFACE/00017300.dat
+32	./IBM14/SURFACE/00039750.dat
+32	./IBM14/SURFACE/00015250.dat
+32	./IBM14/SURFACE/00003150.dat
+32	./IBM14/SURFACE/00010150.dat
+32	./IBM14/SURFACE/00049650.dat
+32	./IBM14/SURFACE/00017050.dat
+32	./IBM14/SURFACE/00021550.dat
+32	./IBM14/SURFACE/00041000.dat
+32	./IBM14/SURFACE/00053750.dat
+32	./IBM14/SURFACE/00029750.dat
+32	./IBM14/SURFACE/00004700.dat
+32	./IBM14/SURFACE/00028200.dat
+32	./IBM14/SURFACE/00016800.dat
+32	./IBM14/SURFACE/00032550.dat
+32	./IBM14/SURFACE/00000400.dat
+32	./IBM14/SURFACE/00017350.dat
+32	./IBM14/SURFACE/00035700.dat
+32	./IBM14/SURFACE/00038300.dat
+32	./IBM14/SURFACE/00006450.dat
+32	./IBM14/SURFACE/00048700.dat
+32	./IBM14/SURFACE/00004650.dat
+32	./IBM14/SURFACE/00048400.dat
+32	./IBM14/SURFACE/00048600.dat
+32	./IBM14/SURFACE/00017850.dat
+32	./IBM14/SURFACE/00029100.dat
+32	./IBM14/SURFACE/00007750.dat
+32	./IBM14/SURFACE/00006350.dat
+32	./IBM14/SURFACE/00020050.dat
+32	./IBM14/SURFACE/00009200.dat
+32	./IBM14/SURFACE/00031050.dat
+32	./IBM14/SURFACE/00030300.dat
+32	./IBM14/SURFACE/00004900.dat
+32	./IBM14/SURFACE/00022950.dat
+32	./IBM14/SURFACE/00012750.dat
+32	./IBM14/SURFACE/00046750.dat
+32	./IBM14/SURFACE/00000150.dat
+32	./IBM14/SURFACE/00025350.dat
+32	./IBM14/SURFACE/00026500.dat
+32	./IBM14/SURFACE/00008000.dat
+32	./IBM14/SURFACE/00053450.dat
+32	./IBM14/SURFACE/00010500.dat
+32	./IBM14/SURFACE/00034000.dat
+32	./IBM14/SURFACE/00021450.dat
+32	./IBM14/SURFACE/00037200.dat
+32	./IBM14/SURFACE/00020900.dat
+32	./IBM14/SURFACE/00020700.dat
+32	./IBM14/SURFACE/00007100.dat
+32	./IBM14/SURFACE/00009700.dat
+32	./IBM14/SURFACE/00048650.dat
+32	./IBM14/SURFACE/00047300.dat
+32	./IBM14/SURFACE/00038000.dat
+32	./IBM14/SURFACE/00021650.dat
+32	./IBM14/SURFACE/00004250.dat
+32	./IBM14/SURFACE/00015800.dat
+32	./IBM14/SURFACE/00049100.dat
+32	./IBM14/SURFACE/00001550.dat
+32	./IBM14/SURFACE/00052250.dat
+32	./IBM14/SURFACE/00019800.dat
+32	./IBM14/SURFACE/00051400.dat
+32	./IBM14/SURFACE/00010550.dat
+32	./IBM14/SURFACE/00021750.dat
+32	./IBM14/SURFACE/00025550.dat
+32	./IBM14/SURFACE/00028300.dat
+32	./IBM14/SURFACE/00013500.dat
+32	./IBM14/SURFACE/00025100.dat
+32	./IBM14/SURFACE/00005200.dat
+32	./IBM14/SURFACE/00027550.dat
+32	./IBM14/SURFACE/00012450.dat
+32	./IBM14/SURFACE/00014800.dat
+32	./IBM14/SURFACE/00011350.dat
+32	./IBM14/SURFACE/00035150.dat
+32	./IBM14/SURFACE/00002300.dat
+32	./IBM14/SURFACE/00052850.dat
+32	./IBM14/SURFACE/00041850.dat
+32	./IBM14/SURFACE/00014000.dat
+32	./IBM14/SURFACE/00007250.dat
+32	./IBM14/SURFACE/00029900.dat
+32	./IBM14/SURFACE/00053650.dat
+32	./IBM14/SURFACE/00002650.dat
+32	./IBM14/SURFACE/00049750.dat
+32	./IBM14/SURFACE/00006600.dat
+32	./IBM14/SURFACE/00019850.dat
+32	./IBM14/SURFACE/00011400.dat
+32	./IBM14/SURFACE/00029150.dat
+32	./IBM14/SURFACE/00013650.dat
+32	./IBM14/SURFACE/00030200.dat
+32	./IBM14/SURFACE/00052150.dat
+32	./IBM14/SURFACE/00006950.dat
+32	./IBM14/SURFACE/00018900.dat
+32	./IBM14/SURFACE/00033750.dat
+32	./IBM14/SURFACE/00006000.dat
+32	./IBM14/SURFACE/00024150.dat
+32	./IBM14/SURFACE/00012050.dat
+32	./IBM14/SURFACE/00029050.dat
+32	./IBM14/SURFACE/00006750.dat
+32	./IBM14/SURFACE/00003850.dat
+32	./IBM14/SURFACE/00008150.dat
+32	./IBM14/SURFACE/00001050.dat
+32	./IBM14/SURFACE/00033550.dat
+32	./IBM14/SURFACE/00036000.dat
+32	./IBM14/SURFACE/00029650.dat
+32	./IBM14/SURFACE/00020450.dat
+32	./IBM14/SURFACE/00036950.dat
+32	./IBM14/SURFACE/00035900.dat
+32	./IBM14/SURFACE/00053600.dat
+32	./IBM14/SURFACE/00018600.dat
+32	./IBM14/SURFACE/00026800.dat
+32	./IBM14/SURFACE/00030650.dat
+32	./IBM14/SURFACE/00007600.dat
+32	./IBM14/SURFACE/00036500.dat
+32	./IBM14/SURFACE/00038650.dat
+32	./IBM14/SURFACE/00000600.dat
+32	./IBM14/SURFACE/00020000.dat
+32	./IBM14/SURFACE/00042150.dat
+32	./IBM14/SURFACE/00024600.dat
+32	./IBM14/SURFACE/00031600.dat
+32	./IBM14/SURFACE/00019600.dat
+32	./IBM14/SURFACE/00013700.dat
+32	./IBM14/SURFACE/00041200.dat
+32	./IBM14/SURFACE/00052100.dat
+32	./IBM14/SURFACE/00000700.dat
+32	./IBM14/SURFACE/00049300.dat
+32	./IBM14/SURFACE/00040000.dat
+32	./IBM14/SURFACE/00007350.dat
+32	./IBM14/SURFACE/00003600.dat
+32	./IBM14/SURFACE/00000450.dat
+32	./IBM14/SURFACE/00017450.dat
+32	./IBM14/SURFACE/00022100.dat
+32	./IBM14/SURFACE/00028250.dat
+32	./IBM14/SURFACE/00023700.dat
+32	./IBM14/SURFACE/00001000.dat
+32	./IBM14/SURFACE/00009900.dat
+32	./IBM14/SURFACE/00045400.dat
+32	./IBM14/SURFACE/00035400.dat
+32	./IBM14/SURFACE/00000350.dat
+32	./IBM14/SURFACE/00010650.dat
+32	./IBM14/SURFACE/00019500.dat
+32	./IBM14/SURFACE/00025000.dat
+32	./IBM14/SURFACE/00028600.dat
+32	./IBM14/SURFACE/00017100.dat
+32	./IBM14/SURFACE/00019400.dat
+32	./IBM14/SURFACE/00027100.dat
+32	./IBM14/SURFACE/00033200.dat
+32	./IBM14/SURFACE/00001600.dat
+32	./IBM14/SURFACE/00047650.dat
+32	./IBM14/SURFACE/00032300.dat
+32	./IBM14/SURFACE/00005550.dat
+32	./IBM14/SURFACE/00018150.dat
+32	./IBM14/SURFACE/00017600.dat
+32	./IBM14/SURFACE/00021900.dat
+32	./IBM14/SURFACE/00021300.dat
+32	./IBM14/SURFACE/00034650.dat
+32	./IBM14/SURFACE/00027450.dat
+32	./IBM14/SURFACE/00029800.dat
+32	./IBM14/SURFACE/00021200.dat
+32	./IBM14/SURFACE/00000050.dat
+32	./IBM14/SURFACE/00032850.dat
+32	./IBM14/SURFACE/00038950.dat
+32	./IBM14/SURFACE/00002250.dat
+32	./IBM14/SURFACE/00005050.dat
+32	./IBM14/SURFACE/00022500.dat
+32	./IBM14/SURFACE/00020950.dat
+32	./IBM14/SURFACE/00008950.dat
+32	./IBM14/SURFACE/00038350.dat
+32	./IBM14/SURFACE/00000650.dat
+32	./IBM14/SURFACE/00028050.dat
+32	./IBM14/SURFACE/00050700.dat
+32	./IBM14/SURFACE/00022350.dat
+32	./IBM14/SURFACE/00039450.dat
+32	./IBM14/SURFACE/00050350.dat
+32	./IBM14/SURFACE/00003750.dat
+32	./IBM14/SURFACE/00020350.dat
+32	./IBM14/SURFACE/00026700.dat
+32	./IBM14/SURFACE/00046550.dat
+32	./IBM14/SURFACE/00036200.dat
+32	./IBM14/SURFACE/00022700.dat
+32	./IBM14/SURFACE/00043400.dat
+32	./IBM14/SURFACE/00052650.dat
+32	./IBM14/SURFACE/00024200.dat
+32	./IBM14/SURFACE/00051450.dat
+32	./IBM14/SURFACE/00030900.dat
+32	./IBM14/SURFACE/00035050.dat
+32	./IBM14/SURFACE/00053400.dat
+32	./IBM14/SURFACE/00043450.dat
+32	./IBM14/SURFACE/00006700.dat
+32	./IBM14/SURFACE/00044000.dat
+32	./IBM14/SURFACE/00027600.dat
+32	./IBM14/SURFACE/00004050.dat
+32	./IBM14/SURFACE/00008350.dat
+32	./IBM14/SURFACE/00039700.dat
+32	./IBM14/SURFACE/00040150.dat
+32	./IBM14/SURFACE/00032800.dat
+32	./IBM14/SURFACE/00011800.dat
+32	./IBM14/SURFACE/00010050.dat
+32	./IBM14/SURFACE/00020750.dat
+32	./IBM14/SURFACE/00035000.dat
+32	./IBM14/SURFACE/00027750.dat
+32	./IBM14/SURFACE/00002750.dat
+32	./IBM14/SURFACE/00019200.dat
+32	./IBM14/SURFACE/00019100.dat
+32	./IBM14/SURFACE/00015850.dat
+32	./IBM14/SURFACE/00044950.dat
+32	./IBM14/SURFACE/00002150.dat
+32	./IBM14/SURFACE/00016550.dat
+32	./IBM14/SURFACE/00034500.dat
+32	./IBM14/SURFACE/00025750.dat
+32	./IBM14/SURFACE/00050600.dat
+32	./IBM14/SURFACE/00042000.dat
+32	./IBM14/SURFACE/00025850.dat
+32	./IBM14/SURFACE/00042900.dat
+32	./IBM14/SURFACE/00021500.dat
+32	./IBM14/SURFACE/00011000.dat
+32	./IBM14/SURFACE/00025400.dat
+32	./IBM14/SURFACE/00032600.dat
+32	./IBM14/SURFACE/00015750.dat
+32	./IBM14/SURFACE/00042250.dat
+32	./IBM14/SURFACE/00049800.dat
+32	./IBM14/SURFACE/00002600.dat
+32	./IBM14/SURFACE/00020850.dat
+32	./IBM14/SURFACE/00029500.dat
+32	./IBM14/SURFACE/00021700.dat
+32	./IBM14/SURFACE/00035750.dat
+32	./IBM14/SURFACE/00041900.dat
+32	./IBM14/SURFACE/00018750.dat
+32	./IBM14/SURFACE/00044150.dat
+32	./IBM14/SURFACE/00007150.dat
+32	./IBM14/SURFACE/00022200.dat
+32	./IBM14/SURFACE/00036850.dat
+32	./IBM14/SURFACE/00012100.dat
+32	./IBM14/SURFACE/00032500.dat
+32	./IBM14/SURFACE/00000550.dat
+32	./IBM14/SURFACE/00044050.dat
+32	./IBM14/SURFACE/00036400.dat
+32	./IBM14/SURFACE/00028650.dat
+32	./IBM14/SURFACE/00019000.dat
+32	./IBM14/SURFACE/00037550.dat
+32	./IBM14/SURFACE/00025650.dat
+32	./IBM14/SURFACE/00016600.dat
+32	./IBM14/SURFACE/00022650.dat
+32	./IBM14/SURFACE/00043750.dat
+32	./IBM14/SURFACE/00017150.dat
+32	./IBM14/SURFACE/00032700.dat
+32	./IBM14/SURFACE/00016850.dat
+32	./IBM14/SURFACE/00052900.dat
+32	./IBM14/SURFACE/00025800.dat
+32	./IBM14/SURFACE/00033000.dat
+32	./IBM14/SURFACE/00031250.dat
+32	./IBM14/SURFACE/00031200.dat
+32	./IBM14/SURFACE/00021250.dat
+32	./IBM14/SURFACE/00009300.dat
+32	./IBM14/SURFACE/00048150.dat
+32	./IBM14/SURFACE/00044200.dat
+32	./IBM14/SURFACE/00010200.dat
+32	./IBM14/SURFACE/00050750.dat
+32	./IBM14/SURFACE/00027050.dat
+32	./IBM14/SURFACE/00036600.dat
+32	./IBM14/SURFACE/00020200.dat
+32	./IBM14/SURFACE/00035350.dat
+32	./IBM14/SURFACE/00017500.dat
+32	./IBM14/SURFACE/00040500.dat
+32	./IBM14/SURFACE/00038250.dat
+32	./IBM14/SURFACE/00039050.dat
+32	./IBM14/SURFACE/00030100.dat
+32	./IBM14/SURFACE/00023400.dat
+32	./IBM14/SURFACE/00022600.dat
+32	./IBM14/SURFACE/00018700.dat
+32	./IBM14/SURFACE/00014650.dat
+32	./IBM14/SURFACE/00047400.dat
+32	./IBM14/SURFACE/00033450.dat
+32	./IBM14/SURFACE/00019650.dat
+32	./IBM14/SURFACE/00027950.dat
+32	./IBM14/SURFACE/00029550.dat
+32	./IBM14/SURFACE/00013450.dat
+32	./IBM14/SURFACE/00019900.dat
+32	./IBM14/SURFACE/00026100.dat
+32	./IBM14/SURFACE/00026600.dat
+32	./IBM14/SURFACE/00007850.dat
+32	./IBM14/SURFACE/00050250.dat
+32	./IBM14/SURFACE/00003350.dat
+32	./IBM14/SURFACE/00001350.dat
+32	./IBM14/SURFACE/00036700.dat
+32	./IBM14/SURFACE/00049250.dat
+32	./IBM14/SURFACE/00016900.dat
+32	./IBM14/SURFACE/00046400.dat
+32	./IBM14/SURFACE/00039000.dat
+32	./IBM14/SURFACE/00039150.dat
+32	./IBM14/SURFACE/00027300.dat
+32	./IBM14/SURFACE/00025050.dat
+32	./IBM14/SURFACE/00038700.dat
+32	./IBM14/SURFACE/00019250.dat
+32	./IBM14/SURFACE/00009550.dat
+32	./IBM14/SURFACE/00015550.dat
+32	./IBM14/SURFACE/00009600.dat
+32	./IBM14/SURFACE/00046250.dat
+32	./IBM14/SURFACE/00049050.dat
+32	./IBM14/SURFACE/00031150.dat
+32	./IBM14/SURFACE/00036800.dat
+32	./IBM14/SURFACE/00045100.dat
+32	./IBM14/SURFACE/00006800.dat
+32	./IBM14/SURFACE/00032250.dat
+32	./IBM14/SURFACE/00020250.dat
+32	./IBM14/SURFACE/00024750.dat
+32	./IBM14/SURFACE/00014150.dat
+32	./IBM14/SURFACE/00046650.dat
+32	./IBM14/SURFACE/00001150.dat
+32	./IBM14/SURFACE/00038400.dat
+32	./IBM14/SURFACE/00041400.dat
+32	./IBM14/SURFACE/00045350.dat
+32	./IBM14/SURFACE/00027400.dat
+32	./IBM14/SURFACE/00014900.dat
+32	./IBM14/SURFACE/00032000.dat
+32	./IBM14/SURFACE/00026400.dat
+32	./IBM14/SURFACE/00022800.dat
+32	./IBM14/SURFACE/00012000.dat
+32	./IBM14/SURFACE/00040350.dat
+32	./IBM14/SURFACE/00006500.dat
+32	./IBM14/SURFACE/00026950.dat
+32	./IBM14/SURFACE/00042350.dat
+32	./IBM14/SURFACE/00030750.dat
+32	./IBM14/SURFACE/00020500.dat
+32	./IBM14/SURFACE/00026350.dat
+32	./IBM14/SURFACE/00031300.dat
+32	./IBM14/SURFACE/00031650.dat
+32	./IBM14/SURFACE/00053150.dat
+32	./IBM14/SURFACE/00045000.dat
+32	./IBM14/SURFACE/00050950.dat
+32	./IBM14/SURFACE/00015400.dat
+32	./IBM14/SURFACE/00050200.dat
+32	./IBM14/SURFACE/00053900.dat
+32	./IBM14/SURFACE/00015500.dat
+32	./IBM14/SURFACE/00015900.dat
+32	./IBM14/SURFACE/00047350.dat
+32	./IBM14/SURFACE/00030350.dat
+32	./IBM14/SURFACE/00040550.dat
+32	./IBM14/SURFACE/00027850.dat
+32	./IBM14/SURFACE/00007400.dat
+32	./IBM14/SURFACE/00043350.dat
+32	./IBM14/SURFACE/00037800.dat
+32	./IBM14/SURFACE/00054050.dat
+32	./IBM14/SURFACE/00008900.dat
+32	./IBM14/SURFACE/00021850.dat
+32	./IBM14/SURFACE/00033100.dat
+32	./IBM14/SURFACE/00047950.dat
+32	./IBM14/SURFACE/00016400.dat
+32	./IBM14/SURFACE/00043100.dat
+32	./IBM14/SURFACE/00035800.dat
+32	./IBM14/SURFACE/00045550.dat
+32	./IBM14/SURFACE/00009500.dat
+32	./IBM14/SURFACE/00014500.dat
+32	./IBM14/SURFACE/00045450.dat
+32	./IBM14/SURFACE/00008600.dat
+32	./IBM14/SURFACE/00015950.dat
+32	./IBM14/SURFACE/00010750.dat
+32	./IBM14/SURFACE/00046150.dat
+32	./IBM14/SURFACE/00051300.dat
+32	./IBM14/SURFACE/00026850.dat
+32	./IBM14/SURFACE/00008550.dat
+32	./IBM14/SURFACE/00027350.dat
+32	./IBM14/SURFACE/00018650.dat
+32	./IBM14/SURFACE/00022250.dat
+32	./IBM14/SURFACE/00006650.dat
+32	./IBM14/SURFACE/00042500.dat
+32	./IBM14/SURFACE/00040700.dat
+32	./IBM14/SURFACE/00013000.dat
+32	./IBM14/SURFACE/00003050.dat
+32	./IBM14/SURFACE/00014700.dat
+32	./IBM14/SURFACE/00033500.dat
+32	./IBM14/SURFACE/00001750.dat
+32	./IBM14/SURFACE/00037950.dat
+32	./IBM14/SURFACE/00006900.dat
+32	./IBM14/SURFACE/00031000.dat
+32	./IBM14/SURFACE/00038050.dat
+32	./IBM14/SURFACE/00039900.dat
+32	./IBM14/SURFACE/00042700.dat
+32	./IBM14/SURFACE/00032400.dat
+32	./IBM14/SURFACE/00052200.dat
+32	./IBM14/SURFACE/00027250.dat
+32	./IBM14/SURFACE/00026550.dat
+32	./IBM14/SURFACE/00041650.dat
+32	./IBM14/SURFACE/00001250.dat
+32	./IBM14/SURFACE/00023650.dat
+32	./IBM14/SURFACE/00022400.dat
+32	./IBM14/SURFACE/00014750.dat
+32	./IBM14/SURFACE/00030800.dat
+32	./IBM14/SURFACE/00037650.dat
+32	./IBM14/SURFACE/00032200.dat
+32	./IBM14/SURFACE/00034800.dat
+32	./IBM14/SURFACE/00044850.dat
+32	./IBM14/SURFACE/00038850.dat
+32	./IBM14/SURFACE/00024650.dat
+32	./IBM14/SURFACE/00024250.dat
+32	./IBM14/SURFACE/00010350.dat
+32	./IBM14/SURFACE/00028500.dat
+32	./IBM14/SURFACE/00018300.dat
+32	./IBM14/SURFACE/00005600.dat
+32	./IBM14/SURFACE/00039850.dat
+32	./IBM14/SURFACE/00042400.dat
+32	./IBM14/SURFACE/00004200.dat
+32	./IBM14/SURFACE/00035950.dat
+32	./IBM14/SURFACE/00048850.dat
+32	./IBM14/SURFACE/00015100.dat
+32	./IBM14/SURFACE/00001800.dat
+32	./IBM14/SURFACE/00017900.dat
+32	./IBM14/SURFACE/00018350.dat
+32	./IBM14/SURFACE/00027650.dat
+32	./IBM14/SURFACE/00053800.dat
+32	./IBM14/SURFACE/00045900.dat
+32	./IBM14/SURFACE/00009350.dat
+32	./IBM14/SURFACE/00037000.dat
+32	./IBM14/SURFACE/00051800.dat
+32	./IBM14/SURFACE/00033350.dat
+32	./IBM14/SURFACE/00043900.dat
+32	./IBM14/SURFACE/00028350.dat
+32	./IBM14/SURFACE/00008250.dat
+32	./IBM14/SURFACE/00012150.dat
+32	./IBM14/SURFACE/00000250.dat
+32	./IBM14/SURFACE/00012500.dat
+32	./IBM14/SURFACE/00035200.dat
+32	./IBM14/SURFACE/00045800.dat
+32	./IBM14/SURFACE/00022750.dat
+32	./IBM14/SURFACE/00052600.dat
+32	./IBM14/SURFACE/00044800.dat
+32	./IBM14/SURFACE/00051350.dat
+32	./IBM14/SURFACE/00038150.dat
+32	./IBM14/SURFACE/00024850.dat
+32	./IBM14/SURFACE/00053250.dat
+32	./IBM14/SURFACE/00053100.dat
+32	./IBM14/SURFACE/00006050.dat
+32	./IBM14/SURFACE/00053700.dat
+32	./IBM14/SURFACE/00033650.dat
+32	./IBM14/SURFACE/00011850.dat
+32	./IBM14/SURFACE/00042200.dat
+32	./IBM14/SURFACE/00012950.dat
+32	./IBM14/SURFACE/00046600.dat
+32	./IBM14/SURFACE/00040100.dat
+32	./IBM14/SURFACE/00051250.dat
+32	./IBM14/SURFACE/00020100.dat
+32	./IBM14/SURFACE/00019350.dat
+32	./IBM14/SURFACE/00035550.dat
+32	./IBM14/SURFACE/00045650.dat
+32	./IBM14/SURFACE/00030600.dat
+32	./IBM14/SURFACE/00011450.dat
+32	./IBM14/SURFACE/00028150.dat
+32	./IBM14/SURFACE/00000950.dat
+32	./IBM14/SURFACE/00049700.dat
+32	./IBM14/SURFACE/00025600.dat
+32	./IBM14/SURFACE/00015600.dat
+32	./IBM14/SURFACE/00013050.dat
+32	./IBM14/SURFACE/00023350.dat
+32	./IBM14/SURFACE/00053300.dat
+32	./IBM14/SURFACE/00028000.dat
+32	./IBM14/SURFACE/00037150.dat
+32	./IBM14/SURFACE/00038600.dat
+32	./IBM14/SURFACE/00048300.dat
+32	./IBM14/SURFACE/00043600.dat
+32	./IBM14/SURFACE/00005950.dat
+32	./IBM14/SURFACE/00033300.dat
+32	./IBM14/SURFACE/00016950.dat
+32	./IBM14/SURFACE/00010850.dat
+32	./IBM14/SURFACE/00042100.dat
+32	./IBM14/SURFACE/00017250.dat
+32	./IBM14/SURFACE/00050650.dat
+32	./IBM14/SURFACE/00013850.dat
+32	./IBM14/SURFACE/00047850.dat
+32	./IBM14/SURFACE/00004600.dat
+32	./IBM14/SURFACE/00013750.dat
+32	./IBM14/SURFACE/00009800.dat
+32	./IBM14/SURFACE/00025500.dat
+32	./IBM14/SURFACE/00017700.dat
+32	./IBM14/SURFACE/00024100.dat
+32	./IBM14/SURFACE/00030150.dat
+32	./IBM14/SURFACE/00002100.dat
+32	./IBM14/SURFACE/00002050.dat
+32	./IBM14/SURFACE/00019550.dat
+32	./IBM14/SURFACE/00034950.dat
+32	./IBM14/SURFACE/00014200.dat
+32	./IBM14/SURFACE/00009050.dat
+32	./IBM14/SURFACE/00026300.dat
+32	./IBM14/SURFACE/00005350.dat
+32	./IBM14/SURFACE/00020550.dat
+32	./IBM14/SURFACE/00020400.dat
+32	./IBM14/SURFACE/00014400.dat
+32	./IBM14/SURFACE/00039350.dat
+32	./IBM14/SURFACE/00033600.dat
+32	./IBM14/SURFACE/00023600.dat
+32	./IBM14/SURFACE/00001450.dat
+32	./IBM14/SURFACE/00023500.dat
+32	./IBM14/SURFACE/00001200.dat
+32	./IBM14/SURFACE/00011050.dat
+32	./IBM14/SURFACE/00013200.dat
+32	./IBM14/SURFACE/00049500.dat
+32	./IBM14/SURFACE/00026450.dat
+32	./IBM14/SURFACE/00025450.dat
+32	./IBM14/SURFACE/00016200.dat
+32	./IBM14/SURFACE/00026650.dat
+32	./IBM14/SURFACE/00043550.dat
+32	./IBM14/SURFACE/00034550.dat
+32	./IBM14/SURFACE/00011250.dat
+32	./IBM14/SURFACE/00003400.dat
+32	./IBM14/SURFACE/00014550.dat
+32	./IBM14/SURFACE/00045050.dat
+32	./IBM14/SURFACE/00008700.dat
+32	./IBM14/SURFACE/00046350.dat
+32	./IBM14/SURFACE/00005250.dat
+32	./IBM14/SURFACE/00003650.dat
+32	./IBM14/SURFACE/00038800.dat
+32	./IBM14/SURFACE/00031100.dat
+32	./IBM14/SURFACE/00014600.dat
+32	./IBM14/SURFACE/00002400.dat
+32	./IBM14/SURFACE/00049400.dat
+32	./IBM14/SURFACE/00011200.dat
+32	./IBM14/SURFACE/00037250.dat
+32	./IBM14/SURFACE/00008050.dat
+32	./IBM14/SURFACE/00044350.dat
+32	./IBM14/SURFACE/00026150.dat
+32	./IBM14/SURFACE/00033250.dat
+32	./IBM14/SURFACE/00001850.dat
+32	./IBM14/SURFACE/00042950.dat
+32	./IBM14/SURFACE/00028450.dat
+32	./IBM14/SURFACE/00006200.dat
+32	./IBM14/SURFACE/00052700.dat
+32	./IBM14/SURFACE/00024800.dat
+32	./IBM14/SURFACE/00029700.dat
+32	./IBM14/SURFACE/00048200.dat
+32	./IBM14/SURFACE/00007900.dat
+32	./IBM14/SURFACE/00052950.dat
+32	./IBM14/SURFACE/00041100.dat
+32	./IBM14/SURFACE/00040400.dat
+32	./IBM14/SURFACE/00013950.dat
+32	./IBM14/SURFACE/00042600.dat
+32	./IBM14/SURFACE/00022550.dat
+32	./IBM14/SURFACE/00013900.dat
+32	./IBM14/SURFACE/00040050.dat
+32	./IBM14/SURFACE/00000300.dat
+32	./IBM14/SURFACE/00030950.dat
+32	./IBM14/SURFACE/00013800.dat
+32	./IBM14/SURFACE/00021600.dat
+32	./IBM14/SURFACE/00027900.dat
+32	./IBM14/SURFACE/00008400.dat
+32	./IBM14/SURFACE/00051150.dat
+32	./IBM14/SURFACE/00018250.dat
+32	./IBM14/SURFACE/00007650.dat
+32	./IBM14/SURFACE/00044250.dat
+32	./IBM14/SURFACE/00047200.dat
+32	./IBM14/SURFACE/00010100.dat
+32	./IBM14/SURFACE/00010300.dat
+32	./IBM14/SURFACE/00004400.dat
+32	./IBM14/SURFACE/00047600.dat
+32	./IBM14/SURFACE/00053350.dat
+32	./IBM14/SURFACE/00040900.dat
+32	./IBM14/SURFACE/00043500.dat
+32	./IBM14/SURFACE/00012900.dat
+32	./IBM14/SURFACE/00049600.dat
+32	./IBM14/SURFACE/00046200.dat
+32	./IBM14/SURFACE/00021100.dat
+32	./IBM14/SURFACE/00005800.dat
+32	./IBM14/SURFACE/00045250.dat
+32	./IBM14/SURFACE/00003200.dat
+32	./IBM14/SURFACE/00015450.dat
+32	./IBM14/SURFACE/00047550.dat
+32	./IBM14/SURFACE/00011900.dat
+32	./IBM14/SURFACE/00023750.dat
+32	./IBM14/SURFACE/00002450.dat
+32	./IBM14/SURFACE/00040450.dat
+32	./IBM14/SURFACE/00049950.dat
+32	./IBM14/SURFACE/00016150.dat
+32	./IBM14/SURFACE/00034050.dat
+32	./IBM14/SURFACE/00031800.dat
+32	./IBM14/SURFACE/00039600.dat
+32	./IBM14/SURFACE/00023050.dat
+32	./IBM14/SURFACE/00005150.dat
+32	./IBM14/SURFACE/00014950.dat
+32	./IBM14/SURFACE/00005100.dat
+32	./IBM14/SURFACE/00015000.dat
+32	./IBM14/SURFACE/00031900.dat
+32	./IBM14/SURFACE/00019050.dat
+32	./IBM14/SURFACE/00033150.dat
+32	./IBM14/SURFACE/00041350.dat
+32	./IBM14/SURFACE/00003000.dat
+32	./IBM14/SURFACE/00012700.dat
+32	./IBM14/SURFACE/00046100.dat
+32	./IBM14/SURFACE/00032450.dat
+32	./IBM14/SURFACE/00005450.dat
+32	./IBM14/SURFACE/00016700.dat
+32	./IBM14/SURFACE/00044550.dat
+32	./IBM14/SURFACE/00032750.dat
+32	./IBM14/SURFACE/00004800.dat
+32	./IBM14/SURFACE/00024550.dat
+32	./IBM14/SURFACE/00046800.dat
+32	./IBM14/SURFACE/00038900.dat
+32	./IBM14/SURFACE/00023100.dat
+32	./IBM14/SURFACE/00001300.dat
+32	./IBM14/SURFACE/00036150.dat
+32	./IBM14/SURFACE/00008300.dat
+32	./IBM14/SURFACE/00003500.dat
+32	./IBM14/SURFACE/00012550.dat
+32	./IBM14/SURFACE/00008850.dat
+32	./IBM14/SURFACE/00043800.dat
+32	./IBM14/SURFACE/00008500.dat
+32	./IBM14/SURFACE/00049850.dat
+32	./IBM14/SURFACE/00038100.dat
+32	./IBM14/SURFACE/00051100.dat
+32	./IBM14/SURFACE/00018850.dat
+32	./IBM14/SURFACE/00018450.dat
+32	./IBM14/SURFACE/00027150.dat
+32	./IBM14/SURFACE/00000500.dat
+32	./IBM14/SURFACE/00044450.dat
+32	./IBM14/SURFACE/00022900.dat
+32	./IBM14/SURFACE/00026750.dat
+32	./IBM14/SURFACE/00034450.dat
+32	./IBM14/SURFACE/00036250.dat
+32	./IBM14/SURFACE/00038750.dat
+32	./IBM14/SURFACE/00015650.dat
+32	./IBM14/SURFACE/00044650.dat
+32	./IBM14/SURFACE/00010000.dat
+32	./IBM14/SURFACE/00036550.dat
+32	./IBM14/SURFACE/00050400.dat
+32	./IBM14/SURFACE/00006150.dat
+32	./IBM14/SURFACE/00034300.dat
+32	./IBM14/SURFACE/00003550.dat
+32	./IBM14/SURFACE/00007550.dat
+32	./IBM14/SURFACE/00043850.dat
+32	./IBM14/SURFACE/00011500.dat
+32	./IBM14/SURFACE/00012200.dat
+32	./IBM14/SURFACE/00044100.dat
+32	./IBM14/SURFACE/00003900.dat
+32	./IBM14/SURFACE/00033800.dat
+32	./IBM14/SURFACE/00013550.dat
+32	./IBM14/SURFACE/00041250.dat
+32	./IBM14/SURFACE/00047700.dat
+32	./IBM14/SURFACE/00054100.dat
+32	./IBM14/SURFACE/00051950.dat
+32	./IBM14/SURFACE/00050150.dat
+32	./IBM14/SURFACE/00051850.dat
+32	./IBM14/SURFACE/00045300.dat
+32	./IBM14/SURFACE/00046850.dat
+32	./IBM14/SURFACE/00012400.dat
+32	./IBM14/SURFACE/00032050.dat
+32	./IBM14/SURFACE/00031500.dat
+32	./IBM14/SURFACE/00027500.dat
+32	./IBM14/SURFACE/00037500.dat
+32	./IBM14/SURFACE/00012850.dat
+32	./IBM14/SURFACE/00010600.dat
+32	./IBM14/SURFACE/00018200.dat
+32	./IBM14/SURFACE/00013250.dat
+32	./IBM14/SURFACE/00034900.dat
+32	./IBM14/SURFACE/00049350.dat
+32	./IBM14/SURFACE/00041450.dat
+32	./IBM14/SURFACE/00051750.dat
+32	./IBM14/SURFACE/00017200.dat
+32	./IBM14/SURFACE/00008200.dat
+32	./IBM14/SURFACE/00014350.dat
+32	./IBM14/SURFACE/00022150.dat
+32	./IBM14/SURFACE/00042800.dat
+32	./IBM14/SURFACE/00042750.dat
+32	./IBM14/SURFACE/00048450.dat
+32	./IBM14/SURFACE/00030250.dat
+32	./IBM14/SURFACE/00001950.dat
+32	./IBM14/SURFACE/00004850.dat
+32	./IBM14/SURFACE/00025300.dat
+32	./IBM14/SURFACE/00044400.dat
+32	./IBM14/SURFACE/00051700.dat
+32	./IBM14/SURFACE/00001400.dat
+32	./IBM14/SURFACE/00028400.dat
+32	./IBM14/SURFACE/00045700.dat
+32	./IBM14/SURFACE/00000800.dat
+32	./IBM14/SURFACE/00003800.dat
+32	./IBM14/SURFACE/00050000.dat
+32	./IBM14/SURFACE/00021150.dat
+32	./IBM14/SURFACE/00029600.dat
+32	./IBM14/SURFACE/00016000.dat
+32	./IBM14/SURFACE/00030700.dat
+32	./IBM14/SURFACE/00047250.dat
+34688	./IBM14/SURFACE
+4	./IBM14/prof_step
+4	./IBM14/Beforemaking
+4	./IBM14/MID/TIME.MID
+8	./IBM14/MID
+du: cannot access `./IBM14/PRIO_GENERATE_GRID/Makefile': Permission denied
+du: cannot access `./IBM14/PRIO_GENERATE_GRID/genegrid': Permission denied
+du: cannot access `./IBM14/PRIO_GENERATE_GRID/GENEGRID.F90': Permission denied
+4	./IBM14/PRIO_GENERATE_GRID
+118084088	./IBM14
+du: cannot access `./IBM7/libtecio.a': Permission denied
+du: cannot access `./IBM7/INCLUDE': Permission denied
+du: cannot access `./IBM7/CALCULATE': Permission denied
+du: cannot access `./IBM7/volume.dat': Permission denied
+du: cannot access `./IBM7/POST_BASIC': Permission denied
+du: cannot access `./IBM7/submit_p': Permission denied
+du: cannot access `./IBM7/aegean_stream.sh': Permission denied
+du: cannot access `./IBM7/screen': Permission denied
+du: cannot access `./IBM7/Makefile': Permission denied
+du: cannot access `./IBM7/submit_data': Permission denied
+du: cannot access `./IBM7/WAVE': Permission denied
+du: cannot access `./IBM7/submit': Permission denied
+du: cannot access `./IBM7/batchrun': Permission denied
+du: cannot access `./IBM7/resga': Permission denied
+du: cannot access `./IBM7/sour.dat': Permission denied
+du: cannot access `./IBM7/aga.sh': Permission denied
+du: cannot access `./IBM7/PARAM.IN': Permission denied
+du: cannot access `./IBM7/screenga': Permission denied
+du: cannot access `./IBM7/GATHERDATA': Permission denied
+du: cannot access `./IBM7/POST_WAVY_WALL': Permission denied
+du: cannot access `./IBM7/TRACER': Permission denied
+du: cannot access `./IBM7/GRID.IN': Permission denied
+du: cannot access `./IBM7/results_aegean': Permission denied
+du: cannot access `./IBM7/prof_step': Permission denied
+du: cannot access `./IBM7/Beforemaking': Permission denied
+du: cannot access `./IBM7/PRIO_GENERATE_GRID': Permission denied
+4	./IBM7
+241376	./IBM17/tp1wCuPSr
+912	./IBM17/libtecio.a
+du: cannot access `./IBM17/INCLUDE/INCLUDE_FFT.FI': Permission denied
+du: cannot access `./IBM17/INCLUDE/INCLUDE_CINTERFACE.FI': Permission denied
+du: cannot access `./IBM17/INCLUDE/INCLUDE_LES.FI': Permission denied
+du: cannot access `./IBM17/INCLUDE/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM17/INCLUDE/INCLUDE_WAVEGENERATOR.FI': Permission denied
+du: cannot access `./IBM17/INCLUDE/INCLUDE_PARALLEL.FI': Permission denied
+du: cannot access `./IBM17/INCLUDE/INCLUDE_PETSC.FI': Permission denied
+du: cannot access `./IBM17/INCLUDE/INCLUDE_ASSIMILATION.FI': Permission denied
+du: cannot access `./IBM17/INCLUDE/INCLUDE_IBM.FI': Permission denied
+du: cannot access `./IBM17/INCLUDE/variables_new.h': Permission denied
+du: cannot access `./IBM17/INCLUDE/INCLUDE_PARAMETER.FI': Permission denied
+du: cannot access `./IBM17/INCLUDE/mpm_vars_new.h': Permission denied
+du: cannot access `./IBM17/INCLUDE/INCLUDE_SCALAR.FI': Permission denied
+du: cannot access `./IBM17/INCLUDE/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM17/INCLUDE/INCLUDE_STATS.FI': Permission denied
+du: cannot access `./IBM17/INCLUDE/INCLUDE_POISSON.FI': Permission denied
+4	./IBM17/INCLUDE
+340	./IBM17/GEOMETRY/PSI.0074
+340	./IBM17/GEOMETRY/PSI.0012
+340	./IBM17/GEOMETRY/PSI.0026
+340	./IBM17/GEOMETRY/PSI.0048
+340	./IBM17/GEOMETRY/PSI.0054
+340	./IBM17/GEOMETRY/PSI.0084
+340	./IBM17/GEOMETRY/PSI.0019
+340	./IBM17/GEOMETRY/PSI.0066
+340	./IBM17/GEOMETRY/PSI.0015
+340	./IBM17/GEOMETRY/PSI.0094
+340	./IBM17/GEOMETRY/PSI.0088
+340	./IBM17/GEOMETRY/PSI.0032
+340	./IBM17/GEOMETRY/PSI.0081
+340	./IBM17/GEOMETRY/PSI.0005
+340	./IBM17/GEOMETRY/PSI.0007
+340	./IBM17/GEOMETRY/PSI.0050
+340	./IBM17/GEOMETRY/PSI.0098
+340	./IBM17/GEOMETRY/PSI.0021
+340	./IBM17/GEOMETRY/PSI.0079
+340	./IBM17/GEOMETRY/PSI.0043
+340	./IBM17/GEOMETRY/PSI.0104
+340	./IBM17/GEOMETRY/PSI.0060
+340	./IBM17/GEOMETRY/PSI.0061
+340	./IBM17/GEOMETRY/PSI.0095
+340	./IBM17/GEOMETRY/PSI.0082
+340	./IBM17/GEOMETRY/PSI.0080
+340	./IBM17/GEOMETRY/PSI.0087
+340	./IBM17/GEOMETRY/PSI.0027
+340	./IBM17/GEOMETRY/PSI.0023
+340	./IBM17/GEOMETRY/PSI.0003
+340	./IBM17/GEOMETRY/PSI.0014
+340	./IBM17/GEOMETRY/PSI.0062
+340	./IBM17/GEOMETRY/PSI.0086
+340	./IBM17/GEOMETRY/PSI.0008
+340	./IBM17/GEOMETRY/PSI.0058
+340	./IBM17/GEOMETRY/PSI.0034
+340	./IBM17/GEOMETRY/PSI.0120
+340	./IBM17/GEOMETRY/PSI.0089
+340	./IBM17/GEOMETRY/PSI.0118
+340	./IBM17/GEOMETRY/PSI.0044
+340	./IBM17/GEOMETRY/PSI.0125
+340	./IBM17/GEOMETRY/PSI.0036
+340	./IBM17/GEOMETRY/PSI.0052
+340	./IBM17/GEOMETRY/PSI.0031
+340	./IBM17/GEOMETRY/PSI.0076
+340	./IBM17/GEOMETRY/PSI.0037
+340	./IBM17/GEOMETRY/PSI.0024
+340	./IBM17/GEOMETRY/PSI.0100
+340	./IBM17/GEOMETRY/PSI.0030
+340	./IBM17/GEOMETRY/PSI.0069
+340	./IBM17/GEOMETRY/PSI.0075
+340	./IBM17/GEOMETRY/PSI.0068
+340	./IBM17/GEOMETRY/PSI.0002
+340	./IBM17/GEOMETRY/PSI.0000
+340	./IBM17/GEOMETRY/PSI.0020
+340	./IBM17/GEOMETRY/PSI.0010
+340	./IBM17/GEOMETRY/PSI.0110
+340	./IBM17/GEOMETRY/PSI.0124
+340	./IBM17/GEOMETRY/PSI.0051
+340	./IBM17/GEOMETRY/PSI.0121
+340	./IBM17/GEOMETRY/PSI.0116
+340	./IBM17/GEOMETRY/PSI.0053
+340	./IBM17/GEOMETRY/PSI.0073
+340	./IBM17/GEOMETRY/PSI.0018
+340	./IBM17/GEOMETRY/PSI.0106
+340	./IBM17/GEOMETRY/PSI.0004
+340	./IBM17/GEOMETRY/PSI.0035
+340	./IBM17/GEOMETRY/PSI.0083
+340	./IBM17/GEOMETRY/PSI.0013
+340	./IBM17/GEOMETRY/PSI.0022
+340	./IBM17/GEOMETRY/PSI.0101
+340	./IBM17/GEOMETRY/PSI.0122
+340	./IBM17/GEOMETRY/PSI.0016
+340	./IBM17/GEOMETRY/PSI.0119
+340	./IBM17/GEOMETRY/PSI.0067
+340	./IBM17/GEOMETRY/PSI.0072
+340	./IBM17/GEOMETRY/PSI.0112
+340	./IBM17/GEOMETRY/PSI.0039
+340	./IBM17/GEOMETRY/PSI.0017
+340	./IBM17/GEOMETRY/PSI.0097
+340	./IBM17/GEOMETRY/PSI.0107
+340	./IBM17/GEOMETRY/PSI.0108
+340	./IBM17/GEOMETRY/PSI.0123
+340	./IBM17/GEOMETRY/PSI.0063
+340	./IBM17/GEOMETRY/PSI.0102
+340	./IBM17/GEOMETRY/PSI.0047
+340	./IBM17/GEOMETRY/PSI.0045
+340	./IBM17/GEOMETRY/PSI.0070
+340	./IBM17/GEOMETRY/PSI.0038
+340	./IBM17/GEOMETRY/PSI.0127
+340	./IBM17/GEOMETRY/PSI.0056
+340	./IBM17/GEOMETRY/PSI.0078
+340	./IBM17/GEOMETRY/PSI.0126
+340	./IBM17/GEOMETRY/PSI.0046
+340	./IBM17/GEOMETRY/PSI.0064
+340	./IBM17/GEOMETRY/PSI.0096
+340	./IBM17/GEOMETRY/PSI.0077
+340	./IBM17/GEOMETRY/PSI.0025
+340	./IBM17/GEOMETRY/PSI.0040
+340	./IBM17/GEOMETRY/PSI.0011
+340	./IBM17/GEOMETRY/PSI.0041
+340	./IBM17/GEOMETRY/PSI.0109
+340	./IBM17/GEOMETRY/PSI.0090
+340	./IBM17/GEOMETRY/PSI.0042
+340	./IBM17/GEOMETRY/PSI.0105
+340	./IBM17/GEOMETRY/PSI.0009
+340	./IBM17/GEOMETRY/PSI.0028
+340	./IBM17/GEOMETRY/PSI.0114
+340	./IBM17/GEOMETRY/PSI.0006
+340	./IBM17/GEOMETRY/PSI.0033
+340	./IBM17/GEOMETRY/PSI.0055
+340	./IBM17/GEOMETRY/PSI.0071
+340	./IBM17/GEOMETRY/PSI.0113
+340	./IBM17/GEOMETRY/PSI.0049
+340	./IBM17/GEOMETRY/PSI.0103
+340	./IBM17/GEOMETRY/PSI.0001
+340	./IBM17/GEOMETRY/PSI.0099
+340	./IBM17/GEOMETRY/PSI.0065
+340	./IBM17/GEOMETRY/PSI.0111
+340	./IBM17/GEOMETRY/PSI.0059
+340	./IBM17/GEOMETRY/PSI.0085
+340	./IBM17/GEOMETRY/PSI.0029
+340	./IBM17/GEOMETRY/PSI.0057
+340	./IBM17/GEOMETRY/PSI.0115
+340	./IBM17/GEOMETRY/PSI.0117
+340	./IBM17/GEOMETRY/PSI.0091
+340	./IBM17/GEOMETRY/PSI.0092
+340	./IBM17/GEOMETRY/PSI.0093
+43532	./IBM17/GEOMETRY
+du: cannot access `./IBM17/CALCULATE/FDM_026_PD_SPE.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_043_VOF.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_123_WALLMODEL_POWERLAW.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_023_SMOOTHING.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_027_RK.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_302_WAVYVOR_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_033_IBM_INTFORCING.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_010_INIT_PARALLEL.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_110_RNG.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_025_PD.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_070_PARALLEL.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_121_WALLMODEL_KANG.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_304_ASSIMILATION_WAVY.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_032_IBM_EXTFORCING.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_111_GERMANO.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_023_SMOOTHING.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_122_WALLMODEL_ROMAN.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_304_ASSIMILATION_WAVY.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_000_MAIN.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_032_IBM_EXTFORCING.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_042_LS.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_123_WALLMODEL_POWERLAW.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_030_IBM.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_044_PRESCRIBEWAVE.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_080_FFT.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_020_PRESOLVE.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_091_SEDIMENT.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_300_ASSIMILATION.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_060_STATS_TS.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_303_MEANFLUC_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_070_PARALLEL.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_305_ASSIMILATION_VORT.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_301_ASSIMILATION_GEOMETRY.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_033_IBM_INTFORCING.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_030_IBM.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_306_ASSIMILATION_TOTAL.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_027_RK.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_020_PRESOLVE.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_021_RHS.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_111_GERMANO.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_999_FINALIZE.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_090_DYE.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_062_STRAINRATE.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_130_INT.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_051_IO.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_063_CIRCVELO.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_061_STATS_TA.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_062_STRAINRATE.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_022_WG.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_050_OUTPUT.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_121_WALLMODEL_KANG.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_043_VOF.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_090_DYE.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_130_INT.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_120_WALLMODEL_TBL.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_021_RHS.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_303_MEANFLUC_DECOMPOSITION.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_306_ASSIMILATION_TOTAL.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_100_LES.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_031_IBM_INIT.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_061_STATS_TA.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_301_ASSIMILATION_GEOMETRY.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_300_ASSIMILATION.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_010_INIT_PARALLEL.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_050_OUTPUT.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_044_PRESCRIBEWAVE.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/tags': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_051_IO.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_110_RNG.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_022_WG.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_025_PD.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_122_WALLMODEL_ROMAN.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_012_INIT_FIELD.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_200_PETSC_SOLVER.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_307_TRACER.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_001_FSTRANSFER.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_305_ASSIMILATION_VORT.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_100_LES.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_060_STATS_TS.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_091_SEDIMENT.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_307_TRACER.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_031_IBM_INIT.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_302_WAVYVOR_DECOMPOSITION.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_080_FFT.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_120_WALLMODEL_TBL.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_026_PD_SPE.F90': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_012_INIT_FIELD.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_063_CIRCVELO.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_000_MAIN.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_042_LS.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_011_INIT_CONSTANTS.o': Permission denied
+du: cannot access `./IBM17/CALCULATE/FDM_200_PETSC_SOLVER.o': Permission denied
+12	./IBM17/CALCULATE
+393156	./IBM17/DATA/V00037000.H5
+393160	./IBM17/DATA/V00023900.H5
+393160	./IBM17/DATA/V00019100.H5
+393160	./IBM17/DATA/V00024200.H5
+393160	./IBM17/DATA/V00006300.H5
+393160	./IBM17/DATA/V00025100.H5
+393160	./IBM17/DATA/V00020500.H5
+393160	./IBM17/DATA/V00030400.H5
+393156	./IBM17/DATA/V00018300.H5
+393160	./IBM17/DATA/V00008200.H5
+393160	./IBM17/DATA/V00070400.H5
+393160	./IBM17/DATA/V00004300.H5
+393156	./IBM17/DATA/V00036400.H5
+393160	./IBM17/DATA/V00008000.H5
+393156	./IBM17/DATA/V00059200.H5
+393160	./IBM17/DATA/V00054400.H5
+393152	./IBM17/DATA/V00017100.H5
+393160	./IBM17/DATA/V00019000.H5
+393160	./IBM17/DATA/V00001800.H5
+393160	./IBM17/DATA/V00053600.H5
+393156	./IBM17/DATA/V00056800.H5
+393160	./IBM17/DATA/V00003800.H5
+393160	./IBM17/DATA/V00024400.H5
+393160	./IBM17/DATA/V00022200.H5
+393160	./IBM17/DATA/V00050400.H5
+393156	./IBM17/DATA/V00033400.H5
+393160	./IBM17/DATA/V00031000.H5
+393156	./IBM17/DATA/V00060800.H5
+393160	./IBM17/DATA/V00034800.H5
+393160	./IBM17/DATA/V00018600.H5
+393160	./IBM17/DATA/V00007500.H5
+393160	./IBM17/DATA/V00030800.H5
+393160	./IBM17/DATA/V00030200.H5
+393156	./IBM17/DATA/V00011000.H5
+393160	./IBM17/DATA/V00019200.H5
+393160	./IBM17/DATA/V00039400.H5
+393160	./IBM17/DATA/V00001500.H5
+393160	./IBM17/DATA/V00052400.H5
+393160	./IBM17/DATA/V00027800.H5
+393160	./IBM17/DATA/V00030000.H5
+393160	./IBM17/DATA/V00026200.H5
+393160	./IBM17/DATA/V00042200.H5
+393160	./IBM17/DATA/V00018000.H5
+393160	./IBM17/DATA/V00052600.H5
+393160	./IBM17/DATA/V00003900.H5
+393160	./IBM17/DATA/V00013500.H5
+393160	./IBM17/DATA/V00008900.H5
+393160	./IBM17/DATA/V00007900.H5
+393160	./IBM17/DATA/V00050600.H5
+393160	./IBM17/DATA/V00055800.H5
+393160	./IBM17/DATA/V00039600.H5
+393160	./IBM17/DATA/V00015200.H5
+393160	./IBM17/DATA/V00028500.H5
+393160	./IBM17/DATA/V00005100.H5
+393160	./IBM17/DATA/V00000200.H5
+393160	./IBM17/DATA/V00056200.H5
+393160	./IBM17/DATA/V00009600.H5
+393160	./IBM17/DATA/V00027400.H5
+393156	./IBM17/DATA/V00048600.H5
+393160	./IBM17/DATA/V00014700.H5
+393160	./IBM17/DATA/V00022500.H5
+393156	./IBM17/DATA/V00049600.H5
+393160	./IBM17/DATA/V00021300.H5
+393156	./IBM17/DATA/V00033000.H5
+393160	./IBM17/DATA/V00045800.H5
+393160	./IBM17/DATA/V00027200.H5
+393160	./IBM17/DATA/V00023600.H5
+393160	./IBM17/DATA/V00014900.H5
+393156	./IBM17/DATA/V00048200.H5
+393160	./IBM17/DATA/V00018800.H5
+393156	./IBM17/DATA/V00040600.H5
+393156	./IBM17/DATA/V00037600.H5
+393160	./IBM17/DATA/V00025800.H5
+393160	./IBM17/DATA/V00001300.H5
+393160	./IBM17/DATA/V00005200.H5
+393160	./IBM17/DATA/V00025300.H5
+393160	./IBM17/DATA/V00021800.H5
+393160	./IBM17/DATA/V00000700.H5
+393160	./IBM17/DATA/V00012800.H5
+393152	./IBM17/DATA/V00029100.H5
+393160	./IBM17/DATA/V00040800.H5
+393160	./IBM17/DATA/V00023400.H5
+393160	./IBM17/DATA/V00011400.H5
+393160	./IBM17/DATA/V00000900.H5
+393160	./IBM17/DATA/V00023100.H5
+393160	./IBM17/DATA/V00042800.H5
+393160	./IBM17/DATA/V00009300.H5
+393160	./IBM17/DATA/V00022100.H5
+393160	./IBM17/DATA/V00055200.H5
+393160	./IBM17/DATA/V00006700.H5
+393156	./IBM17/DATA/V00036000.H5
+393160	./IBM17/DATA/V00012200.H5
+393160	./IBM17/DATA/V00055400.H5
+393160	./IBM17/DATA/V00004500.H5
+393160	./IBM17/DATA/V00068000.H5
+393160	./IBM17/DATA/V00003500.H5
+393160	./IBM17/DATA/V00043000.H5
+393160	./IBM17/DATA/V00012300.H5
+393160	./IBM17/DATA/V00019800.H5
+393160	./IBM17/DATA/V00013300.H5
+393160	./IBM17/DATA/V00014800.H5
+393160	./IBM17/DATA/V00007600.H5
+393160	./IBM17/DATA/V00005300.H5
+393160	./IBM17/DATA/V00041600.H5
+393160	./IBM17/DATA/V00069600.H5
+393156	./IBM17/DATA/V00006600.H5
+393156	./IBM17/DATA/V00036800.H5
+393160	./IBM17/DATA/V00013200.H5
+393160	./IBM17/DATA/V00033600.H5
+393160	./IBM17/DATA/V00062400.H5
+393160	./IBM17/DATA/V00018200.H5
+393160	./IBM17/DATA/V00041000.H5
+393160	./IBM17/DATA/V00024600.H5
+393160	./IBM17/DATA/V00019600.H5
+393160	./IBM17/DATA/V00054000.H5
+393160	./IBM17/DATA/V00005900.H5
+393136	./IBM17/DATA/V00017300.H5
+393160	./IBM17/DATA/V00001700.H5
+393160	./IBM17/DATA/V00019500.H5
+393160	./IBM17/DATA/V00049000.H5
+393160	./IBM17/DATA/V00041400.H5
+393160	./IBM17/DATA/V00027300.H5
+393156	./IBM17/DATA/V00042600.H5
+393160	./IBM17/DATA/V00014100.H5
+393160	./IBM17/DATA/V00067600.H5
+393160	./IBM17/DATA/V00025700.H5
+393156	./IBM17/DATA/V00035800.H5
+393160	./IBM17/DATA/V00038800.H5
+393160	./IBM17/DATA/V00020800.H5
+393160	./IBM17/DATA/V00029900.H5
+393160	./IBM17/DATA/V00009700.H5
+393156	./IBM17/DATA/V00037400.H5
+393160	./IBM17/DATA/V00026600.H5
+393160	./IBM17/DATA/V00014500.H5
+393160	./IBM17/DATA/V00027000.H5
+393160	./IBM17/DATA/V00051200.H5
+393160	./IBM17/DATA/V00019300.H5
+393160	./IBM17/DATA/V00016100.H5
+393160	./IBM17/DATA/V00021200.H5
+393160	./IBM17/DATA/V00015400.H5
+393156	./IBM17/DATA/V00063200.H5
+393160	./IBM17/DATA/V00005800.H5
+393160	./IBM17/DATA/V00044800.H5
+393160	./IBM17/DATA/V00044200.H5
+393136	./IBM17/DATA/V00017500.H5
+393160	./IBM17/DATA/V00016400.H5
+393160	./IBM17/DATA/V00029200.H5
+393160	./IBM17/DATA/V00009900.H5
+393160	./IBM17/DATA/V00038000.H5
+393160	./IBM17/DATA/V00013100.H5
+393160	./IBM17/DATA/V00005600.H5
+393160	./IBM17/DATA/V00033800.H5
+393156	./IBM17/DATA/V00054600.H5
+393160	./IBM17/DATA/V00025200.H5
+393160	./IBM17/DATA/V00058800.H5
+393160	./IBM17/DATA/V00032600.H5
+393160	./IBM17/DATA/V00047400.H5
+393160	./IBM17/DATA/V00011700.H5
+393160	./IBM17/DATA/V00024100.H5
+393160	./IBM17/DATA/V00010300.H5
+393160	./IBM17/DATA/V00018100.H5
+393160	./IBM17/DATA/V00065200.H5
+393160	./IBM17/DATA/V00009200.H5
+393160	./IBM17/DATA/V00026500.H5
+393160	./IBM17/DATA/V00015900.H5
+393160	./IBM17/DATA/V00001000.H5
+393160	./IBM17/DATA/V00014600.H5
+393160	./IBM17/DATA/V00005000.H5
+393160	./IBM17/DATA/V00016800.H5
+393160	./IBM17/DATA/V00038200.H5
+393160	./IBM17/DATA/V00051600.H5
+393160	./IBM17/DATA/V00009400.H5
+393160	./IBM17/DATA/V00006500.H5
+393160	./IBM17/DATA/V00059600.H5
+393156	./IBM17/DATA/V00049400.H5
+393160	./IBM17/DATA/V00000800.H5
+393160	./IBM17/DATA/V00002300.H5
+393160	./IBM17/DATA/V00007200.H5
+393160	./IBM17/DATA/V00052200.H5
+393160	./IBM17/DATA/V00024300.H5
+393160	./IBM17/DATA/V00010400.H5
+393160	./IBM17/DATA/V00020100.H5
+393156	./IBM17/DATA/V00023300.H5
+393160	./IBM17/DATA/V00004900.H5
+393160	./IBM17/DATA/V00021900.H5
+393160	./IBM17/DATA/V00012400.H5
+393160	./IBM17/DATA/V00044000.H5
+393160	./IBM17/DATA/V00002900.H5
+393160	./IBM17/DATA/V00025600.H5
+393160	./IBM17/DATA/V00010600.H5
+393160	./IBM17/DATA/V00047800.H5
+393160	./IBM17/DATA/V00029800.H5
+393160	./IBM17/DATA/V00006100.H5
+393160	./IBM17/DATA/V00007400.H5
+393160	./IBM17/DATA/V00034000.H5
+393160	./IBM17/DATA/V00012700.H5
+393160	./IBM17/DATA/V00016900.H5
+393156	./IBM17/DATA/V00041200.H5
+393160	./IBM17/DATA/V00028300.H5
+393160	./IBM17/DATA/V00028000.H5
+393160	./IBM17/DATA/V00016700.H5
+393160	./IBM17/DATA/V00040000.H5
+393160	./IBM17/DATA/V00007000.H5
+393140	./IBM17/DATA/V00002600.H5
+393152	./IBM17/DATA/V00062800.H5
+393160	./IBM17/DATA/V00031400.H5
+393160	./IBM17/DATA/V00002000.H5
+393160	./IBM17/DATA/V00010000.H5
+393160	./IBM17/DATA/V00021100.H5
+393160	./IBM17/DATA/V00006000.H5
+393160	./IBM17/DATA/V00053200.H5
+393160	./IBM17/DATA/V00004000.H5
+393160	./IBM17/DATA/V00048000.H5
+393156	./IBM17/DATA/V00050800.H5
+393152	./IBM17/DATA/V00029000.H5
+393160	./IBM17/DATA/V00046800.H5
+393160	./IBM17/DATA/V00043800.H5
+393160	./IBM17/DATA/V00015300.H5
+393160	./IBM17/DATA/V00066800.H5
+393160	./IBM17/DATA/V00066400.H5
+393160	./IBM17/DATA/V00018500.H5
+393160	./IBM17/DATA/V00013600.H5
+393160	./IBM17/DATA/V00012900.H5
+393152	./IBM17/DATA/V00040200.H5
+393160	./IBM17/DATA/V00051000.H5
+393160	./IBM17/DATA/V00010200.H5
+393160	./IBM17/DATA/V00004800.H5
+393160	./IBM17/DATA/V00058000.H5
+393160	./IBM17/DATA/V00027900.H5
+393160	./IBM17/DATA/V00034400.H5
+393160	./IBM17/DATA/V00013800.H5
+393160	./IBM17/DATA/V00027600.H5
+393160	./IBM17/DATA/V00010700.H5
+393160	./IBM17/DATA/V00017600.H5
+393160	./IBM17/DATA/V00040400.H5
+393160	./IBM17/DATA/V00012000.H5
+393160	./IBM17/DATA/V00010900.H5
+393160	./IBM17/DATA/V00064000.H5
+393160	./IBM17/DATA/V00031200.H5
+393156	./IBM17/DATA/V00028600.H5
+393160	./IBM17/DATA/V00026100.H5
+393160	./IBM17/DATA/V00001200.H5
+393160	./IBM17/DATA/V00039200.H5
+393160	./IBM17/DATA/V00013000.H5
+393160	./IBM17/DATA/V00007800.H5
+393160	./IBM17/DATA/V00070000.H5
+393160	./IBM17/DATA/V00025500.H5
+393160	./IBM17/DATA/V00001400.H5
+393160	./IBM17/DATA/V00047200.H5
+393160	./IBM17/DATA/V00067200.H5
+393160	./IBM17/DATA/V00029400.H5
+393160	./IBM17/DATA/V00020600.H5
+393160	./IBM17/DATA/V00022400.H5
+393160	./IBM17/DATA/V00019700.H5
+393160	./IBM17/DATA/V00016000.H5
+393160	./IBM17/DATA/V00030100.H5
+393160	./IBM17/DATA/V00008300.H5
+393156	./IBM17/DATA/V00044600.H5
+393160	./IBM17/DATA/V00021700.H5
+393160	./IBM17/DATA/V00039800.H5
+393160	./IBM17/DATA/V00009800.H5
+393156	./IBM17/DATA/V00031800.H5
+393160	./IBM17/DATA/V00000400.H5
+393156	./IBM17/DATA/V00057600.H5
+393160	./IBM17/DATA/V00011800.H5
+393160	./IBM17/DATA/V00015000.H5
+393160	./IBM17/DATA/V00026300.H5
+393156	./IBM17/DATA/V00058400.H5
+393160	./IBM17/DATA/V00052800.H5
+393160	./IBM17/DATA/V00004700.H5
+393156	./IBM17/DATA/V00056400.H5
+393160	./IBM17/DATA/V00010500.H5
+393156	./IBM17/DATA/V00045600.H5
+393160	./IBM17/DATA/V00000500.H5
+393160	./IBM17/DATA/V00053000.H5
+393160	./IBM17/DATA/V00024000.H5
+393160	./IBM17/DATA/V00030500.H5
+393160	./IBM17/DATA/V00068400.H5
+393160	./IBM17/DATA/V00003400.H5
+393160	./IBM17/DATA/V00007700.H5
+393160	./IBM17/DATA/V00029600.H5
+393160	./IBM17/DATA/V00017700.H5
+393160	./IBM17/DATA/V00051800.H5
+393152	./IBM17/DATA/V00017200.H5
+393160	./IBM17/DATA/V00021400.H5
+393160	./IBM17/DATA/V00020200.H5
+393160	./IBM17/DATA/V00045000.H5
+393160	./IBM17/DATA/V00022300.H5
+393160	./IBM17/DATA/V00044400.H5
+393160	./IBM17/DATA/V00023000.H5
+393160	./IBM17/DATA/V00020300.H5
+393160	./IBM17/DATA/V00048400.H5
+393160	./IBM17/DATA/V00027700.H5
+393160	./IBM17/DATA/V00015600.H5
+393160	./IBM17/DATA/V00011200.H5
+393160	./IBM17/DATA/V00032800.H5
+393160	./IBM17/DATA/V00025400.H5
+393160	./IBM17/DATA/V00023200.H5
+393160	./IBM17/DATA/V00015500.H5
+393160	./IBM17/DATA/V00029300.H5
+393160	./IBM17/DATA/V00064400.H5
+393160	./IBM17/DATA/V00012500.H5
+393160	./IBM17/DATA/V00024800.H5
+393160	./IBM17/DATA/V00019900.H5
+393160	./IBM17/DATA/V00015100.H5
+393160	./IBM17/DATA/V00050200.H5
+393160	./IBM17/DATA/V00055600.H5
+393160	./IBM17/DATA/V00026400.H5
+393160	./IBM17/DATA/V00054800.H5
+393160	./IBM17/DATA/V00018700.H5
+393160	./IBM17/DATA/V00035600.H5
+393160	./IBM17/DATA/V00004200.H5
+393160	./IBM17/DATA/V00029700.H5
+393160	./IBM17/DATA/V00000100.H5
+393160	./IBM17/DATA/V00012600.H5
+393160	./IBM17/DATA/V00035000.H5
+393160	./IBM17/DATA/V00018900.H5
+393132	./IBM17/DATA/V00023800.H5
+393160	./IBM17/DATA/V00014300.H5
+393160	./IBM17/DATA/V00060400.H5
+393148	./IBM17/DATA/V00002500.H5
+393160	./IBM17/DATA/V00023500.H5
+393160	./IBM17/DATA/V00016500.H5
+393160	./IBM17/DATA/V00024900.H5
+393156	./IBM17/DATA/V00006200.H5
+393160	./IBM17/DATA/V00003200.H5
+393160	./IBM17/DATA/V00002700.H5
+393160	./IBM17/DATA/V00030700.H5
+393160	./IBM17/DATA/V00035400.H5
+393156	./IBM17/DATA/V00037800.H5
+393160	./IBM17/DATA/V00016300.H5
+393160	./IBM17/DATA/V00008400.H5
+393160	./IBM17/DATA/V00053400.H5
+393160	./IBM17/DATA/V00028100.H5
+393160	./IBM17/DATA/V00030900.H5
+393160	./IBM17/DATA/V00025900.H5
+393160	./IBM17/DATA/V00011300.H5
+393160	./IBM17/DATA/V00011500.H5
+393156	./IBM17/DATA/V00030300.H5
+393160	./IBM17/DATA/V00017900.H5
+393148	./IBM17/DATA/V00002400.H5
+393160	./IBM17/DATA/V00066000.H5
+393160	./IBM17/DATA/V00004400.H5
+393160	./IBM17/DATA/V00018400.H5
+393160	./IBM17/DATA/V00009000.H5
+393156	./IBM17/DATA/V00028800.H5
+393160	./IBM17/DATA/V00020000.H5
+393160	./IBM17/DATA/V00026700.H5
+393160	./IBM17/DATA/V00033200.H5
+393160	./IBM17/DATA/V00022600.H5
+393160	./IBM17/DATA/V00008500.H5
+393156	./IBM17/DATA/V00043200.H5
+393160	./IBM17/DATA/V00010100.H5
+393160	./IBM17/DATA/V00013700.H5
+393160	./IBM17/DATA/V00051400.H5
+393160	./IBM17/DATA/V00008800.H5
+393160	./IBM17/DATA/V00070800.H5
+393160	./IBM17/DATA/V00032200.H5
+393160	./IBM17/DATA/V00007300.H5
+393152	./IBM17/DATA/V00000000.H5
+393160	./IBM17/DATA/V00006800.H5
+393160	./IBM17/DATA/V00003700.H5
+393160	./IBM17/DATA/V00041800.H5
+393160	./IBM17/DATA/V00017800.H5
+393160	./IBM17/DATA/V00007100.H5
+393160	./IBM17/DATA/V00000600.H5
+393160	./IBM17/DATA/V00027500.H5
+393160	./IBM17/DATA/V00026900.H5
+393160	./IBM17/DATA/V00069200.H5
+393160	./IBM17/DATA/V00008700.H5
+393160	./IBM17/DATA/V00047600.H5
+393160	./IBM17/DATA/V00042000.H5
+393160	./IBM17/DATA/V00068800.H5
+393160	./IBM17/DATA/V00015800.H5
+393160	./IBM17/DATA/V00001100.H5
+393160	./IBM17/DATA/V00052000.H5
+393160	./IBM17/DATA/V00029500.H5
+393160	./IBM17/DATA/V00032400.H5
+393160	./IBM17/DATA/V00024700.H5
+393160	./IBM17/DATA/V00014200.H5
+393160	./IBM17/DATA/V00014000.H5
+393152	./IBM17/DATA/V00028900.H5
+393160	./IBM17/DATA/V00036200.H5
+393160	./IBM17/DATA/V00022800.H5
+393160	./IBM17/DATA/V00003600.H5
+393160	./IBM17/DATA/V00065600.H5
+393160	./IBM17/DATA/V00016600.H5
+393160	./IBM17/DATA/V00011100.H5
+393160	./IBM17/DATA/V00002100.H5
+393160	./IBM17/DATA/V00050000.H5
+393156	./IBM17/DATA/V00035200.H5
+393160	./IBM17/DATA/V00030600.H5
+393160	./IBM17/DATA/V00001600.H5
+393160	./IBM17/DATA/V00009500.H5
+393160	./IBM17/DATA/V00000300.H5
+393160	./IBM17/DATA/V00028400.H5
+393160	./IBM17/DATA/V00022000.H5
+393160	./IBM17/DATA/V00014400.H5
+393160	./IBM17/DATA/V00064800.H5
+393160	./IBM17/DATA/V00005700.H5
+393160	./IBM17/DATA/V00020400.H5
+393160	./IBM17/DATA/V00043600.H5
+393160	./IBM17/DATA/V00062000.H5
+393160	./IBM17/DATA/V00046200.H5
+393160	./IBM17/DATA/V00002800.H5
+393160	./IBM17/DATA/V00049800.H5
+393160	./IBM17/DATA/V00003300.H5
+393160	./IBM17/DATA/V00046400.H5
+393160	./IBM17/DATA/V00048800.H5
+393136	./IBM17/DATA/V00017400.H5
+393160	./IBM17/DATA/V00061600.H5
+393160	./IBM17/DATA/V00036600.H5
+393160	./IBM17/DATA/V00011900.H5
+393160	./IBM17/DATA/V00055000.H5
+393160	./IBM17/DATA/V00012100.H5
+393160	./IBM17/DATA/V00032000.H5
+393160	./IBM17/DATA/V00006900.H5
+393160	./IBM17/DATA/V00057200.H5
+393160	./IBM17/DATA/V00021000.H5
+393156	./IBM17/DATA/V00054200.H5
+393160	./IBM17/DATA/V00049200.H5
+393160	./IBM17/DATA/V00060000.H5
+393160	./IBM17/DATA/V00026000.H5
+393160	./IBM17/DATA/V00011600.H5
+393160	./IBM17/DATA/V00027100.H5
+393160	./IBM17/DATA/V00005400.H5
+393160	./IBM17/DATA/V00022900.H5
+393160	./IBM17/DATA/V00026800.H5
+393144	./IBM17/DATA/V00020900.H5
+393160	./IBM17/DATA/V00037200.H5
+393160	./IBM17/DATA/V00038400.H5
+393148	./IBM17/DATA/V00017000.H5
+393156	./IBM17/DATA/V00028700.H5
+393160	./IBM17/DATA/V00019400.H5
+393160	./IBM17/DATA/V00023700.H5
+393160	./IBM17/DATA/V00025000.H5
+393160	./IBM17/DATA/V00043400.H5
+393160	./IBM17/DATA/V00031600.H5
+393160	./IBM17/DATA/V00046000.H5
+393160	./IBM17/DATA/V00042400.H5
+393160	./IBM17/DATA/V00013400.H5
+393160	./IBM17/DATA/V00022700.H5
+393160	./IBM17/DATA/V00003100.H5
+393160	./IBM17/DATA/V00046600.H5
+393160	./IBM17/DATA/V00038600.H5
+393160	./IBM17/DATA/V00006400.H5
+393160	./IBM17/DATA/V00003000.H5
+393160	./IBM17/DATA/V00045200.H5
+393160	./IBM17/DATA/V00063600.H5
+393160	./IBM17/DATA/V00008600.H5
+393160	./IBM17/DATA/V00053800.H5
+393160	./IBM17/DATA/V00004100.H5
+393160	./IBM17/DATA/V00015700.H5
+393160	./IBM17/DATA/V00024500.H5
+325612	./IBM17/DATA/V00071200.H5
+393160	./IBM17/DATA/V00010800.H5
+393160	./IBM17/DATA/V00002200.H5
+393160	./IBM17/DATA/V00020700.H5
+393160	./IBM17/DATA/V00005500.H5
+393160	./IBM17/DATA/V00021600.H5
+393160	./IBM17/DATA/V00061200.H5
+393160	./IBM17/DATA/V00034200.H5
+393160	./IBM17/DATA/V00056000.H5
+393160	./IBM17/DATA/V00009100.H5
+393160	./IBM17/DATA/V00001900.H5
+393160	./IBM17/DATA/V00008100.H5
+393160	./IBM17/DATA/V00047000.H5
+393160	./IBM17/DATA/V00039000.H5
+393160	./IBM17/DATA/V00028200.H5
+393160	./IBM17/DATA/V00004600.H5
+393156	./IBM17/DATA/V00034600.H5
+393160	./IBM17/DATA/V00013900.H5
+393160	./IBM17/DATA/V00016200.H5
+393160	./IBM17/DATA/V00045400.H5
+393160	./IBM17/DATA/V00021500.H5
+186683084	./IBM17/DATA
+du: cannot access `./IBM17/POST_BASIC/POST_020_STATS.F90': Permission denied
+du: cannot access `./IBM17/POST_BASIC/POST_030_READFILE.F90': Permission denied
+du: cannot access `./IBM17/POST_BASIC/POST_031_PARALLEL.F90': Permission denied
+du: cannot access `./IBM17/POST_BASIC/POST_000_MAIN.F90': Permission denied
+du: cannot access `./IBM17/POST_BASIC/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM17/POST_BASIC/POST_040_AVERAGE.F90': Permission denied
+du: cannot access `./IBM17/POST_BASIC/POST_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM17/POST_BASIC/POST_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM17/POST_BASIC/POST_050_WRITEFILE.F90': Permission denied
+du: cannot access `./IBM17/POST_BASIC/POST_010_INIT_PARALLEL.F90': Permission denied
+4	./IBM17/POST_BASIC
+460	./IBM17/gatherdata
+4	./IBM17/aegean_stream.sh
+7508	./IBM17/sink.dat
+8	./IBM17/Makefile
+4	./IBM17/WAVE
+241376	./IBM17/tp1dIgRqn
+4	./IBM17/RESTART_SOLID
+475944	./IBM17/STATS/BASIC.H5
+4	./IBM17/STATS/STAT_STEP
+475952	./IBM17/STATS
+4	./IBM17/resga
+4948	./IBM17/sour.dat
+4	./IBM17/aga.sh
+241376	./IBM17/tp18PUyUS
+4	./IBM17/PARAM.IN
+4	./IBM17/CIRC_VELO
+15956	./IBM17/TIME_SERIES/MAXUVW.DAT
+2676	./IBM17/TIME_SERIES/YTIP.DAT
+8996	./IBM17/TIME_SERIES/CDCF.DAT
+27632	./IBM17/TIME_SERIES
+du: cannot access `./IBM17/GATHERDATA/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM17/GATHERDATA/GATHER_IO.o': Permission denied
+du: cannot access `./IBM17/GATHERDATA/tecio.f90': Permission denied
+du: cannot access `./IBM17/GATHERDATA/GATHER_IO.F90': Permission denied
+du: cannot access `./IBM17/GATHERDATA/GATHERDATA.o': Permission denied
+du: cannot access `./IBM17/GATHERDATA/GATHERDATA.F90': Permission denied
+4	./IBM17/GATHERDATA
+17680	./IBM17/wave
+du: cannot access `./IBM17/POST_WAVY_WALL/POST_030_READFILE.F90': Permission denied
+du: cannot access `./IBM17/POST_WAVY_WALL/POST_000_MAIN.F90': Permission denied
+du: cannot access `./IBM17/POST_WAVY_WALL/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM17/POST_WAVY_WALL/POST_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM17/POST_WAVY_WALL/POST_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM17/POST_WAVY_WALL/POST_040_WRITEFILE.F90': Permission denied
+du: cannot access `./IBM17/POST_WAVY_WALL/POST_020_AVERAGE.F90': Permission denied
+du: cannot access `./IBM17/POST_WAVY_WALL/POST_010_INIT_PARALLEL.F90': Permission denied
+4	./IBM17/POST_WAVY_WALL
+du: cannot read directory `./IBM17/TRACER': Permission denied
+4	./IBM17/TRACER
+8	./IBM17/GRID.IN
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/4600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/17500.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/6900.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/5400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/19500.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/6000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/15700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/26600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/9300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/45400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/30900.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/2200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/29500.png
+24	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/9000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/23000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/5500.png
+24	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/100.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/10200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/17400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/2400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/18700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/63200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/51800.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/8500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/15000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/10800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/19600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/47200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/18600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/17300.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/11300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/50400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/63600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/6800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/29800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/60000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/7900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/54600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/47800.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/1400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/50000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/46400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/23600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/11700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/11500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/25600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/17200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/14000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/1300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/60400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/12100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/35200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/16700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/37600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/24900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/29000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/13200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/7500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/56000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/21800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/28300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/26200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/6400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/48600.png
+28	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/600.png
+32	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/800.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/4300.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/20000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/5700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/22500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/30400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/49600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/10600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/49800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/41200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/14900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/55000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/27500.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/20100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/65200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/3700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/13400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/10900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/61600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/6100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/45000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/4100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/15600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/43400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/32800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/36400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/20400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/2500.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/9600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/40400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/10300.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/11200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/29200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/15200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/26100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/37800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/33400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/56400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/10500.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/13800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/39800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/37200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/10700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/27700.png
+32	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/34800.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/3100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/51200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/26500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/12900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/27800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/16900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/22000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/44800.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/4200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/21300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/12300.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/8800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/42800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/13500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/47000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/11400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/38400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/15400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/8100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/28100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/35000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/27600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/27300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/30700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/18900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/19300.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/8600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/12600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/24300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/39400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/25000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/2100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/19800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/31400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/16500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/26400.png
+36	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/1000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/22400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/41800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/53800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/12200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/58800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/23500.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/3000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/4000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/19900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/62800.png
+28	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/700.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/1500.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/4400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/21600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/30800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/64400.png
+28	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/38200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/60800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/29900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/15800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/40600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/54800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/40000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/7700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/23400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/26700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/58000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/24600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/9800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/37000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/24800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/23100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/32400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/25400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/20700.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/1700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/53600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/51400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/13900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/29300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/17600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/13000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/26900.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/5800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/21100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/12700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/12400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/43000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/27200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/20300.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/7000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/21900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/42400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/11100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/14500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/55200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/50800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/58400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/7400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/28600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/66000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/22700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/59200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/23800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/13300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/27100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/70000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/24100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/64800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/24700.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/10100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/65600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/26300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/52800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/11800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/23900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/34200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/18400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/38800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/29600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/8300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/56200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/52000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/25500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/28400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/24200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/24400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/54200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/16800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/14800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/24000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/5900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/34400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/20500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/33000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/30600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/39600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/23700.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/6200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/2300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/48800.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/12000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/29100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/23200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/14600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/48000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/1800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/30500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/42600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/17800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/49400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/48400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/52400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/43200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/47600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/8200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/8700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/34600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/12800.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/7600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/16200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/11000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/53400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/44400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/3200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/20200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/5300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/30200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/46000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/16600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/39000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/19000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/8000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/22200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/31800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/29700.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/3300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/25800.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/5200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/18300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/21400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/12500.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/9200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/11900.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/14100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/70400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/17000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/22800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/54400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/21500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/53000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/30000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/7100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/36000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/18000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/45600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/27000.png
+24	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/26800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/28900.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/6600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/33200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/5000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/10000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/13600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/6700.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/9700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/49000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/17700.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/2600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/3900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/33800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/41400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/5100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/45800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/25900.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/3500.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/8900.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/15500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/36600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/9100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/19700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/30100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/47400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/40800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/55400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/20600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/26000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/15100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/43800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/30300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/25200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/2900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/38000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/21700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/19200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/17900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/32600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/22100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/64000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/62400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/4900.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/14300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/36800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/28000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/13700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/50600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/28700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/19100.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/3800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/57200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/19400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/16300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/48200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/6300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/46800.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/2800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/31000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/7300.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/3600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/28800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/14700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/27400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/49200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/39200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/43600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/14200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/4800.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/6500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/51000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/35600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/42200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/18200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/16400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/31200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/37400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/21200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/38600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/4700.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/5600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/44600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/20800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/55800.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/9500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/31600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/8400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/1600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/52200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/33600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/59600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/28200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/53200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/34000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/70800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/42000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/13100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/22900.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/9900.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/10400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/35800.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/7200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/18100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/18800.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/7800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/62000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/27900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/16000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/57600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/24500.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/1900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/22600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/28500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/51600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/41000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/32200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/16100.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/1100.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/2700.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/4500.png
+24	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/25300.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/9400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/50200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/23300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/35400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/44200.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/2000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/21000.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/3400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/54000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/15300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/46600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/1200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/55600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/11600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/41600.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/17100.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/25100.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/14400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/56800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/46200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/18500.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/36200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/52600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/45200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/15900.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/32000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/29400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/44000.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/25700.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/40200.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/22300.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000/61200.png
+19716	./IBM17/INSTANTANEOUS/figure_vortex_f_Re1000
+32	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/4600.png
+36	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/5400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/6000.png
+20	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/2200.png
+16	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/200.png
+20	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/2400.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/6800.png
+16	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/1400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/6400.png
+16	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/600.png
+16	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/800.png
+32	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/4200.png
+16	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/1000.png
+24	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/3000.png
+28	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/4000.png
+32	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/4400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/5800.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/7000.png
+48	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/7400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/6200.png
+16	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/1800.png
+48	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/8200.png
+48	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/7600.png
+24	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/3200.png
+48	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/8000.png
+36	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/5200.png
+16	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/400.png
+40	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/6600.png
+32	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/5000.png
+20	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/2600.png
+28	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/3800.png
+24	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/2800.png
+28	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/3600.png
+32	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/4800.png
+36	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/5600.png
+52	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/8400.png
+16	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/1600.png
+44	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/7200.png
+48	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/7800.png
+16	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/2000.png
+28	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/3400.png
+16	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000/1200.png
+1300	./IBM17/INSTANTANEOUS/figure_vortex_f_Re100000
+56	./IBM17/INSTANTANEOUS/batch.log
+28	./IBM17/INSTANTANEOUS/vortex_f.lay
+4	./IBM17/INSTANTANEOUS/vortex_f.mcr
+21136	./IBM17/INSTANTANEOUS
+28	./IBM17/FLUX/00024200f.dat
+28	./IBM17/FLUX/00030600f.dat
+28	./IBM17/FLUX/00009600f.dat
+28	./IBM17/FLUX/00031000f.dat
+28	./IBM17/FLUX/00000000f.dat
+28	./IBM17/FLUX/00020800f.dat
+28	./IBM17/FLUX/00003400f.dat
+28	./IBM17/FLUX/00006600f.dat
+28	./IBM17/FLUX/00040600f.dat
+28	./IBM17/FLUX/00027400f.dat
+28	./IBM17/FLUX/00011200f.dat
+28	./IBM17/FLUX/00054600f.dat
+28	./IBM17/FLUX/00047000f.dat
+28	./IBM17/FLUX/00021000f.dat
+28	./IBM17/FLUX/00029000f.dat
+28	./IBM17/FLUX/00019200f.dat
+28	./IBM17/FLUX/00016000f.dat
+28	./IBM17/FLUX/00014400f.dat
+28	./IBM17/FLUX/00001600f.dat
+28	./IBM17/FLUX/00063200f.dat
+28	./IBM17/FLUX/00037400f.dat
+28	./IBM17/FLUX/00006400f.dat
+28	./IBM17/FLUX/00000200f.dat
+28	./IBM17/FLUX/00004800f.dat
+28	./IBM17/FLUX/00025800f.dat
+28	./IBM17/FLUX/00053400f.dat
+28	./IBM17/FLUX/00003200f.dat
+28	./IBM17/FLUX/00008000f.dat
+28	./IBM17/FLUX/00043800f.dat
+28	./IBM17/FLUX/00034200f.dat
+28	./IBM17/FLUX/00050200f.dat
+28	./IBM17/FLUX/00017600f.dat
+28	./IBM17/FLUX/00012800f.dat
+28	./IBM17/FLUX/00022600f.dat
+28	./IBM17/FLUX/00056800f.dat
+28	./IBM17/FLUX/00069600f.dat
+1012	./IBM17/FLUX
+3424	./IBM17/results_aegean
+241376	./IBM17/tp1uK2Pn3
+8	./IBM17/SURFACE/00033050.dat
+8	./IBM17/SURFACE/00039800.dat
+8	./IBM17/SURFACE/00024400.dat
+8	./IBM17/SURFACE/00035300.dat
+8	./IBM17/SURFACE/00002850.dat
+8	./IBM17/SURFACE/00069550.dat
+8	./IBM17/SURFACE/00046450.dat
+8	./IBM17/SURFACE/00025200.dat
+8	./IBM17/SURFACE/00061250.dat
+8	./IBM17/SURFACE/00047800.dat
+8	./IBM17/SURFACE/00047900.dat
+8	./IBM17/SURFACE/00048750.dat
+8	./IBM17/SURFACE/00003250.dat
+8	./IBM17/SURFACE/00048050.dat
+8	./IBM17/SURFACE/00031850.dat
+8	./IBM17/SURFACE/00005900.dat
+8	./IBM17/SURFACE/00056750.dat
+8	./IBM17/SURFACE/00010950.dat
+8	./IBM17/SURFACE/00066900.dat
+8	./IBM17/SURFACE/00052550.dat
+8	./IBM17/SURFACE/00016350.dat
+8	./IBM17/SURFACE/00010700.dat
+8	./IBM17/SURFACE/00028100.dat
+8	./IBM17/SURFACE/00032950.dat
+8	./IBM17/SURFACE/00057600.dat
+8	./IBM17/SURFACE/00070700.dat
+8	./IBM17/SURFACE/00041300.dat
+8	./IBM17/SURFACE/00016500.dat
+8	./IBM17/SURFACE/00012650.dat
+8	./IBM17/SURFACE/00009400.dat
+8	./IBM17/SURFACE/00047100.dat
+8	./IBM17/SURFACE/00056450.dat
+8	./IBM17/SURFACE/00052300.dat
+8	./IBM17/SURFACE/00058600.dat
+8	./IBM17/SURFACE/00053000.dat
+8	./IBM17/SURFACE/00018950.dat
+8	./IBM17/SURFACE/00043250.dat
+8	./IBM17/SURFACE/00024900.dat
+8	./IBM17/SURFACE/00032650.dat
+8	./IBM17/SURFACE/00009850.dat
+8	./IBM17/SURFACE/00040800.dat
+8	./IBM17/SURFACE/00035500.dat
+8	./IBM17/SURFACE/00034200.dat
+8	./IBM17/SURFACE/00051500.dat
+8	./IBM17/SURFACE/00013150.dat
+8	./IBM17/SURFACE/00019950.dat
+8	./IBM17/SURFACE/00029450.dat
+8	./IBM17/SURFACE/00028750.dat
+8	./IBM17/SURFACE/00026250.dat
+8	./IBM17/SURFACE/00031550.dat
+8	./IBM17/SURFACE/00064400.dat
+8	./IBM17/SURFACE/00032900.dat
+8	./IBM17/SURFACE/00062650.dat
+8	./IBM17/SURFACE/00052450.dat
+8	./IBM17/SURFACE/00014300.dat
+8	./IBM17/SURFACE/00067600.dat
+8	./IBM17/SURFACE/00064350.dat
+8	./IBM17/SURFACE/00042450.dat
+8	./IBM17/SURFACE/00007200.dat
+8	./IBM17/SURFACE/00058800.dat
+8	./IBM17/SURFACE/00031350.dat
+8	./IBM17/SURFACE/00021400.dat
+8	./IBM17/SURFACE/00055000.dat
+8	./IBM17/SURFACE/00067750.dat
+8	./IBM17/SURFACE/00018550.dat
+8	./IBM17/SURFACE/00053200.dat
+8	./IBM17/SURFACE/00013600.dat
+8	./IBM17/SURFACE/00065500.dat
+8	./IBM17/SURFACE/00004950.dat
+8	./IBM17/SURFACE/00004450.dat
+8	./IBM17/SURFACE/00050300.dat
+8	./IBM17/SURFACE/00070400.dat
+8	./IBM17/SURFACE/00033900.dat
+8	./IBM17/SURFACE/00020800.dat
+8	./IBM17/SURFACE/00009000.dat
+8	./IBM17/SURFACE/00014250.dat
+8	./IBM17/SURFACE/00024300.dat
+8	./IBM17/SURFACE/00036750.dat
+8	./IBM17/SURFACE/00040300.dat
+8	./IBM17/SURFACE/00043700.dat
+8	./IBM17/SURFACE/00035450.dat
+8	./IBM17/SURFACE/00009450.dat
+8	./IBM17/SURFACE/00052400.dat
+8	./IBM17/SURFACE/00039950.dat
+8	./IBM17/SURFACE/00011600.dat
+8	./IBM17/SURFACE/00051900.dat
+8	./IBM17/SURFACE/00002950.dat
+8	./IBM17/SURFACE/00001650.dat
+8	./IBM17/SURFACE/00026050.dat
+8	./IBM17/SURFACE/00039200.dat
+8	./IBM17/SURFACE/00034350.dat
+8	./IBM17/SURFACE/00041700.dat
+8	./IBM17/SURFACE/00058500.dat
+8	./IBM17/SURFACE/00047050.dat
+8	./IBM17/SURFACE/00026900.dat
+8	./IBM17/SURFACE/00030550.dat
+8	./IBM17/SURFACE/00054450.dat
+8	./IBM17/SURFACE/00042850.dat
+8	./IBM17/SURFACE/00010800.dat
+8	./IBM17/SURFACE/00028900.dat
+8	./IBM17/SURFACE/00034750.dat
+8	./IBM17/SURFACE/00024350.dat
+8	./IBM17/SURFACE/00006100.dat
+8	./IBM17/SURFACE/00015700.dat
+8	./IBM17/SURFACE/00048000.dat
+8	./IBM17/SURFACE/00049150.dat
+8	./IBM17/SURFACE/00016750.dat
+8	./IBM17/SURFACE/00040600.dat
+8	./IBM17/SURFACE/00015200.dat
+8	./IBM17/SURFACE/00046500.dat
+8	./IBM17/SURFACE/00016250.dat
+8	./IBM17/SURFACE/00011100.dat
+8	./IBM17/SURFACE/00004300.dat
+8	./IBM17/SURFACE/00049550.dat
+8	./IBM17/SURFACE/00012350.dat
+8	./IBM17/SURFACE/00021000.dat
+8	./IBM17/SURFACE/00048100.dat
+8	./IBM17/SURFACE/00022300.dat
+8	./IBM17/SURFACE/00042050.dat
+8	./IBM17/SURFACE/00033950.dat
+8	./IBM17/SURFACE/00052800.dat
+8	./IBM17/SURFACE/00057850.dat
+8	./IBM17/SURFACE/00068650.dat
+8	./IBM17/SURFACE/00066600.dat
+8	./IBM17/SURFACE/00005000.dat
+8	./IBM17/SURFACE/00037300.dat
+8	./IBM17/SURFACE/00030450.dat
+8	./IBM17/SURFACE/00041550.dat
+8	./IBM17/SURFACE/00059150.dat
+8	./IBM17/SURFACE/00006250.dat
+8	./IBM17/SURFACE/00040250.dat
+8	./IBM17/SURFACE/00037400.dat
+8	./IBM17/SURFACE/00019300.dat
+8	./IBM17/SURFACE/00044300.dat
+8	./IBM17/SURFACE/00053550.dat
+8	./IBM17/SURFACE/00023300.dat
+8	./IBM17/SURFACE/00048550.dat
+8	./IBM17/SURFACE/00007050.dat
+8	./IBM17/SURFACE/00012600.dat
+8	./IBM17/SURFACE/00037600.dat
+8	./IBM17/SURFACE/00040650.dat
+8	./IBM17/SURFACE/00026200.dat
+8	./IBM17/SURFACE/00044900.dat
+8	./IBM17/SURFACE/00062750.dat
+8	./IBM17/SURFACE/00055550.dat
+8	./IBM17/SURFACE/00062450.dat
+8	./IBM17/SURFACE/00033400.dat
+8	./IBM17/SURFACE/00001500.dat
+8	./IBM17/SURFACE/00036900.dat
+8	./IBM17/SURFACE/00037350.dat
+8	./IBM17/SURFACE/00011300.dat
+8	./IBM17/SURFACE/00042300.dat
+8	./IBM17/SURFACE/00023200.dat
+8	./IBM17/SURFACE/00056400.dat
+8	./IBM17/SURFACE/00047000.dat
+8	./IBM17/SURFACE/00059650.dat
+8	./IBM17/SURFACE/00049200.dat
+8	./IBM17/SURFACE/00003300.dat
+8	./IBM17/SURFACE/00007300.dat
+8	./IBM17/SURFACE/00017400.dat
+8	./IBM17/SURFACE/00004550.dat
+8	./IBM17/SURFACE/00007950.dat
+8	./IBM17/SURFACE/00056000.dat
+8	./IBM17/SURFACE/00022000.dat
+8	./IBM17/SURFACE/00008100.dat
+8	./IBM17/SURFACE/00059800.dat
+8	./IBM17/SURFACE/00027700.dat
+8	./IBM17/SURFACE/00034700.dat
+8	./IBM17/SURFACE/00050800.dat
+8	./IBM17/SURFACE/00014850.dat
+8	./IBM17/SURFACE/00068950.dat
+8	./IBM17/SURFACE/00039650.dat
+8	./IBM17/SURFACE/00007800.dat
+8	./IBM17/SURFACE/00005300.dat
+8	./IBM17/SURFACE/00018000.dat
+8	./IBM17/SURFACE/00005700.dat
+8	./IBM17/SURFACE/00020300.dat
+8	./IBM17/SURFACE/00004500.dat
+8	./IBM17/SURFACE/00061450.dat
+8	./IBM17/SURFACE/00018800.dat
+8	./IBM17/SURFACE/00017750.dat
+8	./IBM17/SURFACE/00003100.dat
+8	./IBM17/SURFACE/00056300.dat
+8	./IBM17/SURFACE/00063550.dat
+8	./IBM17/SURFACE/00018400.dat
+8	./IBM17/SURFACE/00054950.dat
+8	./IBM17/SURFACE/00050500.dat
+8	./IBM17/SURFACE/00043200.dat
+8	./IBM17/SURFACE/00035100.dat
+8	./IBM17/SURFACE/00060750.dat
+8	./IBM17/SURFACE/00041600.dat
+8	./IBM17/SURFACE/00034400.dat
+8	./IBM17/SURFACE/00023250.dat
+8	./IBM17/SURFACE/00008650.dat
+8	./IBM17/SURFACE/00023150.dat
+8	./IBM17/SURFACE/00007450.dat
+8	./IBM17/SURFACE/00043950.dat
+8	./IBM17/SURFACE/00053950.dat
+8	./IBM17/SURFACE/00029250.dat
+8	./IBM17/SURFACE/00013400.dat
+8	./IBM17/SURFACE/00004150.dat
+8	./IBM17/SURFACE/00041050.dat
+8	./IBM17/SURFACE/00016050.dat
+8	./IBM17/SURFACE/00036650.dat
+8	./IBM17/SURFACE/00069000.dat
+8	./IBM17/SURFACE/00025700.dat
+8	./IBM17/SURFACE/00051200.dat
+8	./IBM17/SURFACE/00036350.dat
+8	./IBM17/SURFACE/00067100.dat
+8	./IBM17/SURFACE/00020650.dat
+8	./IBM17/SURFACE/00050100.dat
+8	./IBM17/SURFACE/00058700.dat
+8	./IBM17/SURFACE/00006850.dat
+8	./IBM17/SURFACE/00046300.dat
+8	./IBM17/SURFACE/00060250.dat
+8	./IBM17/SURFACE/00039400.dat
+8	./IBM17/SURFACE/00037450.dat
+8	./IBM17/SURFACE/00064200.dat
+8	./IBM17/SURFACE/00058650.dat
+8	./IBM17/SURFACE/00046950.dat
+8	./IBM17/SURFACE/00027000.dat
+8	./IBM17/SURFACE/00009650.dat
+8	./IBM17/SURFACE/00000750.dat
+8	./IBM17/SURFACE/00046900.dat
+8	./IBM17/SURFACE/00019750.dat
+8	./IBM17/SURFACE/00068350.dat
+8	./IBM17/SURFACE/00068750.dat
+8	./IBM17/SURFACE/00041750.dat
+8	./IBM17/SURFACE/00068200.dat
+8	./IBM17/SURFACE/00030500.dat
+8	./IBM17/SURFACE/00057150.dat
+8	./IBM17/SURFACE/00040850.dat
+8	./IBM17/SURFACE/00000100.dat
+8	./IBM17/SURFACE/00028700.dat
+8	./IBM17/SURFACE/00066000.dat
+8	./IBM17/SURFACE/00066350.dat
+8	./IBM17/SURFACE/00002700.dat
+8	./IBM17/SURFACE/00040750.dat
+8	./IBM17/SURFACE/00038500.dat
+8	./IBM17/SURFACE/00005650.dat
+8	./IBM17/SURFACE/00043050.dat
+8	./IBM17/SURFACE/00041500.dat
+8	./IBM17/SURFACE/00003450.dat
+8	./IBM17/SURFACE/00061150.dat
+8	./IBM17/SURFACE/00042550.dat
+8	./IBM17/SURFACE/00009100.dat
+8	./IBM17/SURFACE/00041800.dat
+8	./IBM17/SURFACE/00060550.dat
+8	./IBM17/SURFACE/00062600.dat
+8	./IBM17/SURFACE/00069950.dat
+8	./IBM17/SURFACE/00051550.dat
+8	./IBM17/SURFACE/00068800.dat
+8	./IBM17/SURFACE/00056200.dat
+8	./IBM17/SURFACE/00052750.dat
+8	./IBM17/SURFACE/00019150.dat
+8	./IBM17/SURFACE/00062700.dat
+8	./IBM17/SURFACE/00010400.dat
+8	./IBM17/SURFACE/00067900.dat
+8	./IBM17/SURFACE/00060700.dat
+8	./IBM17/SURFACE/00009250.dat
+8	./IBM17/SURFACE/00066150.dat
+8	./IBM17/SURFACE/00034600.dat
+8	./IBM17/SURFACE/00037100.dat
+8	./IBM17/SURFACE/00067400.dat
+8	./IBM17/SURFACE/00069750.dat
+8	./IBM17/SURFACE/00012800.dat
+8	./IBM17/SURFACE/00024050.dat
+8	./IBM17/SURFACE/00062800.dat
+8	./IBM17/SURFACE/00052350.dat
+8	./IBM17/SURFACE/00047150.dat
+8	./IBM17/SURFACE/00028550.dat
+8	./IBM17/SURFACE/00071000.dat
+8	./IBM17/SURFACE/00050050.dat
+8	./IBM17/SURFACE/00029000.dat
+8	./IBM17/SURFACE/00055500.dat
+8	./IBM17/SURFACE/00028850.dat
+8	./IBM17/SURFACE/00021800.dat
+8	./IBM17/SURFACE/00000200.dat
+8	./IBM17/SURFACE/00049450.dat
+8	./IBM17/SURFACE/00070950.dat
+8	./IBM17/SURFACE/00049000.dat
+8	./IBM17/SURFACE/00030400.dat
+8	./IBM17/SURFACE/00011750.dat
+8	./IBM17/SURFACE/00029350.dat
+8	./IBM17/SURFACE/00025950.dat
+8	./IBM17/SURFACE/00033850.dat
+8	./IBM17/SURFACE/00000900.dat
+8	./IBM17/SURFACE/00029200.dat
+8	./IBM17/SURFACE/00001900.dat
+8	./IBM17/SURFACE/00057100.dat
+8	./IBM17/SURFACE/00054850.dat
+8	./IBM17/SURFACE/00070750.dat
+8	./IBM17/SURFACE/00046050.dat
+8	./IBM17/SURFACE/00008450.dat
+8	./IBM17/SURFACE/00070150.dat
+8	./IBM17/SURFACE/00018500.dat
+8	./IBM17/SURFACE/00023850.dat
+8	./IBM17/SURFACE/00025250.dat
+8	./IBM17/SURFACE/00041150.dat
+8	./IBM17/SURFACE/00066050.dat
+8	./IBM17/SURFACE/00026000.dat
+8	./IBM17/SURFACE/00050550.dat
+8	./IBM17/SURFACE/00066250.dat
+8	./IBM17/SURFACE/00030850.dat
+8	./IBM17/SURFACE/00045500.dat
+8	./IBM17/SURFACE/00061800.dat
+8	./IBM17/SURFACE/00063100.dat
+8	./IBM17/SURFACE/00038450.dat
+8	./IBM17/SURFACE/00030050.dat
+8	./IBM17/SURFACE/00056250.dat
+8	./IBM17/SURFACE/00054700.dat
+8	./IBM17/SURFACE/00010900.dat
+8	./IBM17/SURFACE/00051000.dat
+8	./IBM17/SURFACE/00012300.dat
+8	./IBM17/SURFACE/00048500.dat
+8	./IBM17/SURFACE/00039100.dat
+8	./IBM17/SURFACE/00020150.dat
+8	./IBM17/SURFACE/00061850.dat
+8	./IBM17/SURFACE/00043300.dat
+8	./IBM17/SURFACE/00061400.dat
+8	./IBM17/SURFACE/00010250.dat
+8	./IBM17/SURFACE/00004000.dat
+8	./IBM17/SURFACE/00041950.dat
+8	./IBM17/SURFACE/00042650.dat
+8	./IBM17/SURFACE/00014050.dat
+8	./IBM17/SURFACE/00036050.dat
+8	./IBM17/SURFACE/00060800.dat
+8	./IBM17/SURFACE/00054250.dat
+8	./IBM17/SURFACE/00052050.dat
+8	./IBM17/SURFACE/00023450.dat
+8	./IBM17/SURFACE/00062500.dat
+8	./IBM17/SURFACE/00019450.dat
+8	./IBM17/SURFACE/00016650.dat
+8	./IBM17/SURFACE/00048950.dat
+8	./IBM17/SURFACE/00002900.dat
+8	./IBM17/SURFACE/00052000.dat
+8	./IBM17/SURFACE/00063900.dat
+8	./IBM17/SURFACE/00035850.dat
+8	./IBM17/SURFACE/00058450.dat
+8	./IBM17/SURFACE/00045200.dat
+8	./IBM17/SURFACE/00058750.dat
+8	./IBM17/SURFACE/00024000.dat
+8	./IBM17/SURFACE/00018100.dat
+8	./IBM17/SURFACE/00047450.dat
+8	./IBM17/SURFACE/00054400.dat
+8	./IBM17/SURFACE/00045950.dat
+8	./IBM17/SURFACE/00005850.dat
+8	./IBM17/SURFACE/00063650.dat
+8	./IBM17/SURFACE/00057650.dat
+8	./IBM17/SURFACE/00009750.dat
+8	./IBM17/SURFACE/00039300.dat
+8	./IBM17/SURFACE/00031950.dat
+8	./IBM17/SURFACE/00057000.dat
+8	./IBM17/SURFACE/00035650.dat
+8	./IBM17/SURFACE/00047750.dat
+8	./IBM17/SURFACE/00002800.dat
+8	./IBM17/SURFACE/00044600.dat
+8	./IBM17/SURFACE/00014450.dat
+8	./IBM17/SURFACE/00012250.dat
+8	./IBM17/SURFACE/00050850.dat
+8	./IBM17/SURFACE/00062100.dat
+8	./IBM17/SURFACE/00017000.dat
+4	./IBM17/SURFACE/00001700.dat
+8	./IBM17/SURFACE/00029300.dat
+8	./IBM17/SURFACE/00038550.dat
+0	./IBM17/SURFACE/00071200.dat
+8	./IBM17/SURFACE/00057700.dat
+8	./IBM17/SURFACE/00044700.dat
+8	./IBM17/SURFACE/00006400.dat
+8	./IBM17/SURFACE/00015050.dat
+8	./IBM17/SURFACE/00029850.dat
+8	./IBM17/SURFACE/00029400.dat
+8	./IBM17/SURFACE/00069400.dat
+8	./IBM17/SURFACE/00046000.dat
+8	./IBM17/SURFACE/00016300.dat
+8	./IBM17/SURFACE/00006550.dat
+8	./IBM17/SURFACE/00003950.dat
+8	./IBM17/SURFACE/00002200.dat
+8	./IBM17/SURFACE/00021350.dat
+8	./IBM17/SURFACE/00036450.dat
+8	./IBM17/SURFACE/00039500.dat
+8	./IBM17/SURFACE/00045850.dat
+8	./IBM17/SURFACE/00027800.dat
+8	./IBM17/SURFACE/00032100.dat
+8	./IBM17/SURFACE/00063450.dat
+8	./IBM17/SURFACE/00051050.dat
+8	./IBM17/SURFACE/00060150.dat
+8	./IBM17/SURFACE/00019700.dat
+8	./IBM17/SURFACE/00065600.dat
+8	./IBM17/SURFACE/00064250.dat
+8	./IBM17/SURFACE/00010450.dat
+8	./IBM17/SURFACE/00011150.dat
+8	./IBM17/SURFACE/00064450.dat
+8	./IBM17/SURFACE/00015350.dat
+8	./IBM17/SURFACE/00032150.dat
+8	./IBM17/SURFACE/00004750.dat
+8	./IBM17/SURFACE/00000850.dat
+8	./IBM17/SURFACE/00048800.dat
+8	./IBM17/SURFACE/00048350.dat
+8	./IBM17/SURFACE/00023550.dat
+8	./IBM17/SURFACE/00053500.dat
+8	./IBM17/SURFACE/00054000.dat
+8	./IBM17/SURFACE/00034100.dat
+8	./IBM17/SURFACE/00064650.dat
+8	./IBM17/SURFACE/00020600.dat
+8	./IBM17/SURFACE/00043000.dat
+8	./IBM17/SURFACE/00022050.dat
+8	./IBM17/SURFACE/00037050.dat
+8	./IBM17/SURFACE/00004350.dat
+8	./IBM17/SURFACE/00047500.dat
+8	./IBM17/SURFACE/00044500.dat
+8	./IBM17/SURFACE/00007500.dat
+8	./IBM17/SURFACE/00052500.dat
+8	./IBM17/SURFACE/00035250.dat
+8	./IBM17/SURFACE/00033700.dat
+8	./IBM17/SURFACE/00068000.dat
+8	./IBM17/SURFACE/00046700.dat
+8	./IBM17/SURFACE/00013300.dat
+8	./IBM17/SURFACE/00050900.dat
+8	./IBM17/SURFACE/00002000.dat
+8	./IBM17/SURFACE/00059100.dat
+8	./IBM17/SURFACE/00023900.dat
+8	./IBM17/SURFACE/00013350.dat
+8	./IBM17/SURFACE/00050450.dat
+8	./IBM17/SURFACE/00065400.dat
+8	./IBM17/SURFACE/00066450.dat
+8	./IBM17/SURFACE/00034850.dat
+8	./IBM17/SURFACE/00037750.dat
+8	./IBM17/SURFACE/00016450.dat
+8	./IBM17/SURFACE/00031750.dat
+8	./IBM17/SURFACE/00039250.dat
+8	./IBM17/SURFACE/00007700.dat
+8	./IBM17/SURFACE/00023800.dat
+8	./IBM17/SURFACE/00011700.dat
+8	./IBM17/SURFACE/00024500.dat
+8	./IBM17/SURFACE/00060900.dat
+8	./IBM17/SURFACE/00054600.dat
+8	./IBM17/SURFACE/00034150.dat
+8	./IBM17/SURFACE/00018050.dat
+8	./IBM17/SURFACE/00002350.dat
+8	./IBM17/SURFACE/00024700.dat
+8	./IBM17/SURFACE/00062250.dat
+8	./IBM17/SURFACE/00025150.dat
+8	./IBM17/SURFACE/00053050.dat
+8	./IBM17/SURFACE/00017650.dat
+8	./IBM17/SURFACE/00063400.dat
+8	./IBM17/SURFACE/00017800.dat
+8	./IBM17/SURFACE/00040200.dat
+8	./IBM17/SURFACE/00049900.dat
+8	./IBM17/SURFACE/00027200.dat
+8	./IBM17/SURFACE/00004100.dat
+8	./IBM17/SURFACE/00040950.dat
+8	./IBM17/SURFACE/00059900.dat
+8	./IBM17/SURFACE/00038200.dat
+8	./IBM17/SURFACE/00036100.dat
+8	./IBM17/SURFACE/00070900.dat
+8	./IBM17/SURFACE/00029950.dat
+8	./IBM17/SURFACE/00063050.dat
+8	./IBM17/SURFACE/00006300.dat
+8	./IBM17/SURFACE/00014100.dat
+8	./IBM17/SURFACE/00017950.dat
+8	./IBM17/SURFACE/00002550.dat
+8	./IBM17/SURFACE/00015300.dat
+8	./IBM17/SURFACE/00001100.dat
+8	./IBM17/SURFACE/00045600.dat
+8	./IBM17/SURFACE/00016100.dat
+8	./IBM17/SURFACE/00025900.dat
+8	./IBM17/SURFACE/00070850.dat
+8	./IBM17/SURFACE/00071150.dat
+8	./IBM17/SURFACE/00005750.dat
+8	./IBM17/SURFACE/00054550.dat
+8	./IBM17/SURFACE/00036300.dat
+8	./IBM17/SURFACE/00021950.dat
+8	./IBM17/SURFACE/00048900.dat
+8	./IBM17/SURFACE/00022450.dat
+8	./IBM17/SURFACE/00002500.dat
+8	./IBM17/SURFACE/00037850.dat
+8	./IBM17/SURFACE/00035600.dat
+8	./IBM17/SURFACE/00023000.dat
+8	./IBM17/SURFACE/00051600.dat
+8	./IBM17/SURFACE/00008800.dat
+8	./IBM17/SURFACE/00064950.dat
+8	./IBM17/SURFACE/00023950.dat
+8	./IBM17/SURFACE/00063950.dat
+8	./IBM17/SURFACE/00045750.dat
+8	./IBM17/SURFACE/00037700.dat
+8	./IBM17/SURFACE/00028800.dat
+8	./IBM17/SURFACE/00015150.dat
+8	./IBM17/SURFACE/00011650.dat
+8	./IBM17/SURFACE/00043150.dat
+8	./IBM17/SURFACE/00059750.dat
+8	./IBM17/SURFACE/00055950.dat
+8	./IBM17/SURFACE/00030000.dat
+8	./IBM17/SURFACE/00003700.dat
+8	./IBM17/SURFACE/00031450.dat
+8	./IBM17/SURFACE/00037900.dat
+8	./IBM17/SURFACE/00053850.dat
+8	./IBM17/SURFACE/00069250.dat
+8	./IBM17/SURFACE/00039550.dat
+8	./IBM17/SURFACE/00031400.dat
+8	./IBM17/SURFACE/00045150.dat
+8	./IBM17/SURFACE/00032350.dat
+8	./IBM17/SURFACE/00005400.dat
+4	./IBM17/SURFACE/00008750.dat
+8	./IBM17/SURFACE/00043650.dat
+8	./IBM17/SURFACE/00021050.dat
+8	./IBM17/SURFACE/00064500.dat
+8	./IBM17/SURFACE/00054750.dat
+8	./IBM17/SURFACE/00011950.dat
+8	./IBM17/SURFACE/00062050.dat
+8	./IBM17/SURFACE/00017550.dat
+8	./IBM17/SURFACE/00011550.dat
+8	./IBM17/SURFACE/00022850.dat
+8	./IBM17/SURFACE/00005500.dat
+8	./IBM17/SURFACE/00009950.dat
+8	./IBM17/SURFACE/00024450.dat
+8	./IBM17/SURFACE/00055300.dat
+8	./IBM17/SURFACE/00064100.dat
+8	./IBM17/SURFACE/00060200.dat
+8	./IBM17/SURFACE/00009150.dat
+8	./IBM17/SURFACE/00007000.dat
+8	./IBM17/SURFACE/00044750.dat
+8	./IBM17/SURFACE/00024950.dat
+8	./IBM17/SURFACE/00034250.dat
+8	./IBM17/SURFACE/00048250.dat
+8	./IBM17/SURFACE/00028950.dat
+8	./IBM17/SURFACE/00013100.dat
+8	./IBM17/SURFACE/00051650.dat
+8	./IBM17/SURFACE/00031700.dat
+8	./IBM17/SURFACE/00017300.dat
+8	./IBM17/SURFACE/00039750.dat
+8	./IBM17/SURFACE/00015250.dat
+8	./IBM17/SURFACE/00064050.dat
+8	./IBM17/SURFACE/00059450.dat
+8	./IBM17/SURFACE/00060600.dat
+8	./IBM17/SURFACE/00003150.dat
+8	./IBM17/SURFACE/00010150.dat
+8	./IBM17/SURFACE/00049650.dat
+8	./IBM17/SURFACE/00017050.dat
+8	./IBM17/SURFACE/00021550.dat
+8	./IBM17/SURFACE/00041000.dat
+8	./IBM17/SURFACE/00053750.dat
+8	./IBM17/SURFACE/00029750.dat
+8	./IBM17/SURFACE/00059300.dat
+8	./IBM17/SURFACE/00004700.dat
+8	./IBM17/SURFACE/00028200.dat
+8	./IBM17/SURFACE/00016800.dat
+8	./IBM17/SURFACE/00032550.dat
+8	./IBM17/SURFACE/00000400.dat
+8	./IBM17/SURFACE/00065450.dat
+8	./IBM17/SURFACE/00058200.dat
+8	./IBM17/SURFACE/00017350.dat
+8	./IBM17/SURFACE/00035700.dat
+8	./IBM17/SURFACE/00062200.dat
+8	./IBM17/SURFACE/00038300.dat
+8	./IBM17/SURFACE/00006450.dat
+8	./IBM17/SURFACE/00048700.dat
+8	./IBM17/SURFACE/00004650.dat
+8	./IBM17/SURFACE/00064700.dat
+8	./IBM17/SURFACE/00048400.dat
+8	./IBM17/SURFACE/00048600.dat
+8	./IBM17/SURFACE/00017850.dat
+8	./IBM17/SURFACE/00067650.dat
+8	./IBM17/SURFACE/00029100.dat
+8	./IBM17/SURFACE/00007750.dat
+8	./IBM17/SURFACE/00055700.dat
+8	./IBM17/SURFACE/00056350.dat
+8	./IBM17/SURFACE/00006350.dat
+8	./IBM17/SURFACE/00020050.dat
+8	./IBM17/SURFACE/00009200.dat
+8	./IBM17/SURFACE/00058350.dat
+8	./IBM17/SURFACE/00058150.dat
+8	./IBM17/SURFACE/00031050.dat
+8	./IBM17/SURFACE/00061350.dat
+8	./IBM17/SURFACE/00030300.dat
+8	./IBM17/SURFACE/00004900.dat
+8	./IBM17/SURFACE/00059000.dat
+8	./IBM17/SURFACE/00022950.dat
+8	./IBM17/SURFACE/00068150.dat
+8	./IBM17/SURFACE/00012750.dat
+8	./IBM17/SURFACE/00059050.dat
+8	./IBM17/SURFACE/00060350.dat
+8	./IBM17/SURFACE/00046750.dat
+8	./IBM17/SURFACE/00000150.dat
+8	./IBM17/SURFACE/00025350.dat
+8	./IBM17/SURFACE/00026500.dat
+8	./IBM17/SURFACE/00008000.dat
+8	./IBM17/SURFACE/00053450.dat
+8	./IBM17/SURFACE/00010500.dat
+8	./IBM17/SURFACE/00034000.dat
+8	./IBM17/SURFACE/00021450.dat
+8	./IBM17/SURFACE/00037200.dat
+8	./IBM17/SURFACE/00020900.dat
+8	./IBM17/SURFACE/00020700.dat
+8	./IBM17/SURFACE/00007100.dat
+8	./IBM17/SURFACE/00009700.dat
+8	./IBM17/SURFACE/00062950.dat
+8	./IBM17/SURFACE/00048650.dat
+8	./IBM17/SURFACE/00047300.dat
+8	./IBM17/SURFACE/00065850.dat
+8	./IBM17/SURFACE/00038000.dat
+8	./IBM17/SURFACE/00055250.dat
+8	./IBM17/SURFACE/00061500.dat
+8	./IBM17/SURFACE/00021650.dat
+8	./IBM17/SURFACE/00067350.dat
+8	./IBM17/SURFACE/00004250.dat
+8	./IBM17/SURFACE/00015800.dat
+8	./IBM17/SURFACE/00059950.dat
+8	./IBM17/SURFACE/00049100.dat
+8	./IBM17/SURFACE/00001550.dat
+8	./IBM17/SURFACE/00052250.dat
+8	./IBM17/SURFACE/00019800.dat
+8	./IBM17/SURFACE/00051400.dat
+8	./IBM17/SURFACE/00010550.dat
+8	./IBM17/SURFACE/00021750.dat
+8	./IBM17/SURFACE/00025550.dat
+8	./IBM17/SURFACE/00028300.dat
+8	./IBM17/SURFACE/00013500.dat
+8	./IBM17/SURFACE/00025100.dat
+8	./IBM17/SURFACE/00067700.dat
+8	./IBM17/SURFACE/00005200.dat
+8	./IBM17/SURFACE/00027550.dat
+8	./IBM17/SURFACE/00012450.dat
+8	./IBM17/SURFACE/00061300.dat
+8	./IBM17/SURFACE/00014800.dat
+8	./IBM17/SURFACE/00070200.dat
+8	./IBM17/SURFACE/00011350.dat
+8	./IBM17/SURFACE/00062850.dat
+8	./IBM17/SURFACE/00060400.dat
+8	./IBM17/SURFACE/00059850.dat
+8	./IBM17/SURFACE/00055900.dat
+8	./IBM17/SURFACE/00035150.dat
+8	./IBM17/SURFACE/00002300.dat
+8	./IBM17/SURFACE/00052850.dat
+8	./IBM17/SURFACE/00041850.dat
+8	./IBM17/SURFACE/00014000.dat
+8	./IBM17/SURFACE/00007250.dat
+8	./IBM17/SURFACE/00029900.dat
+8	./IBM17/SURFACE/00058950.dat
+8	./IBM17/SURFACE/00066200.dat
+8	./IBM17/SURFACE/00053650.dat
+8	./IBM17/SURFACE/00064600.dat
+8	./IBM17/SURFACE/00002650.dat
+8	./IBM17/SURFACE/00049750.dat
+8	./IBM17/SURFACE/00065550.dat
+8	./IBM17/SURFACE/00058400.dat
+8	./IBM17/SURFACE/00006600.dat
+8	./IBM17/SURFACE/00019850.dat
+8	./IBM17/SURFACE/00011400.dat
+8	./IBM17/SURFACE/00029150.dat
+8	./IBM17/SURFACE/00013650.dat
+8	./IBM17/SURFACE/00065250.dat
+8	./IBM17/SURFACE/00030200.dat
+8	./IBM17/SURFACE/00052150.dat
+8	./IBM17/SURFACE/00006950.dat
+8	./IBM17/SURFACE/00060050.dat
+8	./IBM17/SURFACE/00018900.dat
+8	./IBM17/SURFACE/00033750.dat
+8	./IBM17/SURFACE/00006000.dat
+8	./IBM17/SURFACE/00069800.dat
+8	./IBM17/SURFACE/00024150.dat
+8	./IBM17/SURFACE/00012050.dat
+8	./IBM17/SURFACE/00057750.dat
+8	./IBM17/SURFACE/00029050.dat
+8	./IBM17/SURFACE/00006750.dat
+8	./IBM17/SURFACE/00063200.dat
+8	./IBM17/SURFACE/00062900.dat
+8	./IBM17/SURFACE/00003850.dat
+8	./IBM17/SURFACE/00008150.dat
+8	./IBM17/SURFACE/00068600.dat
+8	./IBM17/SURFACE/00001050.dat
+8	./IBM17/SURFACE/00033550.dat
+8	./IBM17/SURFACE/00036000.dat
+8	./IBM17/SURFACE/00029650.dat
+8	./IBM17/SURFACE/00020450.dat
+8	./IBM17/SURFACE/00036950.dat
+8	./IBM17/SURFACE/00035900.dat
+8	./IBM17/SURFACE/00053600.dat
+8	./IBM17/SURFACE/00018600.dat
+8	./IBM17/SURFACE/00026800.dat
+8	./IBM17/SURFACE/00055650.dat
+8	./IBM17/SURFACE/00030650.dat
+8	./IBM17/SURFACE/00007600.dat
+8	./IBM17/SURFACE/00036500.dat
+8	./IBM17/SURFACE/00064150.dat
+8	./IBM17/SURFACE/00038650.dat
+8	./IBM17/SURFACE/00000600.dat
+8	./IBM17/SURFACE/00063350.dat
+8	./IBM17/SURFACE/00054900.dat
+8	./IBM17/SURFACE/00020000.dat
+8	./IBM17/SURFACE/00064750.dat
+8	./IBM17/SURFACE/00069650.dat
+8	./IBM17/SURFACE/00042150.dat
+8	./IBM17/SURFACE/00024600.dat
+8	./IBM17/SURFACE/00031600.dat
+8	./IBM17/SURFACE/00019600.dat
+8	./IBM17/SURFACE/00061550.dat
+8	./IBM17/SURFACE/00013700.dat
+8	./IBM17/SURFACE/00041200.dat
+8	./IBM17/SURFACE/00052100.dat
+8	./IBM17/SURFACE/00000700.dat
+8	./IBM17/SURFACE/00049300.dat
+8	./IBM17/SURFACE/00040000.dat
+8	./IBM17/SURFACE/00007350.dat
+8	./IBM17/SURFACE/00003600.dat
+8	./IBM17/SURFACE/00000450.dat
+8	./IBM17/SURFACE/00017450.dat
+8	./IBM17/SURFACE/00022100.dat
+8	./IBM17/SURFACE/00028250.dat
+8	./IBM17/SURFACE/00023700.dat
+8	./IBM17/SURFACE/00001000.dat
+8	./IBM17/SURFACE/00009900.dat
+8	./IBM17/SURFACE/00063150.dat
+8	./IBM17/SURFACE/00045400.dat
+8	./IBM17/SURFACE/00035400.dat
+8	./IBM17/SURFACE/00000350.dat
+8	./IBM17/SURFACE/00010650.dat
+8	./IBM17/SURFACE/00019500.dat
+8	./IBM17/SURFACE/00062550.dat
+8	./IBM17/SURFACE/00025000.dat
+8	./IBM17/SURFACE/00028600.dat
+8	./IBM17/SURFACE/00017100.dat
+8	./IBM17/SURFACE/00019400.dat
+8	./IBM17/SURFACE/00027100.dat
+8	./IBM17/SURFACE/00033200.dat
+8	./IBM17/SURFACE/00001600.dat
+8	./IBM17/SURFACE/00047650.dat
+8	./IBM17/SURFACE/00068050.dat
+8	./IBM17/SURFACE/00062400.dat
+8	./IBM17/SURFACE/00032300.dat
+8	./IBM17/SURFACE/00057800.dat
+8	./IBM17/SURFACE/00005550.dat
+8	./IBM17/SURFACE/00018150.dat
+8	./IBM17/SURFACE/00017600.dat
+8	./IBM17/SURFACE/00021900.dat
+8	./IBM17/SURFACE/00021300.dat
+8	./IBM17/SURFACE/00034650.dat
+8	./IBM17/SURFACE/00027450.dat
+8	./IBM17/SURFACE/00056150.dat
+8	./IBM17/SURFACE/00029800.dat
+8	./IBM17/SURFACE/00021200.dat
+8	./IBM17/SURFACE/00000050.dat
+8	./IBM17/SURFACE/00059250.dat
+8	./IBM17/SURFACE/00032850.dat
+8	./IBM17/SURFACE/00038950.dat
+8	./IBM17/SURFACE/00002250.dat
+8	./IBM17/SURFACE/00005050.dat
+8	./IBM17/SURFACE/00022500.dat
+8	./IBM17/SURFACE/00020950.dat
+8	./IBM17/SURFACE/00008950.dat
+8	./IBM17/SURFACE/00038350.dat
+8	./IBM17/SURFACE/00000650.dat
+8	./IBM17/SURFACE/00028050.dat
+8	./IBM17/SURFACE/00050700.dat
+8	./IBM17/SURFACE/00022350.dat
+8	./IBM17/SURFACE/00039450.dat
+8	./IBM17/SURFACE/00050350.dat
+8	./IBM17/SURFACE/00003750.dat
+8	./IBM17/SURFACE/00020350.dat
+8	./IBM17/SURFACE/00026700.dat
+8	./IBM17/SURFACE/00068400.dat
+8	./IBM17/SURFACE/00046550.dat
+8	./IBM17/SURFACE/00036200.dat
+8	./IBM17/SURFACE/00022700.dat
+8	./IBM17/SURFACE/00059200.dat
+8	./IBM17/SURFACE/00043400.dat
+8	./IBM17/SURFACE/00065050.dat
+8	./IBM17/SURFACE/00052650.dat
+8	./IBM17/SURFACE/00024200.dat
+8	./IBM17/SURFACE/00051450.dat
+8	./IBM17/SURFACE/00030900.dat
+8	./IBM17/SURFACE/00063750.dat
+8	./IBM17/SURFACE/00056950.dat
+8	./IBM17/SURFACE/00035050.dat
+8	./IBM17/SURFACE/00053400.dat
+8	./IBM17/SURFACE/00043450.dat
+8	./IBM17/SURFACE/00061200.dat
+8	./IBM17/SURFACE/00006700.dat
+8	./IBM17/SURFACE/00063600.dat
+8	./IBM17/SURFACE/00044000.dat
+8	./IBM17/SURFACE/00027600.dat
+8	./IBM17/SURFACE/00004050.dat
+8	./IBM17/SURFACE/00058300.dat
+8	./IBM17/SURFACE/00008350.dat
+8	./IBM17/SURFACE/00054650.dat
+8	./IBM17/SURFACE/00061950.dat
+8	./IBM17/SURFACE/00039700.dat
+8	./IBM17/SURFACE/00040150.dat
+8	./IBM17/SURFACE/00032800.dat
+8	./IBM17/SURFACE/00011800.dat
+8	./IBM17/SURFACE/00065950.dat
+8	./IBM17/SURFACE/00010050.dat
+8	./IBM17/SURFACE/00020750.dat
+8	./IBM17/SURFACE/00057250.dat
+8	./IBM17/SURFACE/00035000.dat
+8	./IBM17/SURFACE/00027750.dat
+8	./IBM17/SURFACE/00067850.dat
+8	./IBM17/SURFACE/00002750.dat
+8	./IBM17/SURFACE/00019200.dat
+8	./IBM17/SURFACE/00019100.dat
+8	./IBM17/SURFACE/00069100.dat
+8	./IBM17/SURFACE/00015850.dat
+8	./IBM17/SURFACE/00044950.dat
+8	./IBM17/SURFACE/00002150.dat
+8	./IBM17/SURFACE/00016550.dat
+8	./IBM17/SURFACE/00034500.dat
+8	./IBM17/SURFACE/00025750.dat
+8	./IBM17/SURFACE/00050600.dat
+8	./IBM17/SURFACE/00042000.dat
+8	./IBM17/SURFACE/00025850.dat
+8	./IBM17/SURFACE/00042900.dat
+8	./IBM17/SURFACE/00021500.dat
+8	./IBM17/SURFACE/00011000.dat
+8	./IBM17/SURFACE/00025400.dat
+8	./IBM17/SURFACE/00061750.dat
+8	./IBM17/SURFACE/00032600.dat
+8	./IBM17/SURFACE/00015750.dat
+8	./IBM17/SURFACE/00042250.dat
+8	./IBM17/SURFACE/00049800.dat
+8	./IBM17/SURFACE/00002600.dat
+8	./IBM17/SURFACE/00020850.dat
+8	./IBM17/SURFACE/00056600.dat
+8	./IBM17/SURFACE/00029500.dat
+8	./IBM17/SURFACE/00066650.dat
+8	./IBM17/SURFACE/00021700.dat
+8	./IBM17/SURFACE/00035750.dat
+8	./IBM17/SURFACE/00041900.dat
+8	./IBM17/SURFACE/00018750.dat
+8	./IBM17/SURFACE/00067450.dat
+8	./IBM17/SURFACE/00056700.dat
+8	./IBM17/SURFACE/00044150.dat
+8	./IBM17/SURFACE/00007150.dat
+8	./IBM17/SURFACE/00022200.dat
+8	./IBM17/SURFACE/00036850.dat
+8	./IBM17/SURFACE/00066850.dat
+8	./IBM17/SURFACE/00012100.dat
+8	./IBM17/SURFACE/00032500.dat
+8	./IBM17/SURFACE/00000550.dat
+8	./IBM17/SURFACE/00044050.dat
+8	./IBM17/SURFACE/00036400.dat
+8	./IBM17/SURFACE/00055600.dat
+8	./IBM17/SURFACE/00028650.dat
+8	./IBM17/SURFACE/00019000.dat
+8	./IBM17/SURFACE/00037550.dat
+8	./IBM17/SURFACE/00025650.dat
+8	./IBM17/SURFACE/00016600.dat
+8	./IBM17/SURFACE/00070600.dat
+8	./IBM17/SURFACE/00022650.dat
+8	./IBM17/SURFACE/00043750.dat
+8	./IBM17/SURFACE/00017150.dat
+8	./IBM17/SURFACE/00068100.dat
+8	./IBM17/SURFACE/00032700.dat
+8	./IBM17/SURFACE/00016850.dat
+8	./IBM17/SURFACE/00052900.dat
+8	./IBM17/SURFACE/00025800.dat
+8	./IBM17/SURFACE/00033000.dat
+8	./IBM17/SURFACE/00055400.dat
+8	./IBM17/SURFACE/00031250.dat
+8	./IBM17/SURFACE/00031200.dat
+8	./IBM17/SURFACE/00021250.dat
+8	./IBM17/SURFACE/00009300.dat
+8	./IBM17/SURFACE/00048150.dat
+8	./IBM17/SURFACE/00068500.dat
+8	./IBM17/SURFACE/00044200.dat
+8	./IBM17/SURFACE/00010200.dat
+8	./IBM17/SURFACE/00050750.dat
+8	./IBM17/SURFACE/00027050.dat
+8	./IBM17/SURFACE/00036600.dat
+8	./IBM17/SURFACE/00020200.dat
+8	./IBM17/SURFACE/00059550.dat
+8	./IBM17/SURFACE/00035350.dat
+8	./IBM17/SURFACE/00017500.dat
+8	./IBM17/SURFACE/00040500.dat
+8	./IBM17/SURFACE/00038250.dat
+8	./IBM17/SURFACE/00039050.dat
+8	./IBM17/SURFACE/00030100.dat
+8	./IBM17/SURFACE/00070250.dat
+8	./IBM17/SURFACE/00023400.dat
+8	./IBM17/SURFACE/00022600.dat
+8	./IBM17/SURFACE/00018700.dat
+8	./IBM17/SURFACE/00014650.dat
+8	./IBM17/SURFACE/00063300.dat
+8	./IBM17/SURFACE/00047400.dat
+8	./IBM17/SURFACE/00033450.dat
+8	./IBM17/SURFACE/00067150.dat
+8	./IBM17/SURFACE/00019650.dat
+8	./IBM17/SURFACE/00027950.dat
+8	./IBM17/SURFACE/00029550.dat
+8	./IBM17/SURFACE/00056800.dat
+8	./IBM17/SURFACE/00013450.dat
+8	./IBM17/SURFACE/00019900.dat
+8	./IBM17/SURFACE/00026100.dat
+8	./IBM17/SURFACE/00026600.dat
+8	./IBM17/SURFACE/00007850.dat
+8	./IBM17/SURFACE/00050250.dat
+8	./IBM17/SURFACE/00069700.dat
+8	./IBM17/SURFACE/00003350.dat
+8	./IBM17/SURFACE/00067300.dat
+8	./IBM17/SURFACE/00001350.dat
+8	./IBM17/SURFACE/00064000.dat
+8	./IBM17/SURFACE/00036700.dat
+8	./IBM17/SURFACE/00069050.dat
+8	./IBM17/SURFACE/00049250.dat
+8	./IBM17/SURFACE/00016900.dat
+8	./IBM17/SURFACE/00046400.dat
+8	./IBM17/SURFACE/00039000.dat
+8	./IBM17/SURFACE/00039150.dat
+8	./IBM17/SURFACE/00027300.dat
+8	./IBM17/SURFACE/00070500.dat
+8	./IBM17/SURFACE/00069200.dat
+8	./IBM17/SURFACE/00025050.dat
+8	./IBM17/SURFACE/00038700.dat
+8	./IBM17/SURFACE/00063800.dat
+8	./IBM17/SURFACE/00019250.dat
+8	./IBM17/SURFACE/00009550.dat
+8	./IBM17/SURFACE/00061000.dat
+8	./IBM17/SURFACE/00015550.dat
+8	./IBM17/SURFACE/00009600.dat
+8	./IBM17/SURFACE/00056500.dat
+8	./IBM17/SURFACE/00046250.dat
+8	./IBM17/SURFACE/00049050.dat
+8	./IBM17/SURFACE/00031150.dat
+8	./IBM17/SURFACE/00036800.dat
+8	./IBM17/SURFACE/00045100.dat
+8	./IBM17/SURFACE/00006800.dat
+8	./IBM17/SURFACE/00058900.dat
+8	./IBM17/SURFACE/00062350.dat
+8	./IBM17/SURFACE/00032250.dat
+8	./IBM17/SURFACE/00020250.dat
+8	./IBM17/SURFACE/00024750.dat
+8	./IBM17/SURFACE/00065750.dat
+8	./IBM17/SURFACE/00014150.dat
+8	./IBM17/SURFACE/00046650.dat
+8	./IBM17/SURFACE/00001150.dat
+8	./IBM17/SURFACE/00066300.dat
+8	./IBM17/SURFACE/00038400.dat
+8	./IBM17/SURFACE/00041400.dat
+8	./IBM17/SURFACE/00045350.dat
+8	./IBM17/SURFACE/00027400.dat
+8	./IBM17/SURFACE/00065000.dat
+8	./IBM17/SURFACE/00014900.dat
+8	./IBM17/SURFACE/00032000.dat
+8	./IBM17/SURFACE/00026400.dat
+8	./IBM17/SURFACE/00022800.dat
+8	./IBM17/SURFACE/00012000.dat
+8	./IBM17/SURFACE/00058550.dat
+8	./IBM17/SURFACE/00040350.dat
+8	./IBM17/SURFACE/00006500.dat
+8	./IBM17/SURFACE/00054200.dat
+8	./IBM17/SURFACE/00026950.dat
+8	./IBM17/SURFACE/00042350.dat
+8	./IBM17/SURFACE/00030750.dat
+8	./IBM17/SURFACE/00056650.dat
+8	./IBM17/SURFACE/00020500.dat
+8	./IBM17/SURFACE/00026350.dat
+8	./IBM17/SURFACE/00031300.dat
+8	./IBM17/SURFACE/00031650.dat
+8	./IBM17/SURFACE/00053150.dat
+8	./IBM17/SURFACE/00045000.dat
+8	./IBM17/SURFACE/00055200.dat
+8	./IBM17/SURFACE/00062150.dat
+8	./IBM17/SURFACE/00050950.dat
+8	./IBM17/SURFACE/00015400.dat
+8	./IBM17/SURFACE/00050200.dat
+8	./IBM17/SURFACE/00053900.dat
+8	./IBM17/SURFACE/00068450.dat
+8	./IBM17/SURFACE/00015500.dat
+8	./IBM17/SURFACE/00059500.dat
+8	./IBM17/SURFACE/00015900.dat
+8	./IBM17/SURFACE/00047350.dat
+8	./IBM17/SURFACE/00030350.dat
+8	./IBM17/SURFACE/00040550.dat
+8	./IBM17/SURFACE/00027850.dat
+8	./IBM17/SURFACE/00007400.dat
+8	./IBM17/SURFACE/00043350.dat
+8	./IBM17/SURFACE/00037800.dat
+8	./IBM17/SURFACE/00054050.dat
+8	./IBM17/SURFACE/00008900.dat
+8	./IBM17/SURFACE/00021850.dat
+8	./IBM17/SURFACE/00033100.dat
+8	./IBM17/SURFACE/00047950.dat
+8	./IBM17/SURFACE/00016400.dat
+8	./IBM17/SURFACE/00043100.dat
+8	./IBM17/SURFACE/00035800.dat
+8	./IBM17/SURFACE/00045550.dat
+8	./IBM17/SURFACE/00009500.dat
+8	./IBM17/SURFACE/00014500.dat
+8	./IBM17/SURFACE/00045450.dat
+8	./IBM17/SURFACE/00008600.dat
+8	./IBM17/SURFACE/00066750.dat
+8	./IBM17/SURFACE/00015950.dat
+8	./IBM17/SURFACE/00010750.dat
+8	./IBM17/SURFACE/00046150.dat
+8	./IBM17/SURFACE/00051300.dat
+8	./IBM17/SURFACE/00026850.dat
+8	./IBM17/SURFACE/00008550.dat
+8	./IBM17/SURFACE/00066800.dat
+8	./IBM17/SURFACE/00027350.dat
+8	./IBM17/SURFACE/00018650.dat
+8	./IBM17/SURFACE/00022250.dat
+8	./IBM17/SURFACE/00006650.dat
+8	./IBM17/SURFACE/00042500.dat
+8	./IBM17/SURFACE/00040700.dat
+8	./IBM17/SURFACE/00063250.dat
+8	./IBM17/SURFACE/00013000.dat
+8	./IBM17/SURFACE/00059350.dat
+8	./IBM17/SURFACE/00054350.dat
+8	./IBM17/SURFACE/00057200.dat
+8	./IBM17/SURFACE/00003050.dat
+8	./IBM17/SURFACE/00014700.dat
+8	./IBM17/SURFACE/00059400.dat
+8	./IBM17/SURFACE/00033500.dat
+8	./IBM17/SURFACE/00001750.dat
+8	./IBM17/SURFACE/00037950.dat
+8	./IBM17/SURFACE/00065350.dat
+8	./IBM17/SURFACE/00006900.dat
+0	./IBM17/SURFACE/00031000.dat
+8	./IBM17/SURFACE/00038050.dat
+8	./IBM17/SURFACE/00039900.dat
+8	./IBM17/SURFACE/00042700.dat
+8	./IBM17/SURFACE/00032400.dat
+8	./IBM17/SURFACE/00052200.dat
+8	./IBM17/SURFACE/00027250.dat
+8	./IBM17/SURFACE/00062000.dat
+8	./IBM17/SURFACE/00026550.dat
+8	./IBM17/SURFACE/00061050.dat
+8	./IBM17/SURFACE/00041650.dat
+8	./IBM17/SURFACE/00001250.dat
+8	./IBM17/SURFACE/00023650.dat
+8	./IBM17/SURFACE/00070550.dat
+8	./IBM17/SURFACE/00022400.dat
+8	./IBM17/SURFACE/00014750.dat
+8	./IBM17/SURFACE/00030800.dat
+8	./IBM17/SURFACE/00037650.dat
+8	./IBM17/SURFACE/00032200.dat
+8	./IBM17/SURFACE/00034800.dat
+8	./IBM17/SURFACE/00044850.dat
+8	./IBM17/SURFACE/00038850.dat
+8	./IBM17/SURFACE/00024650.dat
+8	./IBM17/SURFACE/00024250.dat
+8	./IBM17/SURFACE/00010350.dat
+8	./IBM17/SURFACE/00063700.dat
+8	./IBM17/SURFACE/00054300.dat
+8	./IBM17/SURFACE/00069350.dat
+8	./IBM17/SURFACE/00028500.dat
+8	./IBM17/SURFACE/00018300.dat
+8	./IBM17/SURFACE/00005600.dat
+8	./IBM17/SURFACE/00039850.dat
+8	./IBM17/SURFACE/00067000.dat
+8	./IBM17/SURFACE/00056050.dat
+8	./IBM17/SURFACE/00042400.dat
+8	./IBM17/SURFACE/00004200.dat
+8	./IBM17/SURFACE/00035950.dat
+8	./IBM17/SURFACE/00048850.dat
+8	./IBM17/SURFACE/00066500.dat
+8	./IBM17/SURFACE/00015100.dat
+8	./IBM17/SURFACE/00067500.dat
+8	./IBM17/SURFACE/00001800.dat
+8	./IBM17/SURFACE/00017900.dat
+8	./IBM17/SURFACE/00068700.dat
+8	./IBM17/SURFACE/00018350.dat
+8	./IBM17/SURFACE/00027650.dat
+8	./IBM17/SURFACE/00063000.dat
+8	./IBM17/SURFACE/00053800.dat
+8	./IBM17/SURFACE/00045900.dat
+8	./IBM17/SURFACE/00009350.dat
+8	./IBM17/SURFACE/00037000.dat
+8	./IBM17/SURFACE/00063500.dat
+8	./IBM17/SURFACE/00051800.dat
+8	./IBM17/SURFACE/00033350.dat
+8	./IBM17/SURFACE/00055850.dat
+8	./IBM17/SURFACE/00043900.dat
+8	./IBM17/SURFACE/00065700.dat
+8	./IBM17/SURFACE/00028350.dat
+8	./IBM17/SURFACE/00008250.dat
+8	./IBM17/SURFACE/00012150.dat
+8	./IBM17/SURFACE/00055800.dat
+8	./IBM17/SURFACE/00000250.dat
+8	./IBM17/SURFACE/00012500.dat
+8	./IBM17/SURFACE/00035200.dat
+8	./IBM17/SURFACE/00064800.dat
+8	./IBM17/SURFACE/00045800.dat
+8	./IBM17/SURFACE/00022750.dat
+8	./IBM17/SURFACE/00052600.dat
+8	./IBM17/SURFACE/00044800.dat
+8	./IBM17/SURFACE/00051350.dat
+8	./IBM17/SURFACE/00038150.dat
+8	./IBM17/SURFACE/00024850.dat
+8	./IBM17/SURFACE/00053250.dat
+8	./IBM17/SURFACE/00053100.dat
+8	./IBM17/SURFACE/00006050.dat
+8	./IBM17/SURFACE/00054800.dat
+8	./IBM17/SURFACE/00053700.dat
+8	./IBM17/SURFACE/00060000.dat
+8	./IBM17/SURFACE/00033650.dat
+8	./IBM17/SURFACE/00011850.dat
+8	./IBM17/SURFACE/00042200.dat
+8	./IBM17/SURFACE/00012950.dat
+8	./IBM17/SURFACE/00058850.dat
+8	./IBM17/SURFACE/00046600.dat
+8	./IBM17/SURFACE/00070300.dat
+8	./IBM17/SURFACE/00040100.dat
+8	./IBM17/SURFACE/00051250.dat
+8	./IBM17/SURFACE/00020100.dat
+8	./IBM17/SURFACE/00065900.dat
+8	./IBM17/SURFACE/00067050.dat
+8	./IBM17/SURFACE/00067550.dat
+8	./IBM17/SURFACE/00019350.dat
+8	./IBM17/SURFACE/00057900.dat
+8	./IBM17/SURFACE/00060450.dat
+8	./IBM17/SURFACE/00035550.dat
+8	./IBM17/SURFACE/00067950.dat
+8	./IBM17/SURFACE/00066950.dat
+8	./IBM17/SURFACE/00045650.dat
+8	./IBM17/SURFACE/00070450.dat
+8	./IBM17/SURFACE/00030600.dat
+8	./IBM17/SURFACE/00070650.dat
+8	./IBM17/SURFACE/00057050.dat
+8	./IBM17/SURFACE/00011450.dat
+8	./IBM17/SURFACE/00028150.dat
+8	./IBM17/SURFACE/00000950.dat
+8	./IBM17/SURFACE/00057500.dat
+8	./IBM17/SURFACE/00049700.dat
+8	./IBM17/SURFACE/00056550.dat
+8	./IBM17/SURFACE/00025600.dat
+8	./IBM17/SURFACE/00015600.dat
+8	./IBM17/SURFACE/00013050.dat
+8	./IBM17/SURFACE/00064850.dat
+8	./IBM17/SURFACE/00061100.dat
+8	./IBM17/SURFACE/00023350.dat
+8	./IBM17/SURFACE/00053300.dat
+8	./IBM17/SURFACE/00028000.dat
+8	./IBM17/SURFACE/00037150.dat
+8	./IBM17/SURFACE/00038600.dat
+8	./IBM17/SURFACE/00069450.dat
+8	./IBM17/SURFACE/00048300.dat
+8	./IBM17/SURFACE/00043600.dat
+8	./IBM17/SURFACE/00005950.dat
+8	./IBM17/SURFACE/00033300.dat
+8	./IBM17/SURFACE/00016950.dat
+8	./IBM17/SURFACE/00010850.dat
+8	./IBM17/SURFACE/00042100.dat
+8	./IBM17/SURFACE/00017250.dat
+8	./IBM17/SURFACE/00050650.dat
+8	./IBM17/SURFACE/00013850.dat
+8	./IBM17/SURFACE/00070100.dat
+8	./IBM17/SURFACE/00047850.dat
+8	./IBM17/SURFACE/00068250.dat
+8	./IBM17/SURFACE/00004600.dat
+8	./IBM17/SURFACE/00060100.dat
+8	./IBM17/SURFACE/00013750.dat
+8	./IBM17/SURFACE/00009800.dat
+8	./IBM17/SURFACE/00025500.dat
+8	./IBM17/SURFACE/00017700.dat
+8	./IBM17/SURFACE/00024100.dat
+8	./IBM17/SURFACE/00030150.dat
+8	./IBM17/SURFACE/00002100.dat
+8	./IBM17/SURFACE/00002050.dat
+8	./IBM17/SURFACE/00019550.dat
+8	./IBM17/SURFACE/00034950.dat
+8	./IBM17/SURFACE/00069600.dat
+8	./IBM17/SURFACE/00066550.dat
+8	./IBM17/SURFACE/00014200.dat
+8	./IBM17/SURFACE/00009050.dat
+8	./IBM17/SURFACE/00026300.dat
+8	./IBM17/SURFACE/00071050.dat
+8	./IBM17/SURFACE/00005350.dat
+8	./IBM17/SURFACE/00020550.dat
+8	./IBM17/SURFACE/00020400.dat
+8	./IBM17/SURFACE/00060300.dat
+8	./IBM17/SURFACE/00014400.dat
+8	./IBM17/SURFACE/00063850.dat
+8	./IBM17/SURFACE/00039350.dat
+8	./IBM17/SURFACE/00033600.dat
+8	./IBM17/SURFACE/00058000.dat
+8	./IBM17/SURFACE/00023600.dat
+8	./IBM17/SURFACE/00060850.dat
+8	./IBM17/SURFACE/00064900.dat
+8	./IBM17/SURFACE/00001450.dat
+8	./IBM17/SURFACE/00023500.dat
+8	./IBM17/SURFACE/00001200.dat
+8	./IBM17/SURFACE/00011050.dat
+8	./IBM17/SURFACE/00013200.dat
+8	./IBM17/SURFACE/00067800.dat
+8	./IBM17/SURFACE/00049500.dat
+8	./IBM17/SURFACE/00026450.dat
+8	./IBM17/SURFACE/00057550.dat
+8	./IBM17/SURFACE/00066700.dat
+8	./IBM17/SURFACE/00025450.dat
+8	./IBM17/SURFACE/00061650.dat
+8	./IBM17/SURFACE/00016200.dat
+8	./IBM17/SURFACE/00026650.dat
+8	./IBM17/SURFACE/00043550.dat
+8	./IBM17/SURFACE/00034550.dat
+8	./IBM17/SURFACE/00011250.dat
+8	./IBM17/SURFACE/00003400.dat
+8	./IBM17/SURFACE/00014550.dat
+8	./IBM17/SURFACE/00045050.dat
+8	./IBM17/SURFACE/00008700.dat
+8	./IBM17/SURFACE/00046350.dat
+8	./IBM17/SURFACE/00005250.dat
+8	./IBM17/SURFACE/00003650.dat
+8	./IBM17/SURFACE/00038800.dat
+8	./IBM17/SURFACE/00058050.dat
+8	./IBM17/SURFACE/00058100.dat
+8	./IBM17/SURFACE/00031100.dat
+8	./IBM17/SURFACE/00014600.dat
+8	./IBM17/SURFACE/00002400.dat
+8	./IBM17/SURFACE/00065650.dat
+8	./IBM17/SURFACE/00049400.dat
+8	./IBM17/SURFACE/00011200.dat
+8	./IBM17/SURFACE/00037250.dat
+8	./IBM17/SURFACE/00008050.dat
+8	./IBM17/SURFACE/00044350.dat
+8	./IBM17/SURFACE/00055350.dat
+8	./IBM17/SURFACE/00060950.dat
+8	./IBM17/SURFACE/00056900.dat
+8	./IBM17/SURFACE/00026150.dat
+8	./IBM17/SURFACE/00033250.dat
+8	./IBM17/SURFACE/00001850.dat
+8	./IBM17/SURFACE/00042950.dat
+8	./IBM17/SURFACE/00067200.dat
+8	./IBM17/SURFACE/00028450.dat
+8	./IBM17/SURFACE/00006200.dat
+8	./IBM17/SURFACE/00069850.dat
+8	./IBM17/SURFACE/00052700.dat
+8	./IBM17/SURFACE/00024800.dat
+8	./IBM17/SURFACE/00029700.dat
+8	./IBM17/SURFACE/00048200.dat
+8	./IBM17/SURFACE/00007900.dat
+8	./IBM17/SURFACE/00055450.dat
+8	./IBM17/SURFACE/00067250.dat
+8	./IBM17/SURFACE/00052950.dat
+8	./IBM17/SURFACE/00041100.dat
+8	./IBM17/SURFACE/00040400.dat
+8	./IBM17/SURFACE/00013950.dat
+8	./IBM17/SURFACE/00042600.dat
+8	./IBM17/SURFACE/00022550.dat
+8	./IBM17/SURFACE/00013900.dat
+8	./IBM17/SURFACE/00069300.dat
+8	./IBM17/SURFACE/00040050.dat
+8	./IBM17/SURFACE/00000300.dat
+8	./IBM17/SURFACE/00061600.dat
+8	./IBM17/SURFACE/00030950.dat
+8	./IBM17/SURFACE/00068300.dat
+8	./IBM17/SURFACE/00066100.dat
+8	./IBM17/SURFACE/00013800.dat
+8	./IBM17/SURFACE/00021600.dat
+8	./IBM17/SURFACE/00027900.dat
+8	./IBM17/SURFACE/00008400.dat
+8	./IBM17/SURFACE/00051150.dat
+8	./IBM17/SURFACE/00018250.dat
+8	./IBM17/SURFACE/00057950.dat
+8	./IBM17/SURFACE/00007650.dat
+8	./IBM17/SURFACE/00070800.dat
+8	./IBM17/SURFACE/00044250.dat
+8	./IBM17/SURFACE/00047200.dat
+8	./IBM17/SURFACE/00010100.dat
+8	./IBM17/SURFACE/00010300.dat
+8	./IBM17/SURFACE/00004400.dat
+8	./IBM17/SURFACE/00047600.dat
+8	./IBM17/SURFACE/00069900.dat
+8	./IBM17/SURFACE/00055750.dat
+8	./IBM17/SURFACE/00053350.dat
+8	./IBM17/SURFACE/00040900.dat
+8	./IBM17/SURFACE/00065150.dat
+8	./IBM17/SURFACE/00043500.dat
+8	./IBM17/SURFACE/00070000.dat
+8	./IBM17/SURFACE/00056100.dat
+8	./IBM17/SURFACE/00012900.dat
+8	./IBM17/SURFACE/00064300.dat
+8	./IBM17/SURFACE/00049600.dat
+8	./IBM17/SURFACE/00071100.dat
+8	./IBM17/SURFACE/00059600.dat
+8	./IBM17/SURFACE/00057400.dat
+8	./IBM17/SURFACE/00046200.dat
+8	./IBM17/SURFACE/00021100.dat
+8	./IBM17/SURFACE/00005800.dat
+8	./IBM17/SURFACE/00045250.dat
+8	./IBM17/SURFACE/00003200.dat
+8	./IBM17/SURFACE/00056850.dat
+8	./IBM17/SURFACE/00015450.dat
+8	./IBM17/SURFACE/00047550.dat
+8	./IBM17/SURFACE/00011900.dat
+8	./IBM17/SURFACE/00059700.dat
+8	./IBM17/SURFACE/00023750.dat
+8	./IBM17/SURFACE/00002450.dat
+8	./IBM17/SURFACE/00040450.dat
+8	./IBM17/SURFACE/00049950.dat
+8	./IBM17/SURFACE/00016150.dat
+8	./IBM17/SURFACE/00034050.dat
+8	./IBM17/SURFACE/00031800.dat
+8	./IBM17/SURFACE/00039600.dat
+8	./IBM17/SURFACE/00060650.dat
+8	./IBM17/SURFACE/00023050.dat
+8	./IBM17/SURFACE/00005150.dat
+8	./IBM17/SURFACE/00014950.dat
+8	./IBM17/SURFACE/00005100.dat
+8	./IBM17/SURFACE/00015000.dat
+8	./IBM17/SURFACE/00031900.dat
+8	./IBM17/SURFACE/00019050.dat
+8	./IBM17/SURFACE/00033150.dat
+8	./IBM17/SURFACE/00041350.dat
+8	./IBM17/SURFACE/00003000.dat
+8	./IBM17/SURFACE/00012700.dat
+8	./IBM17/SURFACE/00046100.dat
+8	./IBM17/SURFACE/00032450.dat
+8	./IBM17/SURFACE/00068550.dat
+8	./IBM17/SURFACE/00064550.dat
+8	./IBM17/SURFACE/00005450.dat
+8	./IBM17/SURFACE/00016700.dat
+8	./IBM17/SURFACE/00044550.dat
+8	./IBM17/SURFACE/00032750.dat
+8	./IBM17/SURFACE/00004800.dat
+8	./IBM17/SURFACE/00024550.dat
+8	./IBM17/SURFACE/00068900.dat
+8	./IBM17/SURFACE/00055150.dat
+8	./IBM17/SURFACE/00046800.dat
+8	./IBM17/SURFACE/00058250.dat
+8	./IBM17/SURFACE/00038900.dat
+8	./IBM17/SURFACE/00065300.dat
+8	./IBM17/SURFACE/00023100.dat
+8	./IBM17/SURFACE/00054150.dat
+8	./IBM17/SURFACE/00001300.dat
+8	./IBM17/SURFACE/00036150.dat
+8	./IBM17/SURFACE/00008300.dat
+8	./IBM17/SURFACE/00003500.dat
+8	./IBM17/SURFACE/00012550.dat
+8	./IBM17/SURFACE/00054500.dat
+8	./IBM17/SURFACE/00008850.dat
+8	./IBM17/SURFACE/00043800.dat
+8	./IBM17/SURFACE/00008500.dat
+8	./IBM17/SURFACE/00049850.dat
+8	./IBM17/SURFACE/00038100.dat
+8	./IBM17/SURFACE/00051100.dat
+8	./IBM17/SURFACE/00069150.dat
+8	./IBM17/SURFACE/00018850.dat
+8	./IBM17/SURFACE/00018450.dat
+8	./IBM17/SURFACE/00027150.dat
+8	./IBM17/SURFACE/00000500.dat
+8	./IBM17/SURFACE/00044450.dat
+8	./IBM17/SURFACE/00061700.dat
+8	./IBM17/SURFACE/00022900.dat
+8	./IBM17/SURFACE/00026750.dat
+8	./IBM17/SURFACE/00034450.dat
+8	./IBM17/SURFACE/00036250.dat
+8	./IBM17/SURFACE/00038750.dat
+8	./IBM17/SURFACE/00057450.dat
+8	./IBM17/SURFACE/00015650.dat
+8	./IBM17/SURFACE/00044650.dat
+8	./IBM17/SURFACE/00010000.dat
+8	./IBM17/SURFACE/00065100.dat
+8	./IBM17/SURFACE/00036550.dat
+8	./IBM17/SURFACE/00050400.dat
+8	./IBM17/SURFACE/00066400.dat
+8	./IBM17/SURFACE/00006150.dat
+8	./IBM17/SURFACE/00055100.dat
+8	./IBM17/SURFACE/00060500.dat
+8	./IBM17/SURFACE/00068850.dat
+8	./IBM17/SURFACE/00070050.dat
+8	./IBM17/SURFACE/00034300.dat
+8	./IBM17/SURFACE/00069500.dat
+8	./IBM17/SURFACE/00061900.dat
+8	./IBM17/SURFACE/00003550.dat
+8	./IBM17/SURFACE/00007550.dat
+8	./IBM17/SURFACE/00062300.dat
+8	./IBM17/SURFACE/00043850.dat
+8	./IBM17/SURFACE/00011500.dat
+8	./IBM17/SURFACE/00012200.dat
+8	./IBM17/SURFACE/00044100.dat
+8	./IBM17/SURFACE/00003900.dat
+8	./IBM17/SURFACE/00065200.dat
+8	./IBM17/SURFACE/00033800.dat
+8	./IBM17/SURFACE/00013550.dat
+8	./IBM17/SURFACE/00041250.dat
+8	./IBM17/SURFACE/00047700.dat
+8	./IBM17/SURFACE/00054100.dat
+8	./IBM17/SURFACE/00051950.dat
+8	./IBM17/SURFACE/00050150.dat
+8	./IBM17/SURFACE/00051850.dat
+8	./IBM17/SURFACE/00045300.dat
+8	./IBM17/SURFACE/00046850.dat
+8	./IBM17/SURFACE/00055050.dat
+8	./IBM17/SURFACE/00012400.dat
+8	./IBM17/SURFACE/00032050.dat
+8	./IBM17/SURFACE/00031500.dat
+8	./IBM17/SURFACE/00027500.dat
+8	./IBM17/SURFACE/00037500.dat
+8	./IBM17/SURFACE/00012850.dat
+8	./IBM17/SURFACE/00010600.dat
+8	./IBM17/SURFACE/00057350.dat
+8	./IBM17/SURFACE/00018200.dat
+8	./IBM17/SURFACE/00013250.dat
+8	./IBM17/SURFACE/00034900.dat
+8	./IBM17/SURFACE/00049350.dat
+8	./IBM17/SURFACE/00041450.dat
+8	./IBM17/SURFACE/00051750.dat
+8	./IBM17/SURFACE/00017200.dat
+8	./IBM17/SURFACE/00008200.dat
+8	./IBM17/SURFACE/00065800.dat
+8	./IBM17/SURFACE/00014350.dat
+8	./IBM17/SURFACE/00022150.dat
+8	./IBM17/SURFACE/00042800.dat
+8	./IBM17/SURFACE/00042750.dat
+8	./IBM17/SURFACE/00048450.dat
+8	./IBM17/SURFACE/00030250.dat
+8	./IBM17/SURFACE/00001950.dat
+8	./IBM17/SURFACE/00070350.dat
+8	./IBM17/SURFACE/00004850.dat
+8	./IBM17/SURFACE/00025300.dat
+8	./IBM17/SURFACE/00044400.dat
+8	./IBM17/SURFACE/00051700.dat
+8	./IBM17/SURFACE/00057300.dat
+8	./IBM17/SURFACE/00001400.dat
+8	./IBM17/SURFACE/00028400.dat
+8	./IBM17/SURFACE/00045700.dat
+8	./IBM17/SURFACE/00000800.dat
+8	./IBM17/SURFACE/00003800.dat
+8	./IBM17/SURFACE/00050000.dat
+8	./IBM17/SURFACE/00021150.dat
+8	./IBM17/SURFACE/00029600.dat
+8	./IBM17/SURFACE/00016000.dat
+8	./IBM17/SURFACE/00030700.dat
+8	./IBM17/SURFACE/00047250.dat
+11448	./IBM17/SURFACE
+4	./IBM17/prof_step
+4	./IBM17/Beforemaking
+4	./IBM17/MID/TIME.MID
+8	./IBM17/MID
+du: cannot access `./IBM17/PRIO_GENERATE_GRID/Makefile': Permission denied
+du: cannot access `./IBM17/PRIO_GENERATE_GRID/genegrid': Permission denied
+du: cannot access `./IBM17/PRIO_GENERATE_GRID/GENEGRID.F90': Permission denied
+4	./IBM17/PRIO_GENERATE_GRID
+188264332	./IBM17
+4	./COPY_GATHERDATA/GATHERDATA/INCLUDE_IO.FI
+12	./COPY_GATHERDATA/GATHERDATA/GATHER_IO.o
+12	./COPY_GATHERDATA/GATHERDATA/tecio.f90
+4	./COPY_GATHERDATA/GATHERDATA/GATHER_IO.F90
+68	./COPY_GATHERDATA/GATHERDATA/GATHERDATA.o
+12	./COPY_GATHERDATA/GATHERDATA/GATHERDATA.F90
+116	./COPY_GATHERDATA/GATHERDATA
+120	./COPY_GATHERDATA
+du: cannot read directory `./JFM01': Permission denied
+4	./JFM01
+912	./IBM13/libtecio.a
+du: cannot access `./IBM13/INCLUDE/INCLUDE_FFT.FI': Permission denied
+du: cannot access `./IBM13/INCLUDE/INCLUDE_CINTERFACE.FI': Permission denied
+du: cannot access `./IBM13/INCLUDE/INCLUDE_LES.FI': Permission denied
+du: cannot access `./IBM13/INCLUDE/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM13/INCLUDE/INCLUDE_WAVEGENERATOR.FI': Permission denied
+du: cannot access `./IBM13/INCLUDE/INCLUDE_PARALLEL.FI': Permission denied
+du: cannot access `./IBM13/INCLUDE/INCLUDE_PETSC.FI': Permission denied
+du: cannot access `./IBM13/INCLUDE/INCLUDE_ASSIMILATION.FI': Permission denied
+du: cannot access `./IBM13/INCLUDE/INCLUDE_IBM.FI': Permission denied
+du: cannot access `./IBM13/INCLUDE/variables_new.h': Permission denied
+du: cannot access `./IBM13/INCLUDE/INCLUDE_PARAMETER.FI': Permission denied
+du: cannot access `./IBM13/INCLUDE/mpm_vars_new.h': Permission denied
+du: cannot access `./IBM13/INCLUDE/INCLUDE_SCALAR.FI': Permission denied
+du: cannot access `./IBM13/INCLUDE/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM13/INCLUDE/INCLUDE_STATS.FI': Permission denied
+du: cannot access `./IBM13/INCLUDE/INCLUDE_POISSON.FI': Permission denied
+4	./IBM13/INCLUDE
+4	./IBM13/vorcenterp.sh
+452	./IBM13/GEOMETRY/PSI.0074
+452	./IBM13/GEOMETRY/PSI.0012
+452	./IBM13/GEOMETRY/PSI.0026
+452	./IBM13/GEOMETRY/PSI.0048
+452	./IBM13/GEOMETRY/PSI.0054
+452	./IBM13/GEOMETRY/PSI.0084
+452	./IBM13/GEOMETRY/PSI.0019
+452	./IBM13/GEOMETRY/PSI.0066
+452	./IBM13/GEOMETRY/PSI.0015
+452	./IBM13/GEOMETRY/PSI.0094
+452	./IBM13/GEOMETRY/PSI.0088
+452	./IBM13/GEOMETRY/PSI.0032
+452	./IBM13/GEOMETRY/PSI.0081
+452	./IBM13/GEOMETRY/PSI.0005
+452	./IBM13/GEOMETRY/PSI.0007
+452	./IBM13/GEOMETRY/PSI.0050
+452	./IBM13/GEOMETRY/PSI.0098
+452	./IBM13/GEOMETRY/PSI.0021
+452	./IBM13/GEOMETRY/PSI.0079
+452	./IBM13/GEOMETRY/PSI.0043
+452	./IBM13/GEOMETRY/PSI.0104
+452	./IBM13/GEOMETRY/PSI.0060
+452	./IBM13/GEOMETRY/PSI.0061
+452	./IBM13/GEOMETRY/PSI.0095
+452	./IBM13/GEOMETRY/PSI.0082
+452	./IBM13/GEOMETRY/PSI.0080
+452	./IBM13/GEOMETRY/PSI.0087
+452	./IBM13/GEOMETRY/PSI.0027
+452	./IBM13/GEOMETRY/PSI.0023
+452	./IBM13/GEOMETRY/PSI.0003
+452	./IBM13/GEOMETRY/PSI.0014
+452	./IBM13/GEOMETRY/PSI.0062
+452	./IBM13/GEOMETRY/PSI.0086
+452	./IBM13/GEOMETRY/PSI.0008
+452	./IBM13/GEOMETRY/PSI.0058
+452	./IBM13/GEOMETRY/PSI.0034
+452	./IBM13/GEOMETRY/PSI.0120
+452	./IBM13/GEOMETRY/PSI.0089
+452	./IBM13/GEOMETRY/PSI.0118
+452	./IBM13/GEOMETRY/PSI.0044
+452	./IBM13/GEOMETRY/PSI.0125
+452	./IBM13/GEOMETRY/PSI.0036
+452	./IBM13/GEOMETRY/PSI.0052
+452	./IBM13/GEOMETRY/PSI.0031
+452	./IBM13/GEOMETRY/PSI.0076
+452	./IBM13/GEOMETRY/PSI.0037
+452	./IBM13/GEOMETRY/PSI.0024
+452	./IBM13/GEOMETRY/PSI.0100
+452	./IBM13/GEOMETRY/PSI.0030
+452	./IBM13/GEOMETRY/PSI.0069
+452	./IBM13/GEOMETRY/PSI.0075
+452	./IBM13/GEOMETRY/PSI.0068
+452	./IBM13/GEOMETRY/PSI.0002
+452	./IBM13/GEOMETRY/PSI.0000
+452	./IBM13/GEOMETRY/PSI.0020
+452	./IBM13/GEOMETRY/PSI.0010
+452	./IBM13/GEOMETRY/PSI.0110
+452	./IBM13/GEOMETRY/PSI.0124
+452	./IBM13/GEOMETRY/PSI.0051
+452	./IBM13/GEOMETRY/PSI.0121
+452	./IBM13/GEOMETRY/PSI.0116
+452	./IBM13/GEOMETRY/PSI.0053
+452	./IBM13/GEOMETRY/PSI.0073
+452	./IBM13/GEOMETRY/PSI.0018
+452	./IBM13/GEOMETRY/PSI.0106
+452	./IBM13/GEOMETRY/PSI.0004
+452	./IBM13/GEOMETRY/PSI.0035
+452	./IBM13/GEOMETRY/PSI.0083
+452	./IBM13/GEOMETRY/PSI.0013
+452	./IBM13/GEOMETRY/PSI.0022
+452	./IBM13/GEOMETRY/PSI.0101
+452	./IBM13/GEOMETRY/PSI.0122
+452	./IBM13/GEOMETRY/PSI.0016
+452	./IBM13/GEOMETRY/PSI.0119
+452	./IBM13/GEOMETRY/PSI.0067
+452	./IBM13/GEOMETRY/PSI.0072
+452	./IBM13/GEOMETRY/PSI.0112
+452	./IBM13/GEOMETRY/PSI.0039
+452	./IBM13/GEOMETRY/PSI.0017
+452	./IBM13/GEOMETRY/PSI.0097
+452	./IBM13/GEOMETRY/PSI.0107
+452	./IBM13/GEOMETRY/PSI.0108
+452	./IBM13/GEOMETRY/PSI.0123
+452	./IBM13/GEOMETRY/PSI.0063
+452	./IBM13/GEOMETRY/PSI.0102
+452	./IBM13/GEOMETRY/PSI.0047
+452	./IBM13/GEOMETRY/PSI.0045
+452	./IBM13/GEOMETRY/PSI.0070
+452	./IBM13/GEOMETRY/PSI.0038
+452	./IBM13/GEOMETRY/PSI.0127
+452	./IBM13/GEOMETRY/PSI.0056
+452	./IBM13/GEOMETRY/PSI.0078
+452	./IBM13/GEOMETRY/PSI.0126
+452	./IBM13/GEOMETRY/PSI.0046
+452	./IBM13/GEOMETRY/PSI.0064
+452	./IBM13/GEOMETRY/PSI.0096
+452	./IBM13/GEOMETRY/PSI.0077
+452	./IBM13/GEOMETRY/PSI.0025
+452	./IBM13/GEOMETRY/PSI.0040
+452	./IBM13/GEOMETRY/PSI.0011
+452	./IBM13/GEOMETRY/PSI.0041
+452	./IBM13/GEOMETRY/PSI.0109
+452	./IBM13/GEOMETRY/PSI.0090
+452	./IBM13/GEOMETRY/PSI.0042
+452	./IBM13/GEOMETRY/PSI.0105
+452	./IBM13/GEOMETRY/PSI.0009
+452	./IBM13/GEOMETRY/PSI.0028
+452	./IBM13/GEOMETRY/PSI.0114
+452	./IBM13/GEOMETRY/PSI.0006
+452	./IBM13/GEOMETRY/PSI.0033
+452	./IBM13/GEOMETRY/PSI.0055
+452	./IBM13/GEOMETRY/PSI.0071
+452	./IBM13/GEOMETRY/PSI.0113
+452	./IBM13/GEOMETRY/PSI.0049
+452	./IBM13/GEOMETRY/PSI.0103
+452	./IBM13/GEOMETRY/PSI.0001
+452	./IBM13/GEOMETRY/PSI.0099
+452	./IBM13/GEOMETRY/PSI.0065
+452	./IBM13/GEOMETRY/PSI.0111
+452	./IBM13/GEOMETRY/PSI.0059
+452	./IBM13/GEOMETRY/PSI.0085
+452	./IBM13/GEOMETRY/PSI.0029
+452	./IBM13/GEOMETRY/PSI.0057
+452	./IBM13/GEOMETRY/PSI.0115
+452	./IBM13/GEOMETRY/PSI.0117
+452	./IBM13/GEOMETRY/PSI.0091
+452	./IBM13/GEOMETRY/PSI.0092
+452	./IBM13/GEOMETRY/PSI.0093
+57868	./IBM13/GEOMETRY
+du: cannot access `./IBM13/CALCULATE/FDM_026_PD_SPE.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_043_VOF.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_123_WALLMODEL_POWERLAW.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_023_SMOOTHING.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_027_RK.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_302_WAVYVOR_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_033_IBM_INTFORCING.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_010_INIT_PARALLEL.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_110_RNG.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_025_PD.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_070_PARALLEL.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_121_WALLMODEL_KANG.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_304_ASSIMILATION_WAVY.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_032_IBM_EXTFORCING.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_111_GERMANO.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_023_SMOOTHING.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_122_WALLMODEL_ROMAN.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_304_ASSIMILATION_WAVY.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_000_MAIN.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_032_IBM_EXTFORCING.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_042_LS.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_123_WALLMODEL_POWERLAW.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_030_IBM.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_044_PRESCRIBEWAVE.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_080_FFT.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_020_PRESOLVE.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_091_SEDIMENT.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_300_ASSIMILATION.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_060_STATS_TS.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_303_MEANFLUC_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_070_PARALLEL.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_305_ASSIMILATION_VORT.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_301_ASSIMILATION_GEOMETRY.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_033_IBM_INTFORCING.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_030_IBM.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_306_ASSIMILATION_TOTAL.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_027_RK.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_020_PRESOLVE.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_021_RHS.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_111_GERMANO.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_999_FINALIZE.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_090_DYE.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_062_STRAINRATE.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_130_INT.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_051_IO.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_063_CIRCVELO.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_061_STATS_TA.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_062_STRAINRATE.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_022_WG.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_050_OUTPUT.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_121_WALLMODEL_KANG.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_043_VOF.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_090_DYE.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_130_INT.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_120_WALLMODEL_TBL.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_021_RHS.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_303_MEANFLUC_DECOMPOSITION.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_306_ASSIMILATION_TOTAL.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_100_LES.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_031_IBM_INIT.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_061_STATS_TA.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_301_ASSIMILATION_GEOMETRY.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_300_ASSIMILATION.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_010_INIT_PARALLEL.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_050_OUTPUT.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_044_PRESCRIBEWAVE.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/tags': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_051_IO.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_110_RNG.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_022_WG.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_025_PD.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_122_WALLMODEL_ROMAN.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_012_INIT_FIELD.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_200_PETSC_SOLVER.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_307_TRACER.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_001_FSTRANSFER.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_305_ASSIMILATION_VORT.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_100_LES.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_060_STATS_TS.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_091_SEDIMENT.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_307_TRACER.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_031_IBM_INIT.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_302_WAVYVOR_DECOMPOSITION.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_080_FFT.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_120_WALLMODEL_TBL.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_026_PD_SPE.F90': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_012_INIT_FIELD.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_063_CIRCVELO.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_000_MAIN.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_042_LS.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_011_INIT_CONSTANTS.o': Permission denied
+du: cannot access `./IBM13/CALCULATE/FDM_200_PETSC_SOLVER.o': Permission denied
+12	./IBM13/CALCULATE
+8	./IBM13/volume.dat
+575056	./IBM13/DATA/V00037000.H5
+575056	./IBM13/DATA/V00024200.H5
+575056	./IBM13/DATA/V00030400.H5
+575056	./IBM13/DATA/V00036400.H5
+575056	./IBM13/DATA/V00024400.H5
+575056	./IBM13/DATA/V00022200.H5
+575056	./IBM13/DATA/V00033400.H5
+575056	./IBM13/DATA/V00031000.H5
+575056	./IBM13/DATA/V00034800.H5
+575056	./IBM13/DATA/V00030800.H5
+575056	./IBM13/DATA/V00030200.H5
+575056	./IBM13/DATA/V00039400.H5
+575056	./IBM13/DATA/V00027800.H5
+575056	./IBM13/DATA/V00030000.H5
+575056	./IBM13/DATA/V00026200.H5
+575056	./IBM13/DATA/V00042200.H5
+575056	./IBM13/DATA/V00039600.H5
+575056	./IBM13/DATA/V00027400.H5
+575056	./IBM13/DATA/V00033000.H5
+575056	./IBM13/DATA/V00045800.H5
+575056	./IBM13/DATA/V00027200.H5
+575056	./IBM13/DATA/V00023600.H5
+575056	./IBM13/DATA/V00040600.H5
+575056	./IBM13/DATA/V00037600.H5
+575056	./IBM13/DATA/V00025800.H5
+575056	./IBM13/DATA/V00021800.H5
+575056	./IBM13/DATA/V00040800.H5
+575056	./IBM13/DATA/V00023400.H5
+575056	./IBM13/DATA/V00042800.H5
+575056	./IBM13/DATA/V00036000.H5
+575056	./IBM13/DATA/V00043000.H5
+575056	./IBM13/DATA/V00041600.H5
+575056	./IBM13/DATA/V00036800.H5
+575056	./IBM13/DATA/V00033600.H5
+575056	./IBM13/DATA/V00041000.H5
+575056	./IBM13/DATA/V00024600.H5
+575056	./IBM13/DATA/V00041400.H5
+575056	./IBM13/DATA/V00042600.H5
+575056	./IBM13/DATA/V00035800.H5
+575056	./IBM13/DATA/V00038800.H5
+575056	./IBM13/DATA/V00020800.H5
+575056	./IBM13/DATA/V00037400.H5
+575056	./IBM13/DATA/V00026600.H5
+575056	./IBM13/DATA/V00027000.H5
+575056	./IBM13/DATA/V00021200.H5
+575056	./IBM13/DATA/V00044800.H5
+575056	./IBM13/DATA/V00044200.H5
+575056	./IBM13/DATA/V00029200.H5
+575056	./IBM13/DATA/V00038000.H5
+575056	./IBM13/DATA/V00033800.H5
+575056	./IBM13/DATA/V00025200.H5
+575056	./IBM13/DATA/V00032600.H5
+575056	./IBM13/DATA/V00038200.H5
+575056	./IBM13/DATA/V00044000.H5
+575056	./IBM13/DATA/V00025600.H5
+575056	./IBM13/DATA/V00029800.H5
+575056	./IBM13/DATA/V00034000.H5
+575056	./IBM13/DATA/V00041200.H5
+575056	./IBM13/DATA/V00028000.H5
+575056	./IBM13/DATA/V00040000.H5
+575056	./IBM13/DATA/V00031400.H5
+575056	./IBM13/DATA/V00029000.H5
+575056	./IBM13/DATA/V00046800.H5
+575056	./IBM13/DATA/V00043800.H5
+575056	./IBM13/DATA/V00040200.H5
+575056	./IBM13/DATA/V00034400.H5
+575056	./IBM13/DATA/V00027600.H5
+575056	./IBM13/DATA/V00040400.H5
+575056	./IBM13/DATA/V00031200.H5
+575056	./IBM13/DATA/V00028600.H5
+575056	./IBM13/DATA/V00039200.H5
+575056	./IBM13/DATA/V00047200.H5
+575056	./IBM13/DATA/V00029400.H5
+575056	./IBM13/DATA/V00020600.H5
+575056	./IBM13/DATA/V00022400.H5
+575056	./IBM13/DATA/V00044600.H5
+575056	./IBM13/DATA/V00039800.H5
+575056	./IBM13/DATA/V00031800.H5
+575056	./IBM13/DATA/V00045600.H5
+575056	./IBM13/DATA/V00024000.H5
+575056	./IBM13/DATA/V00029600.H5
+575056	./IBM13/DATA/V00021400.H5
+575056	./IBM13/DATA/V00020200.H5
+575056	./IBM13/DATA/V00045000.H5
+575056	./IBM13/DATA/V00044400.H5
+575056	./IBM13/DATA/V00023000.H5
+575056	./IBM13/DATA/V00032800.H5
+575056	./IBM13/DATA/V00025400.H5
+575056	./IBM13/DATA/V00023200.H5
+575056	./IBM13/DATA/V00024800.H5
+575056	./IBM13/DATA/V00026400.H5
+575056	./IBM13/DATA/V00035600.H5
+575056	./IBM13/DATA/V00035000.H5
+575056	./IBM13/DATA/V00023800.H5
+575056	./IBM13/DATA/V00035400.H5
+575056	./IBM13/DATA/V00037800.H5
+575056	./IBM13/DATA/V00028800.H5
+575056	./IBM13/DATA/V00020000.H5
+575056	./IBM13/DATA/V00033200.H5
+575056	./IBM13/DATA/V00022600.H5
+575056	./IBM13/DATA/V00043200.H5
+575056	./IBM13/DATA/V00032200.H5
+575056	./IBM13/DATA/V00041800.H5
+575056	./IBM13/DATA/V00042000.H5
+575056	./IBM13/DATA/V00032400.H5
+575056	./IBM13/DATA/V00036200.H5
+575056	./IBM13/DATA/V00022800.H5
+575056	./IBM13/DATA/V00035200.H5
+575056	./IBM13/DATA/V00030600.H5
+575056	./IBM13/DATA/V00028400.H5
+575056	./IBM13/DATA/V00022000.H5
+575056	./IBM13/DATA/V00020400.H5
+575056	./IBM13/DATA/V00043600.H5
+575056	./IBM13/DATA/V00046200.H5
+575056	./IBM13/DATA/V00046400.H5
+575056	./IBM13/DATA/V00036600.H5
+575056	./IBM13/DATA/V00032000.H5
+575056	./IBM13/DATA/V00021000.H5
+575056	./IBM13/DATA/V00026000.H5
+575056	./IBM13/DATA/V00026800.H5
+575056	./IBM13/DATA/V00037200.H5
+575056	./IBM13/DATA/V00038400.H5
+575056	./IBM13/DATA/V00025000.H5
+575056	./IBM13/DATA/V00043400.H5
+575056	./IBM13/DATA/V00031600.H5
+575056	./IBM13/DATA/V00046000.H5
+575056	./IBM13/DATA/V00042400.H5
+575056	./IBM13/DATA/V00046600.H5
+575056	./IBM13/DATA/V00038600.H5
+575056	./IBM13/DATA/V00045200.H5
+575056	./IBM13/DATA/V00021600.H5
+575056	./IBM13/DATA/V00034200.H5
+575056	./IBM13/DATA/V00047000.H5
+575056	./IBM13/DATA/V00039000.H5
+575056	./IBM13/DATA/V00028200.H5
+575056	./IBM13/DATA/V00034600.H5
+575056	./IBM13/DATA/V00045400.H5
+78782692	./IBM13/DATA
+du: cannot access `./IBM13/LIB/libtecio.a': Permission denied
+4	./IBM13/LIB
+du: cannot access `./IBM13/POST_BASIC/POST_020_STATS.F90': Permission denied
+du: cannot access `./IBM13/POST_BASIC/POST_030_READFILE.F90': Permission denied
+du: cannot access `./IBM13/POST_BASIC/POST_031_PARALLEL.F90': Permission denied
+du: cannot access `./IBM13/POST_BASIC/POST_000_MAIN.F90': Permission denied
+du: cannot access `./IBM13/POST_BASIC/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM13/POST_BASIC/POST_040_AVERAGE.F90': Permission denied
+du: cannot access `./IBM13/POST_BASIC/POST_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM13/POST_BASIC/POST_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM13/POST_BASIC/POST_050_WRITEFILE.F90': Permission denied
+du: cannot access `./IBM13/POST_BASIC/POST_010_INIT_PARALLEL.F90': Permission denied
+4	./IBM13/POST_BASIC
+464	./IBM13/gatherdata
+12	./IBM13/POST_TKE/TKEDATA_IBM.F90
+4	./IBM13/POST_TKE/TKE_IO.F90
+4	./IBM13/POST_TKE/INCLUDE_IO.FI
+8	./IBM13/POST_TKE/TKEPRE.F90
+4	./IBM13/POST_TKE/TKEPS.F90
+12	./IBM13/POST_TKE/tecio.f90
+48	./IBM13/POST_TKE
+4	./IBM13/aegean_stream.sh
+8	./IBM13/Makefile
+373184	./IBM13/VORCENTER_PRE/00029800.DAT
+373184	./IBM13/VORCENTER_PRE/00011000.DAT
+373176	./IBM13/VORCENTER_PRE/00044200.DAT
+373184	./IBM13/VORCENTER_PRE/00024600.DAT
+373184	./IBM13/VORCENTER_PRE/00031800.DAT
+373184	./IBM13/VORCENTER_PRE/00033200.DAT
+373184	./IBM13/VORCENTER_PRE/00015200.DAT
+373184	./IBM13/VORCENTER_PRE/00036000.DAT
+373184	./IBM13/VORCENTER_PRE/00013800.DAT
+373184	./IBM13/VORCENTER_PRE/00016800.DAT
+373184	./IBM13/VORCENTER_PRE/00027000.DAT
+373184	./IBM13/VORCENTER_PRE/00021400.DAT
+373184	./IBM13/VORCENTER_PRE/00040000.DAT
+373184	./IBM13/VORCENTER_PRE/00007800.DAT
+373184	./IBM13/VORCENTER_PRE/00022000.DAT
+373184	./IBM13/VORCENTER_PRE/00014600.DAT
+373184	./IBM13/VORCENTER_PRE/00033000.DAT
+373184	./IBM13/VORCENTER_PRE/00034200.DAT
+373184	./IBM13/VORCENTER_PRE/00028000.DAT
+373184	./IBM13/VORCENTER_PRE/00032800.DAT
+373184	./IBM13/VORCENTER_PRE/00007400.DAT
+373184	./IBM13/VORCENTER_PRE/00024400.DAT
+373184	./IBM13/VORCENTER_PRE/00016400.DAT
+373184	./IBM13/VORCENTER_PRE/00006400.DAT
+373184	./IBM13/VORCENTER_PRE/00006600.DAT
+373176	./IBM13/VORCENTER_PRE/00045400.DAT
+373184	./IBM13/VORCENTER_PRE/00016200.DAT
+373184	./IBM13/VORCENTER_PRE/00005600.DAT
+373184	./IBM13/VORCENTER_PRE/00026400.DAT
+373184	./IBM13/VORCENTER_PRE/00021200.DAT
+373184	./IBM13/VORCENTER_PRE/00023400.DAT
+373184	./IBM13/VORCENTER_PRE/00027600.DAT
+373176	./IBM13/VORCENTER_PRE/00045000.DAT
+373184	./IBM13/VORCENTER_PRE/00018800.DAT
+373176	./IBM13/VORCENTER_PRE/00044800.DAT
+373176	./IBM13/VORCENTER_PRE/00043400.DAT
+373184	./IBM13/VORCENTER_PRE/00022400.DAT
+373184	./IBM13/VORCENTER_PRE/00026800.DAT
+373176	./IBM13/VORCENTER_PRE/00042800.DAT
+373184	./IBM13/VORCENTER_PRE/00004600.DAT
+373184	./IBM13/VORCENTER_PRE/00019400.DAT
+373184	./IBM13/VORCENTER_PRE/00029600.DAT
+373172	./IBM13/VORCENTER_PRE/00046400.DAT
+373184	./IBM13/VORCENTER_PRE/00004800.DAT
+373184	./IBM13/VORCENTER_PRE/00040200.DAT
+373184	./IBM13/VORCENTER_PRE/00039200.DAT
+373184	./IBM13/VORCENTER_PRE/00024000.DAT
+373184	./IBM13/VORCENTER_PRE/00024800.DAT
+373184	./IBM13/VORCENTER_PRE/00033800.DAT
+373184	./IBM13/VORCENTER_PRE/00002000.DAT
+373184	./IBM13/VORCENTER_PRE/00041400.DAT
+373184	./IBM13/VORCENTER_PRE/00012400.DAT
+373184	./IBM13/VORCENTER_PRE/00000200.DAT
+373184	./IBM13/VORCENTER_PRE/00008200.DAT
+373184	./IBM13/VORCENTER_PRE/00035200.DAT
+373184	./IBM13/VORCENTER_PRE/00020200.DAT
+373184	./IBM13/VORCENTER_PRE/00029200.DAT
+373184	./IBM13/VORCENTER_PRE/00041800.DAT
+373184	./IBM13/VORCENTER_PRE/00035400.DAT
+373184	./IBM13/VORCENTER_PRE/00009400.DAT
+373184	./IBM13/VORCENTER_PRE/00020600.DAT
+373184	./IBM13/VORCENTER_PRE/00031000.DAT
+373172	./IBM13/VORCENTER_PRE/00045800.DAT
+373184	./IBM13/VORCENTER_PRE/00020400.DAT
+373184	./IBM13/VORCENTER_PRE/00011600.DAT
+373176	./IBM13/VORCENTER_PRE/00042600.DAT
+373184	./IBM13/VORCENTER_PRE/00002200.DAT
+373184	./IBM13/VORCENTER_PRE/00023200.DAT
+373184	./IBM13/VORCENTER_PRE/00037400.DAT
+373184	./IBM13/VORCENTER_PRE/00028400.DAT
+373184	./IBM13/VORCENTER_PRE/00032600.DAT
+373184	./IBM13/VORCENTER_PRE/00038000.DAT
+373168	./IBM13/VORCENTER_PRE/00046600.DAT
+373184	./IBM13/VORCENTER_PRE/00034400.DAT
+373184	./IBM13/VORCENTER_PRE/00025600.DAT
+373184	./IBM13/VORCENTER_PRE/00030800.DAT
+373184	./IBM13/VORCENTER_PRE/00008800.DAT
+373184	./IBM13/VORCENTER_PRE/00003200.DAT
+373184	./IBM13/VORCENTER_PRE/00015400.DAT
+373184	./IBM13/VORCENTER_PRE/00001800.DAT
+373184	./IBM13/VORCENTER_PRE/00029000.DAT
+373176	./IBM13/VORCENTER_PRE/00043800.DAT
+373184	./IBM13/VORCENTER_PRE/00002400.DAT
+373184	./IBM13/VORCENTER_PRE/00040800.DAT
+373184	./IBM13/VORCENTER_PRE/00017800.DAT
+373176	./IBM13/VORCENTER_PRE/00045600.DAT
+373184	./IBM13/VORCENTER_PRE/00002600.DAT
+373184	./IBM13/VORCENTER_PRE/00015800.DAT
+373184	./IBM13/VORCENTER_PRE/00037000.DAT
+373184	./IBM13/VORCENTER_PRE/00011200.DAT
+373184	./IBM13/VORCENTER_PRE/00030600.DAT
+373184	./IBM13/VORCENTER_PRE/00036600.DAT
+373172	./IBM13/VORCENTER_PRE/00047000.DAT
+373184	./IBM13/VORCENTER_PRE/00030200.DAT
+373184	./IBM13/VORCENTER_PRE/00032400.DAT
+373184	./IBM13/VORCENTER_PRE/00009800.DAT
+373184	./IBM13/VORCENTER_PRE/00001200.DAT
+373184	./IBM13/VORCENTER_PRE/00010000.DAT
+373184	./IBM13/VORCENTER_PRE/00001000.DAT
+373168	./IBM13/VORCENTER_PRE/00046200.DAT
+373184	./IBM13/VORCENTER_PRE/00014400.DAT
+373168	./IBM13/VORCENTER_PRE/00046000.DAT
+373184	./IBM13/VORCENTER_PRE/00034600.DAT
+373184	./IBM13/VORCENTER_PRE/00020800.DAT
+373184	./IBM13/VORCENTER_PRE/00022600.DAT
+373184	./IBM13/VORCENTER_PRE/00037200.DAT
+373184	./IBM13/VORCENTER_PRE/00001600.DAT
+373184	./IBM13/VORCENTER_PRE/00004400.DAT
+373184	./IBM13/VORCENTER_PRE/00010600.DAT
+373184	./IBM13/VORCENTER_PRE/00037800.DAT
+373184	./IBM13/VORCENTER_PRE/00018000.DAT
+373176	./IBM13/VORCENTER_PRE/00043200.DAT
+373184	./IBM13/VORCENTER_PRE/00014200.DAT
+373184	./IBM13/VORCENTER_PRE/00034800.DAT
+373184	./IBM13/VORCENTER_PRE/00001400.DAT
+373184	./IBM13/VORCENTER_PRE/00006800.DAT
+373184	./IBM13/VORCENTER_PRE/00003600.DAT
+373184	./IBM13/VORCENTER_PRE/00026200.DAT
+373184	./IBM13/VORCENTER_PRE/00027400.DAT
+373184	./IBM13/VORCENTER_PRE/00042000.DAT
+373184	./IBM13/VORCENTER_PRE/00028800.DAT
+373184	./IBM13/VORCENTER_PRE/00031200.DAT
+373184	./IBM13/VORCENTER_PRE/00016600.DAT
+373184	./IBM13/VORCENTER_PRE/00036800.DAT
+373184	./IBM13/VORCENTER_PRE/00007200.DAT
+373184	./IBM13/VORCENTER_PRE/00032200.DAT
+373176	./IBM13/VORCENTER_PRE/00044400.DAT
+373184	./IBM13/VORCENTER_PRE/00033600.DAT
+373184	./IBM13/VORCENTER_PRE/00031600.DAT
+373184	./IBM13/VORCENTER_PRE/00030000.DAT
+373184	./IBM13/VORCENTER_PRE/00017000.DAT
+373184	./IBM13/VORCENTER_PRE/00042200.DAT
+373184	./IBM13/VORCENTER_PRE/00026000.DAT
+373184	./IBM13/VORCENTER_PRE/00023600.DAT
+373184	./IBM13/VORCENTER_PRE/00040400.DAT
+373184	./IBM13/VORCENTER_PRE/00041200.DAT
+373184	./IBM13/VORCENTER_PRE/00028600.DAT
+373184	./IBM13/VORCENTER_PRE/00038800.DAT
+373184	./IBM13/VORCENTER_PRE/00039400.DAT
+373184	./IBM13/VORCENTER_PRE/00025400.DAT
+373184	./IBM13/VORCENTER_PRE/00040600.DAT
+373184	./IBM13/VORCENTER_PRE/00010800.DAT
+373184	./IBM13/VORCENTER_PRE/00039800.DAT
+373184	./IBM13/VORCENTER_PRE/00025200.DAT
+373184	./IBM13/VORCENTER_PRE/00007600.DAT
+373184	./IBM13/VORCENTER_PRE/00020000.DAT
+373184	./IBM13/VORCENTER_PRE/00000800.DAT
+373184	./IBM13/VORCENTER_PRE/00018400.DAT
+373176	./IBM13/VORCENTER_PRE/00043600.DAT
+373184	./IBM13/VORCENTER_PRE/00024200.DAT
+373184	./IBM13/VORCENTER_PRE/00005800.DAT
+373184	./IBM13/VORCENTER_PRE/00012000.DAT
+373184	./IBM13/VORCENTER_PRE/00000400.DAT
+373184	./IBM13/VORCENTER_PRE/00006000.DAT
+373184	./IBM13/VORCENTER_PRE/00008600.DAT
+373184	./IBM13/VORCENTER_PRE/00003800.DAT
+373184	./IBM13/VORCENTER_PRE/00027200.DAT
+373184	./IBM13/VORCENTER_PRE/00021600.DAT
+373184	./IBM13/VORCENTER_PRE/00013000.DAT
+373184	./IBM13/VORCENTER_PRE/00013200.DAT
+373184	./IBM13/VORCENTER_PRE/00000600.DAT
+373184	./IBM13/VORCENTER_PRE/00015000.DAT
+373184	./IBM13/VORCENTER_PRE/00004000.DAT
+373184	./IBM13/VORCENTER_PRE/00041600.DAT
+373184	./IBM13/VORCENTER_PRE/00036200.DAT
+373184	./IBM13/VORCENTER_PRE/00019800.DAT
+373184	./IBM13/VORCENTER_PRE/00035000.DAT
+373184	./IBM13/VORCENTER_PRE/00012800.DAT
+373184	./IBM13/VORCENTER_PRE/00038400.DAT
+373184	./IBM13/VORCENTER_PRE/00004200.DAT
+373184	./IBM13/VORCENTER_PRE/00010200.DAT
+373184	./IBM13/VORCENTER_PRE/00041000.DAT
+373184	./IBM13/VORCENTER_PRE/00011400.DAT
+373184	./IBM13/VORCENTER_PRE/00023800.DAT
+373176	./IBM13/VORCENTER_PRE/00045200.DAT
+373184	./IBM13/VORCENTER_PRE/00032000.DAT
+373184	./IBM13/VORCENTER_PRE/00026600.DAT
+373184	./IBM13/VORCENTER_PRE/00037600.DAT
+373184	./IBM13/VORCENTER_PRE/00038600.DAT
+373184	./IBM13/VORCENTER_PRE/00005000.DAT
+373184	./IBM13/VORCENTER_PRE/00005200.DAT
+373184	./IBM13/VORCENTER_PRE/00023000.DAT
+373184	./IBM13/VORCENTER_PRE/00039600.DAT
+373168	./IBM13/VORCENTER_PRE/00047200.DAT
+373184	./IBM13/VORCENTER_PRE/00019600.DAT
+373184	./IBM13/VORCENTER_PRE/00028200.DAT
+373184	./IBM13/VORCENTER_PRE/00021000.DAT
+373184	./IBM13/VORCENTER_PRE/00010400.DAT
+373184	./IBM13/VORCENTER_PRE/00011800.DAT
+373184	./IBM13/VORCENTER_PRE/00017600.DAT
+373184	./IBM13/VORCENTER_PRE/00018600.DAT
+373184	./IBM13/VORCENTER_PRE/00012200.DAT
+373184	./IBM13/VORCENTER_PRE/00033400.DAT
+373184	./IBM13/VORCENTER_PRE/00019200.DAT
+373184	./IBM13/VORCENTER_PRE/00012600.DAT
+373184	./IBM13/VORCENTER_PRE/00005400.DAT
+373184	./IBM13/VORCENTER_PRE/00017400.DAT
+373184	./IBM13/VORCENTER_PRE/00003000.DAT
+373184	./IBM13/VORCENTER_PRE/00009600.DAT
+373184	./IBM13/VORCENTER_PRE/00016000.DAT
+373184	./IBM13/VORCENTER_PRE/00030400.DAT
+373184	./IBM13/VORCENTER_PRE/00014000.DAT
+373184	./IBM13/VORCENTER_PRE/00014800.DAT
+373184	./IBM13/VORCENTER_PRE/00038200.DAT
+373184	./IBM13/VORCENTER_PRE/00035600.DAT
+373176	./IBM13/VORCENTER_PRE/00043000.DAT
+373184	./IBM13/VORCENTER_PRE/00031400.DAT
+373184	./IBM13/VORCENTER_PRE/00013600.DAT
+373184	./IBM13/VORCENTER_PRE/00021800.DAT
+373184	./IBM13/VORCENTER_PRE/00018200.DAT
+373184	./IBM13/VORCENTER_PRE/00025800.DAT
+373184	./IBM13/VORCENTER_PRE/00042400.DAT
+373184	./IBM13/VORCENTER_PRE/00015600.DAT
+373184	./IBM13/VORCENTER_PRE/00039000.DAT
+373184	./IBM13/VORCENTER_PRE/00035800.DAT
+373184	./IBM13/VORCENTER_PRE/00000000.DAT
+373176	./IBM13/VORCENTER_PRE/00044000.DAT
+373184	./IBM13/VORCENTER_PRE/00009000.DAT
+373184	./IBM13/VORCENTER_PRE/00008400.DAT
+373184	./IBM13/VORCENTER_PRE/00006200.DAT
+373184	./IBM13/VORCENTER_PRE/00017200.DAT
+373184	./IBM13/VORCENTER_PRE/00029400.DAT
+373184	./IBM13/VORCENTER_PRE/00007000.DAT
+373184	./IBM13/VORCENTER_PRE/00013400.DAT
+373184	./IBM13/VORCENTER_PRE/00019000.DAT
+373184	./IBM13/VORCENTER_PRE/00034000.DAT
+373184	./IBM13/VORCENTER_PRE/00022200.DAT
+373184	./IBM13/VORCENTER_PRE/00002800.DAT
+373184	./IBM13/VORCENTER_PRE/00025000.DAT
+373184	./IBM13/VORCENTER_PRE/00008000.DAT
+373184	./IBM13/VORCENTER_PRE/00036400.DAT
+373184	./IBM13/VORCENTER_PRE/00009200.DAT
+373184	./IBM13/VORCENTER_PRE/00003400.DAT
+373184	./IBM13/VORCENTER_PRE/00027800.DAT
+373184	./IBM13/VORCENTER_PRE/00022800.DAT
+373172	./IBM13/VORCENTER_PRE/00046800.DAT
+373176	./IBM13/VORCENTER_PRE/00044600.DAT
+88444384	./IBM13/VORCENTER_PRE
+4	./IBM13/WAVE
+4	./IBM13/RESTART_SOLID
+631528	./IBM13/STATS/BASIC.H5
+4	./IBM13/STATS/STAT_STEP
+631536	./IBM13/STATS
+4	./IBM13/vor.sh
+du: cannot access `./IBM13/batchrun/main.py': Permission denied
+du: cannot access `./IBM13/batchrun/grid.py': Permission denied
+du: cannot access `./IBM13/batchrun/param.py': Permission denied
+du: cannot access `./IBM13/batchrun/compile.py': Permission denied
+du: cannot access `./IBM13/batchrun/control.py': Permission denied
+du: cannot access `./IBM13/batchrun/directory.py': Permission denied
+du: cannot access `./IBM13/batchrun/ReadMe.md': Permission denied
+du: cannot access `./IBM13/batchrun/script.py': Permission denied
+4	./IBM13/batchrun
+4	./IBM13/resga
+5544	./IBM13/sour.dat
+4	./IBM13/aga.sh
+du: cannot access `./IBM13/POST/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM13/POST/post': Permission denied
+du: cannot access `./IBM13/POST/POST_TKE.F90': Permission denied
+du: cannot access `./IBM13/POST/POST_SURFACE.F90': Permission denied
+du: cannot access `./IBM13/POST/POST_IO.F90': Permission denied
+4	./IBM13/POST
+4	./IBM13/PARAM.IN
+4	./IBM13/CIRC_VELO
+4	./IBM13/vorcenter.sh
+9376	./IBM13/TIME_SERIES/MAXUVW.DAT
+1660	./IBM13/TIME_SERIES/YTIP.DAT
+5564	./IBM13/TIME_SERIES/CDCF.DAT
+16604	./IBM13/TIME_SERIES
+du: cannot access `./IBM13/GATHERDATA/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM13/GATHERDATA/GATHER_IO.o': Permission denied
+du: cannot access `./IBM13/GATHERDATA/tecio.f90': Permission denied
+du: cannot access `./IBM13/GATHERDATA/GATHER_IO.F90': Permission denied
+du: cannot access `./IBM13/GATHERDATA/GATHERDATA.o': Permission denied
+du: cannot access `./IBM13/GATHERDATA/GATHERDATA.F90': Permission denied
+4	./IBM13/GATHERDATA
+du: cannot access `./IBM13/POST_VORTEX/FDM_064_VORENSTROPHY.F90': Permission denied
+du: cannot access `./IBM13/POST_VORTEX/VORTEXP.F90': Permission denied
+du: cannot access `./IBM13/POST_VORTEX/VORDYNAMIC.F90': Permission denied
+du: cannot access `./IBM13/POST_VORTEX/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM13/POST_VORTEX/POST_VORTEX.F90': Permission denied
+du: cannot access `./IBM13/POST_VORTEX/VORMAX.F90': Permission denied
+du: cannot access `./IBM13/POST_VORTEX/tecio.f90': Permission denied
+du: cannot access `./IBM13/POST_VORTEX/VORTEX_IO.F90': Permission denied
+du: cannot access `./IBM13/POST_VORTEX/VORTEX_IBM.F90': Permission denied
+du: cannot access `./IBM13/POST_VORTEX/tags': Permission denied
+du: cannot access `./IBM13/POST_VORTEX/VORTEX.F90': Permission denied
+du: cannot access `./IBM13/POST_VORTEX/VORTEX_X.F90': Permission denied
+du: cannot access `./IBM13/POST_VORTEX/VORDYNAMIC_TH.F90': Permission denied
+du: cannot access `./IBM13/POST_VORTEX/VORDYNAMIC_Y.F90': Permission denied
+4	./IBM13/POST_VORTEX
+17612	./IBM13/wave
+du: cannot access `./IBM13/POST_WAVY_WALL/POST_030_READFILE.F90': Permission denied
+du: cannot access `./IBM13/POST_WAVY_WALL/POST_000_MAIN.F90': Permission denied
+du: cannot access `./IBM13/POST_WAVY_WALL/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM13/POST_WAVY_WALL/POST_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM13/POST_WAVY_WALL/POST_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM13/POST_WAVY_WALL/POST_040_WRITEFILE.F90': Permission denied
+du: cannot access `./IBM13/POST_WAVY_WALL/POST_020_AVERAGE.F90': Permission denied
+du: cannot access `./IBM13/POST_WAVY_WALL/POST_010_INIT_PARALLEL.F90': Permission denied
+4	./IBM13/POST_WAVY_WALL
+4	./IBM13/TRACER
+8	./IBM13/GRID.IN
+319648	./IBM13/INSTANTANEOUS/3D00034000.plt
+319648	./IBM13/INSTANTANEOUS/3D00040000.plt
+319640	./IBM13/INSTANTANEOUS/3D00045400.plt
+319648	./IBM13/INSTANTANEOUS/3D00037000.plt
+319648	./IBM13/INSTANTANEOUS/3D00033800.plt
+319648	./IBM13/INSTANTANEOUS/3D00036200.plt
+319652	./IBM13/INSTANTANEOUS/3D00032600.plt
+319648	./IBM13/INSTANTANEOUS/3D00037600.plt
+319648	./IBM13/INSTANTANEOUS/3D00037800.plt
+319648	./IBM13/INSTANTANEOUS/3D00035400.plt
+319648	./IBM13/INSTANTANEOUS/3D00041000.plt
+319648	./IBM13/INSTANTANEOUS/3D00040800.plt
+319640	./IBM13/INSTANTANEOUS/3D00045800.plt
+319648	./IBM13/INSTANTANEOUS/3D00036600.plt
+319648	./IBM13/INSTANTANEOUS/3D00037400.plt
+319640	./IBM13/INSTANTANEOUS/3D00043800.plt
+319652	./IBM13/INSTANTANEOUS/3D00031600.plt
+319648	./IBM13/INSTANTANEOUS/3D00039800.plt
+319648	./IBM13/INSTANTANEOUS/3D00038000.plt
+319640	./IBM13/INSTANTANEOUS/3D00045600.plt
+319648	./IBM13/INSTANTANEOUS/3D00034400.plt
+319640	./IBM13/INSTANTANEOUS/3D00047000.plt
+319648	./IBM13/INSTANTANEOUS/3D00041800.plt
+319640	./IBM13/INSTANTANEOUS/3D00044600.plt
+319640	./IBM13/INSTANTANEOUS/3D00045000.plt
+319652	./IBM13/INSTANTANEOUS/3D00029800.plt
+319648	./IBM13/INSTANTANEOUS/3D00044800.plt
+319652	./IBM13/INSTANTANEOUS/3D00032000.plt
+319640	./IBM13/INSTANTANEOUS/3D00043400.plt
+319648	./IBM13/INSTANTANEOUS/3D00035800.plt
+319640	./IBM13/INSTANTANEOUS/3D00042600.plt
+319640	./IBM13/INSTANTANEOUS/3D00046200.plt
+319648	./IBM13/INSTANTANEOUS/3D00034800.plt
+319640	./IBM13/INSTANTANEOUS/3D00047200.plt
+319652	./IBM13/INSTANTANEOUS/3D00032800.plt
+319652	./IBM13/INSTANTANEOUS/3D00031400.plt
+319640	./IBM13/INSTANTANEOUS/3D00043000.plt
+319648	./IBM13/INSTANTANEOUS/3D00038800.plt
+319648	./IBM13/INSTANTANEOUS/3D00042800.plt
+319648	./IBM13/INSTANTANEOUS/3D00033000.plt
+319648	./IBM13/INSTANTANEOUS/3D00040400.plt
+319648	./IBM13/INSTANTANEOUS/3D00033200.plt
+319640	./IBM13/INSTANTANEOUS/3D00044000.plt
+319648	./IBM13/INSTANTANEOUS/3D00034600.plt
+319648	./IBM13/INSTANTANEOUS/3D00033400.plt
+319648	./IBM13/INSTANTANEOUS/3D00035600.plt
+319652	./IBM13/INSTANTANEOUS/3D00030200.plt
+319648	./IBM13/INSTANTANEOUS/3D00036000.plt
+319648	./IBM13/INSTANTANEOUS/3D00045200.plt
+319648	./IBM13/INSTANTANEOUS/3D00033600.plt
+319652	./IBM13/INSTANTANEOUS/3D00031800.plt
+319648	./IBM13/INSTANTANEOUS/3D00039200.plt
+319648	./IBM13/INSTANTANEOUS/3D00034200.plt
+319648	./IBM13/INSTANTANEOUS/3D00038200.plt
+319640	./IBM13/INSTANTANEOUS/3D00043200.plt
+319648	./IBM13/INSTANTANEOUS/3D00037200.plt
+319652	./IBM13/INSTANTANEOUS/3D00030400.plt
+319648	./IBM13/INSTANTANEOUS/3D00042000.plt
+319648	./IBM13/INSTANTANEOUS/3D00035200.plt
+319640	./IBM13/INSTANTANEOUS/3D00044400.plt
+319648	./IBM13/INSTANTANEOUS/3D00041400.plt
+319640	./IBM13/INSTANTANEOUS/3D00046400.plt
+319648	./IBM13/INSTANTANEOUS/3D00040200.plt
+319640	./IBM13/INSTANTANEOUS/3D00044200.plt
+319640	./IBM13/INSTANTANEOUS/3D00046000.plt
+319652	./IBM13/INSTANTANEOUS/3D00032200.plt
+319648	./IBM13/INSTANTANEOUS/3D00042200.plt
+319648	./IBM13/INSTANTANEOUS/3D00041200.plt
+319652	./IBM13/INSTANTANEOUS/3D00030800.plt
+319648	./IBM13/INSTANTANEOUS/3D00036800.plt
+319648	./IBM13/INSTANTANEOUS/3D00041600.plt
+319652	./IBM13/INSTANTANEOUS/3D00031000.plt
+319640	./IBM13/INSTANTANEOUS/3D00046800.plt
+319652	./IBM13/INSTANTANEOUS/3D00032400.plt
+319652	./IBM13/INSTANTANEOUS/3D00030600.plt
+319648	./IBM13/INSTANTANEOUS/3D00040600.plt
+319648	./IBM13/INSTANTANEOUS/3D00038600.plt
+319648	./IBM13/INSTANTANEOUS/3D00039000.plt
+319640	./IBM13/INSTANTANEOUS/3D00046600.plt
+319640	./IBM13/INSTANTANEOUS/3D00043600.plt
+319648	./IBM13/INSTANTANEOUS/3D00042400.plt
+319648	./IBM13/INSTANTANEOUS/3D00035000.plt
+319648	./IBM13/INSTANTANEOUS/3D00039600.plt
+319648	./IBM13/INSTANTANEOUS/3D00038400.plt
+319652	./IBM13/INSTANTANEOUS/3D00031200.plt
+319648	./IBM13/INSTANTANEOUS/3D00036400.plt
+319648	./IBM13/INSTANTANEOUS/3D00039400.plt
+319652	./IBM13/INSTANTANEOUS/3D00030000.plt
+28128924	./IBM13/INSTANTANEOUS
+1176	./IBM13/results_aegean
+32	./IBM13/SURFACE/00033050.dat
+32	./IBM13/SURFACE/00039800.dat
+32	./IBM13/SURFACE/00024400.dat
+32	./IBM13/SURFACE/00035300.dat
+32	./IBM13/SURFACE/00002850.dat
+32	./IBM13/SURFACE/00046450.dat
+32	./IBM13/SURFACE/00025200.dat
+32	./IBM13/SURFACE/00003250.dat
+32	./IBM13/SURFACE/00031850.dat
+32	./IBM13/SURFACE/00005900.dat
+32	./IBM13/SURFACE/00010950.dat
+32	./IBM13/SURFACE/00016350.dat
+32	./IBM13/SURFACE/00010700.dat
+32	./IBM13/SURFACE/00028100.dat
+32	./IBM13/SURFACE/00032950.dat
+32	./IBM13/SURFACE/00041300.dat
+32	./IBM13/SURFACE/00016500.dat
+32	./IBM13/SURFACE/00012650.dat
+32	./IBM13/SURFACE/00009400.dat
+32	./IBM13/SURFACE/00047100.dat
+32	./IBM13/SURFACE/00018950.dat
+32	./IBM13/SURFACE/00043250.dat
+32	./IBM13/SURFACE/00024900.dat
+32	./IBM13/SURFACE/00032650.dat
+32	./IBM13/SURFACE/00009850.dat
+32	./IBM13/SURFACE/00040800.dat
+32	./IBM13/SURFACE/00035500.dat
+32	./IBM13/SURFACE/00034200.dat
+32	./IBM13/SURFACE/00013150.dat
+32	./IBM13/SURFACE/00019950.dat
+32	./IBM13/SURFACE/00029450.dat
+32	./IBM13/SURFACE/00028750.dat
+32	./IBM13/SURFACE/00026250.dat
+32	./IBM13/SURFACE/00031550.dat
+32	./IBM13/SURFACE/00032900.dat
+32	./IBM13/SURFACE/00014300.dat
+32	./IBM13/SURFACE/00042450.dat
+32	./IBM13/SURFACE/00007200.dat
+32	./IBM13/SURFACE/00031350.dat
+32	./IBM13/SURFACE/00021400.dat
+32	./IBM13/SURFACE/00018550.dat
+32	./IBM13/SURFACE/00013600.dat
+32	./IBM13/SURFACE/00004950.dat
+32	./IBM13/SURFACE/00004450.dat
+32	./IBM13/SURFACE/00033900.dat
+32	./IBM13/SURFACE/00020800.dat
+32	./IBM13/SURFACE/00009000.dat
+32	./IBM13/SURFACE/00014250.dat
+32	./IBM13/SURFACE/00024300.dat
+32	./IBM13/SURFACE/00036750.dat
+32	./IBM13/SURFACE/00040300.dat
+32	./IBM13/SURFACE/00043700.dat
+32	./IBM13/SURFACE/00035450.dat
+32	./IBM13/SURFACE/00009450.dat
+32	./IBM13/SURFACE/00039950.dat
+32	./IBM13/SURFACE/00011600.dat
+32	./IBM13/SURFACE/00002950.dat
+32	./IBM13/SURFACE/00001650.dat
+32	./IBM13/SURFACE/00026050.dat
+32	./IBM13/SURFACE/00039200.dat
+32	./IBM13/SURFACE/00034350.dat
+32	./IBM13/SURFACE/00041700.dat
+32	./IBM13/SURFACE/00047050.dat
+32	./IBM13/SURFACE/00026900.dat
+32	./IBM13/SURFACE/00030550.dat
+32	./IBM13/SURFACE/00042850.dat
+32	./IBM13/SURFACE/00010800.dat
+32	./IBM13/SURFACE/00028900.dat
+32	./IBM13/SURFACE/00034750.dat
+32	./IBM13/SURFACE/00024350.dat
+32	./IBM13/SURFACE/00006100.dat
+32	./IBM13/SURFACE/00015700.dat
+32	./IBM13/SURFACE/00016750.dat
+32	./IBM13/SURFACE/00040600.dat
+32	./IBM13/SURFACE/00015200.dat
+32	./IBM13/SURFACE/00046500.dat
+32	./IBM13/SURFACE/00016250.dat
+32	./IBM13/SURFACE/00011100.dat
+32	./IBM13/SURFACE/00004300.dat
+32	./IBM13/SURFACE/00012350.dat
+32	./IBM13/SURFACE/00021000.dat
+32	./IBM13/SURFACE/00022300.dat
+32	./IBM13/SURFACE/00042050.dat
+32	./IBM13/SURFACE/00033950.dat
+32	./IBM13/SURFACE/00005000.dat
+32	./IBM13/SURFACE/00037300.dat
+32	./IBM13/SURFACE/00030450.dat
+32	./IBM13/SURFACE/00041550.dat
+32	./IBM13/SURFACE/00006250.dat
+32	./IBM13/SURFACE/00040250.dat
+32	./IBM13/SURFACE/00037400.dat
+32	./IBM13/SURFACE/00019300.dat
+32	./IBM13/SURFACE/00044300.dat
+32	./IBM13/SURFACE/00023300.dat
+32	./IBM13/SURFACE/00007050.dat
+32	./IBM13/SURFACE/00012600.dat
+32	./IBM13/SURFACE/00037600.dat
+32	./IBM13/SURFACE/00040650.dat
+32	./IBM13/SURFACE/00026200.dat
+32	./IBM13/SURFACE/00044900.dat
+32	./IBM13/SURFACE/00033400.dat
+32	./IBM13/SURFACE/00001500.dat
+32	./IBM13/SURFACE/00036900.dat
+32	./IBM13/SURFACE/00037350.dat
+32	./IBM13/SURFACE/00011300.dat
+32	./IBM13/SURFACE/00042300.dat
+32	./IBM13/SURFACE/00023200.dat
+32	./IBM13/SURFACE/00047000.dat
+32	./IBM13/SURFACE/00003300.dat
+32	./IBM13/SURFACE/00007300.dat
+32	./IBM13/SURFACE/00017400.dat
+32	./IBM13/SURFACE/00004550.dat
+32	./IBM13/SURFACE/00007950.dat
+32	./IBM13/SURFACE/00022000.dat
+32	./IBM13/SURFACE/00008100.dat
+32	./IBM13/SURFACE/00027700.dat
+32	./IBM13/SURFACE/00034700.dat
+32	./IBM13/SURFACE/00014850.dat
+32	./IBM13/SURFACE/00039650.dat
+32	./IBM13/SURFACE/00007800.dat
+32	./IBM13/SURFACE/00005300.dat
+32	./IBM13/SURFACE/00018000.dat
+32	./IBM13/SURFACE/00005700.dat
+32	./IBM13/SURFACE/00020300.dat
+32	./IBM13/SURFACE/00004500.dat
+32	./IBM13/SURFACE/00018800.dat
+32	./IBM13/SURFACE/00017750.dat
+32	./IBM13/SURFACE/00003100.dat
+32	./IBM13/SURFACE/00018400.dat
+32	./IBM13/SURFACE/00043200.dat
+32	./IBM13/SURFACE/00035100.dat
+32	./IBM13/SURFACE/00041600.dat
+32	./IBM13/SURFACE/00034400.dat
+32	./IBM13/SURFACE/00023250.dat
+32	./IBM13/SURFACE/00008650.dat
+32	./IBM13/SURFACE/00023150.dat
+32	./IBM13/SURFACE/00007450.dat
+32	./IBM13/SURFACE/00043950.dat
+32	./IBM13/SURFACE/00029250.dat
+32	./IBM13/SURFACE/00013400.dat
+32	./IBM13/SURFACE/00004150.dat
+32	./IBM13/SURFACE/00041050.dat
+32	./IBM13/SURFACE/00016050.dat
+32	./IBM13/SURFACE/00036650.dat
+32	./IBM13/SURFACE/00025700.dat
+32	./IBM13/SURFACE/00036350.dat
+32	./IBM13/SURFACE/00020650.dat
+32	./IBM13/SURFACE/00006850.dat
+32	./IBM13/SURFACE/00046300.dat
+32	./IBM13/SURFACE/00039400.dat
+32	./IBM13/SURFACE/00037450.dat
+32	./IBM13/SURFACE/00046950.dat
+32	./IBM13/SURFACE/00027000.dat
+32	./IBM13/SURFACE/00009650.dat
+32	./IBM13/SURFACE/00000750.dat
+32	./IBM13/SURFACE/00046900.dat
+32	./IBM13/SURFACE/00019750.dat
+32	./IBM13/SURFACE/00041750.dat
+32	./IBM13/SURFACE/00030500.dat
+32	./IBM13/SURFACE/00040850.dat
+32	./IBM13/SURFACE/00000100.dat
+32	./IBM13/SURFACE/00028700.dat
+32	./IBM13/SURFACE/00002700.dat
+32	./IBM13/SURFACE/00040750.dat
+32	./IBM13/SURFACE/00038500.dat
+32	./IBM13/SURFACE/00005650.dat
+32	./IBM13/SURFACE/00043050.dat
+32	./IBM13/SURFACE/00041500.dat
+32	./IBM13/SURFACE/00003450.dat
+32	./IBM13/SURFACE/00042550.dat
+32	./IBM13/SURFACE/00009100.dat
+32	./IBM13/SURFACE/00041800.dat
+32	./IBM13/SURFACE/00019150.dat
+32	./IBM13/SURFACE/00010400.dat
+32	./IBM13/SURFACE/00009250.dat
+32	./IBM13/SURFACE/00034600.dat
+32	./IBM13/SURFACE/00037100.dat
+32	./IBM13/SURFACE/00012800.dat
+32	./IBM13/SURFACE/00024050.dat
+32	./IBM13/SURFACE/00047150.dat
+32	./IBM13/SURFACE/00028550.dat
+32	./IBM13/SURFACE/00029000.dat
+32	./IBM13/SURFACE/00028850.dat
+32	./IBM13/SURFACE/00021800.dat
+32	./IBM13/SURFACE/00000200.dat
+32	./IBM13/SURFACE/00030400.dat
+32	./IBM13/SURFACE/00011750.dat
+32	./IBM13/SURFACE/00029350.dat
+32	./IBM13/SURFACE/00025950.dat
+32	./IBM13/SURFACE/00033850.dat
+32	./IBM13/SURFACE/00000900.dat
+32	./IBM13/SURFACE/00029200.dat
+32	./IBM13/SURFACE/00001900.dat
+32	./IBM13/SURFACE/00046050.dat
+32	./IBM13/SURFACE/00008450.dat
+32	./IBM13/SURFACE/00018500.dat
+32	./IBM13/SURFACE/00023850.dat
+32	./IBM13/SURFACE/00025250.dat
+32	./IBM13/SURFACE/00041150.dat
+32	./IBM13/SURFACE/00026000.dat
+32	./IBM13/SURFACE/00030850.dat
+32	./IBM13/SURFACE/00045500.dat
+32	./IBM13/SURFACE/00038450.dat
+32	./IBM13/SURFACE/00030050.dat
+32	./IBM13/SURFACE/00010900.dat
+32	./IBM13/SURFACE/00012300.dat
+32	./IBM13/SURFACE/00039100.dat
+32	./IBM13/SURFACE/00020150.dat
+32	./IBM13/SURFACE/00043300.dat
+32	./IBM13/SURFACE/00010250.dat
+32	./IBM13/SURFACE/00004000.dat
+32	./IBM13/SURFACE/00041950.dat
+32	./IBM13/SURFACE/00042650.dat
+32	./IBM13/SURFACE/00014050.dat
+32	./IBM13/SURFACE/00036050.dat
+32	./IBM13/SURFACE/00023450.dat
+32	./IBM13/SURFACE/00019450.dat
+32	./IBM13/SURFACE/00016650.dat
+32	./IBM13/SURFACE/00002900.dat
+32	./IBM13/SURFACE/00035850.dat
+32	./IBM13/SURFACE/00045200.dat
+32	./IBM13/SURFACE/00024000.dat
+32	./IBM13/SURFACE/00018100.dat
+32	./IBM13/SURFACE/00045950.dat
+32	./IBM13/SURFACE/00005850.dat
+32	./IBM13/SURFACE/00009750.dat
+32	./IBM13/SURFACE/00039300.dat
+32	./IBM13/SURFACE/00031950.dat
+32	./IBM13/SURFACE/00035650.dat
+32	./IBM13/SURFACE/00002800.dat
+32	./IBM13/SURFACE/00044600.dat
+32	./IBM13/SURFACE/00014450.dat
+32	./IBM13/SURFACE/00012250.dat
+32	./IBM13/SURFACE/00017000.dat
+32	./IBM13/SURFACE/00001700.dat
+32	./IBM13/SURFACE/00029300.dat
+32	./IBM13/SURFACE/00038550.dat
+32	./IBM13/SURFACE/00044700.dat
+32	./IBM13/SURFACE/00006400.dat
+32	./IBM13/SURFACE/00015050.dat
+32	./IBM13/SURFACE/00029850.dat
+32	./IBM13/SURFACE/00029400.dat
+32	./IBM13/SURFACE/00046000.dat
+32	./IBM13/SURFACE/00016300.dat
+32	./IBM13/SURFACE/00006550.dat
+32	./IBM13/SURFACE/00003950.dat
+32	./IBM13/SURFACE/00002200.dat
+32	./IBM13/SURFACE/00021350.dat
+32	./IBM13/SURFACE/00036450.dat
+32	./IBM13/SURFACE/00039500.dat
+32	./IBM13/SURFACE/00045850.dat
+32	./IBM13/SURFACE/00027800.dat
+32	./IBM13/SURFACE/00032100.dat
+32	./IBM13/SURFACE/00019700.dat
+32	./IBM13/SURFACE/00010450.dat
+32	./IBM13/SURFACE/00011150.dat
+32	./IBM13/SURFACE/00015350.dat
+32	./IBM13/SURFACE/00032150.dat
+32	./IBM13/SURFACE/00004750.dat
+32	./IBM13/SURFACE/00000850.dat
+32	./IBM13/SURFACE/00023550.dat
+32	./IBM13/SURFACE/00034100.dat
+32	./IBM13/SURFACE/00020600.dat
+32	./IBM13/SURFACE/00043000.dat
+32	./IBM13/SURFACE/00022050.dat
+32	./IBM13/SURFACE/00037050.dat
+32	./IBM13/SURFACE/00004350.dat
+32	./IBM13/SURFACE/00044500.dat
+32	./IBM13/SURFACE/00007500.dat
+32	./IBM13/SURFACE/00035250.dat
+32	./IBM13/SURFACE/00033700.dat
+32	./IBM13/SURFACE/00046700.dat
+32	./IBM13/SURFACE/00013300.dat
+32	./IBM13/SURFACE/00002000.dat
+32	./IBM13/SURFACE/00023900.dat
+32	./IBM13/SURFACE/00013350.dat
+32	./IBM13/SURFACE/00034850.dat
+32	./IBM13/SURFACE/00037750.dat
+32	./IBM13/SURFACE/00016450.dat
+32	./IBM13/SURFACE/00031750.dat
+32	./IBM13/SURFACE/00039250.dat
+32	./IBM13/SURFACE/00007700.dat
+32	./IBM13/SURFACE/00023800.dat
+32	./IBM13/SURFACE/00011700.dat
+32	./IBM13/SURFACE/00024500.dat
+32	./IBM13/SURFACE/00034150.dat
+32	./IBM13/SURFACE/00018050.dat
+32	./IBM13/SURFACE/00002350.dat
+32	./IBM13/SURFACE/00024700.dat
+32	./IBM13/SURFACE/00025150.dat
+32	./IBM13/SURFACE/00017650.dat
+32	./IBM13/SURFACE/00017800.dat
+32	./IBM13/SURFACE/00040200.dat
+32	./IBM13/SURFACE/00027200.dat
+32	./IBM13/SURFACE/00004100.dat
+32	./IBM13/SURFACE/00040950.dat
+32	./IBM13/SURFACE/00038200.dat
+32	./IBM13/SURFACE/00036100.dat
+32	./IBM13/SURFACE/00029950.dat
+32	./IBM13/SURFACE/00006300.dat
+32	./IBM13/SURFACE/00014100.dat
+32	./IBM13/SURFACE/00017950.dat
+32	./IBM13/SURFACE/00002550.dat
+32	./IBM13/SURFACE/00015300.dat
+32	./IBM13/SURFACE/00001100.dat
+32	./IBM13/SURFACE/00045600.dat
+32	./IBM13/SURFACE/00016100.dat
+32	./IBM13/SURFACE/00025900.dat
+32	./IBM13/SURFACE/00005750.dat
+32	./IBM13/SURFACE/00036300.dat
+32	./IBM13/SURFACE/00021950.dat
+32	./IBM13/SURFACE/00022450.dat
+32	./IBM13/SURFACE/00002500.dat
+32	./IBM13/SURFACE/00037850.dat
+32	./IBM13/SURFACE/00035600.dat
+32	./IBM13/SURFACE/00023000.dat
+32	./IBM13/SURFACE/00008800.dat
+32	./IBM13/SURFACE/00023950.dat
+32	./IBM13/SURFACE/00045750.dat
+32	./IBM13/SURFACE/00037700.dat
+32	./IBM13/SURFACE/00028800.dat
+32	./IBM13/SURFACE/00015150.dat
+32	./IBM13/SURFACE/00011650.dat
+32	./IBM13/SURFACE/00043150.dat
+32	./IBM13/SURFACE/00030000.dat
+32	./IBM13/SURFACE/00003700.dat
+32	./IBM13/SURFACE/00031450.dat
+32	./IBM13/SURFACE/00037900.dat
+32	./IBM13/SURFACE/00039550.dat
+32	./IBM13/SURFACE/00031400.dat
+32	./IBM13/SURFACE/00045150.dat
+32	./IBM13/SURFACE/00032350.dat
+32	./IBM13/SURFACE/00005400.dat
+32	./IBM13/SURFACE/00008750.dat
+32	./IBM13/SURFACE/00043650.dat
+32	./IBM13/SURFACE/00021050.dat
+32	./IBM13/SURFACE/00011950.dat
+32	./IBM13/SURFACE/00017550.dat
+32	./IBM13/SURFACE/00011550.dat
+32	./IBM13/SURFACE/00022850.dat
+32	./IBM13/SURFACE/00005500.dat
+32	./IBM13/SURFACE/00009950.dat
+32	./IBM13/SURFACE/00024450.dat
+32	./IBM13/SURFACE/00009150.dat
+32	./IBM13/SURFACE/00007000.dat
+32	./IBM13/SURFACE/00044750.dat
+32	./IBM13/SURFACE/00024950.dat
+32	./IBM13/SURFACE/00034250.dat
+32	./IBM13/SURFACE/00028950.dat
+32	./IBM13/SURFACE/00013100.dat
+32	./IBM13/SURFACE/00031700.dat
+32	./IBM13/SURFACE/00017300.dat
+32	./IBM13/SURFACE/00039750.dat
+32	./IBM13/SURFACE/00015250.dat
+32	./IBM13/SURFACE/00003150.dat
+32	./IBM13/SURFACE/00010150.dat
+32	./IBM13/SURFACE/00017050.dat
+32	./IBM13/SURFACE/00021550.dat
+32	./IBM13/SURFACE/00041000.dat
+32	./IBM13/SURFACE/00029750.dat
+32	./IBM13/SURFACE/00004700.dat
+32	./IBM13/SURFACE/00028200.dat
+32	./IBM13/SURFACE/00016800.dat
+32	./IBM13/SURFACE/00032550.dat
+32	./IBM13/SURFACE/00000400.dat
+32	./IBM13/SURFACE/00017350.dat
+32	./IBM13/SURFACE/00035700.dat
+32	./IBM13/SURFACE/00038300.dat
+32	./IBM13/SURFACE/00006450.dat
+32	./IBM13/SURFACE/00004650.dat
+32	./IBM13/SURFACE/00017850.dat
+32	./IBM13/SURFACE/00029100.dat
+32	./IBM13/SURFACE/00007750.dat
+32	./IBM13/SURFACE/00006350.dat
+32	./IBM13/SURFACE/00020050.dat
+32	./IBM13/SURFACE/00009200.dat
+32	./IBM13/SURFACE/00031050.dat
+32	./IBM13/SURFACE/00030300.dat
+32	./IBM13/SURFACE/00004900.dat
+32	./IBM13/SURFACE/00022950.dat
+32	./IBM13/SURFACE/00012750.dat
+32	./IBM13/SURFACE/00046750.dat
+32	./IBM13/SURFACE/00000150.dat
+32	./IBM13/SURFACE/00025350.dat
+32	./IBM13/SURFACE/00026500.dat
+32	./IBM13/SURFACE/00008000.dat
+32	./IBM13/SURFACE/00010500.dat
+32	./IBM13/SURFACE/00034000.dat
+32	./IBM13/SURFACE/00021450.dat
+32	./IBM13/SURFACE/00037200.dat
+32	./IBM13/SURFACE/00020900.dat
+32	./IBM13/SURFACE/00020700.dat
+32	./IBM13/SURFACE/00007100.dat
+32	./IBM13/SURFACE/00009700.dat
+32	./IBM13/SURFACE/00047300.dat
+32	./IBM13/SURFACE/00038000.dat
+32	./IBM13/SURFACE/00021650.dat
+32	./IBM13/SURFACE/00004250.dat
+32	./IBM13/SURFACE/00015800.dat
+32	./IBM13/SURFACE/00001550.dat
+32	./IBM13/SURFACE/00019800.dat
+32	./IBM13/SURFACE/00010550.dat
+32	./IBM13/SURFACE/00021750.dat
+32	./IBM13/SURFACE/00025550.dat
+32	./IBM13/SURFACE/00028300.dat
+32	./IBM13/SURFACE/00013500.dat
+32	./IBM13/SURFACE/00025100.dat
+32	./IBM13/SURFACE/00005200.dat
+32	./IBM13/SURFACE/00027550.dat
+32	./IBM13/SURFACE/00012450.dat
+32	./IBM13/SURFACE/00014800.dat
+32	./IBM13/SURFACE/00011350.dat
+32	./IBM13/SURFACE/00035150.dat
+32	./IBM13/SURFACE/00002300.dat
+32	./IBM13/SURFACE/00041850.dat
+32	./IBM13/SURFACE/00014000.dat
+32	./IBM13/SURFACE/00007250.dat
+32	./IBM13/SURFACE/00029900.dat
+32	./IBM13/SURFACE/00002650.dat
+32	./IBM13/SURFACE/00006600.dat
+32	./IBM13/SURFACE/00019850.dat
+32	./IBM13/SURFACE/00011400.dat
+32	./IBM13/SURFACE/00029150.dat
+32	./IBM13/SURFACE/00013650.dat
+32	./IBM13/SURFACE/00030200.dat
+32	./IBM13/SURFACE/00006950.dat
+32	./IBM13/SURFACE/00018900.dat
+32	./IBM13/SURFACE/00033750.dat
+32	./IBM13/SURFACE/00006000.dat
+32	./IBM13/SURFACE/00024150.dat
+32	./IBM13/SURFACE/00012050.dat
+32	./IBM13/SURFACE/00029050.dat
+32	./IBM13/SURFACE/00006750.dat
+32	./IBM13/SURFACE/00003850.dat
+32	./IBM13/SURFACE/00008150.dat
+32	./IBM13/SURFACE/00001050.dat
+32	./IBM13/SURFACE/00033550.dat
+32	./IBM13/SURFACE/00036000.dat
+32	./IBM13/SURFACE/00029650.dat
+32	./IBM13/SURFACE/00020450.dat
+32	./IBM13/SURFACE/00036950.dat
+32	./IBM13/SURFACE/00035900.dat
+32	./IBM13/SURFACE/00018600.dat
+32	./IBM13/SURFACE/00026800.dat
+32	./IBM13/SURFACE/00030650.dat
+32	./IBM13/SURFACE/00007600.dat
+32	./IBM13/SURFACE/00036500.dat
+32	./IBM13/SURFACE/00038650.dat
+32	./IBM13/SURFACE/00000600.dat
+32	./IBM13/SURFACE/00020000.dat
+32	./IBM13/SURFACE/00042150.dat
+32	./IBM13/SURFACE/00024600.dat
+32	./IBM13/SURFACE/00031600.dat
+32	./IBM13/SURFACE/00019600.dat
+32	./IBM13/SURFACE/00013700.dat
+32	./IBM13/SURFACE/00041200.dat
+32	./IBM13/SURFACE/00000700.dat
+32	./IBM13/SURFACE/00040000.dat
+32	./IBM13/SURFACE/00007350.dat
+32	./IBM13/SURFACE/00003600.dat
+32	./IBM13/SURFACE/00000450.dat
+32	./IBM13/SURFACE/00017450.dat
+32	./IBM13/SURFACE/00022100.dat
+32	./IBM13/SURFACE/00028250.dat
+32	./IBM13/SURFACE/00023700.dat
+32	./IBM13/SURFACE/00001000.dat
+32	./IBM13/SURFACE/00009900.dat
+32	./IBM13/SURFACE/00045400.dat
+32	./IBM13/SURFACE/00035400.dat
+32	./IBM13/SURFACE/00000350.dat
+32	./IBM13/SURFACE/00010650.dat
+32	./IBM13/SURFACE/00019500.dat
+32	./IBM13/SURFACE/00025000.dat
+32	./IBM13/SURFACE/00028600.dat
+32	./IBM13/SURFACE/00017100.dat
+32	./IBM13/SURFACE/00019400.dat
+32	./IBM13/SURFACE/00027100.dat
+32	./IBM13/SURFACE/00033200.dat
+32	./IBM13/SURFACE/00001600.dat
+32	./IBM13/SURFACE/00032300.dat
+32	./IBM13/SURFACE/00005550.dat
+32	./IBM13/SURFACE/00018150.dat
+32	./IBM13/SURFACE/00017600.dat
+32	./IBM13/SURFACE/00021900.dat
+32	./IBM13/SURFACE/00021300.dat
+32	./IBM13/SURFACE/00034650.dat
+32	./IBM13/SURFACE/00027450.dat
+32	./IBM13/SURFACE/00029800.dat
+32	./IBM13/SURFACE/00021200.dat
+32	./IBM13/SURFACE/00000050.dat
+32	./IBM13/SURFACE/00032850.dat
+32	./IBM13/SURFACE/00038950.dat
+32	./IBM13/SURFACE/00002250.dat
+32	./IBM13/SURFACE/00005050.dat
+32	./IBM13/SURFACE/00022500.dat
+32	./IBM13/SURFACE/00020950.dat
+32	./IBM13/SURFACE/00008950.dat
+32	./IBM13/SURFACE/00038350.dat
+32	./IBM13/SURFACE/00000650.dat
+32	./IBM13/SURFACE/00028050.dat
+32	./IBM13/SURFACE/00022350.dat
+32	./IBM13/SURFACE/00039450.dat
+32	./IBM13/SURFACE/00003750.dat
+32	./IBM13/SURFACE/00020350.dat
+32	./IBM13/SURFACE/00026700.dat
+32	./IBM13/SURFACE/00046550.dat
+32	./IBM13/SURFACE/00036200.dat
+32	./IBM13/SURFACE/00022700.dat
+32	./IBM13/SURFACE/00043400.dat
+32	./IBM13/SURFACE/00024200.dat
+32	./IBM13/SURFACE/00030900.dat
+32	./IBM13/SURFACE/00035050.dat
+32	./IBM13/SURFACE/00043450.dat
+32	./IBM13/SURFACE/00006700.dat
+32	./IBM13/SURFACE/00044000.dat
+32	./IBM13/SURFACE/00027600.dat
+32	./IBM13/SURFACE/00004050.dat
+32	./IBM13/SURFACE/00008350.dat
+32	./IBM13/SURFACE/00039700.dat
+32	./IBM13/SURFACE/00040150.dat
+32	./IBM13/SURFACE/00032800.dat
+32	./IBM13/SURFACE/00011800.dat
+32	./IBM13/SURFACE/00010050.dat
+32	./IBM13/SURFACE/00020750.dat
+32	./IBM13/SURFACE/00035000.dat
+32	./IBM13/SURFACE/00027750.dat
+32	./IBM13/SURFACE/00002750.dat
+32	./IBM13/SURFACE/00019200.dat
+32	./IBM13/SURFACE/00019100.dat
+32	./IBM13/SURFACE/00015850.dat
+32	./IBM13/SURFACE/00044950.dat
+32	./IBM13/SURFACE/00002150.dat
+32	./IBM13/SURFACE/00016550.dat
+32	./IBM13/SURFACE/00034500.dat
+32	./IBM13/SURFACE/00025750.dat
+32	./IBM13/SURFACE/00042000.dat
+32	./IBM13/SURFACE/00025850.dat
+32	./IBM13/SURFACE/00042900.dat
+32	./IBM13/SURFACE/00021500.dat
+32	./IBM13/SURFACE/00011000.dat
+32	./IBM13/SURFACE/00025400.dat
+32	./IBM13/SURFACE/00032600.dat
+32	./IBM13/SURFACE/00015750.dat
+32	./IBM13/SURFACE/00042250.dat
+32	./IBM13/SURFACE/00002600.dat
+32	./IBM13/SURFACE/00020850.dat
+32	./IBM13/SURFACE/00029500.dat
+32	./IBM13/SURFACE/00021700.dat
+32	./IBM13/SURFACE/00035750.dat
+32	./IBM13/SURFACE/00041900.dat
+32	./IBM13/SURFACE/00018750.dat
+32	./IBM13/SURFACE/00044150.dat
+32	./IBM13/SURFACE/00007150.dat
+32	./IBM13/SURFACE/00022200.dat
+32	./IBM13/SURFACE/00036850.dat
+32	./IBM13/SURFACE/00012100.dat
+32	./IBM13/SURFACE/00032500.dat
+32	./IBM13/SURFACE/00000550.dat
+32	./IBM13/SURFACE/00044050.dat
+32	./IBM13/SURFACE/00036400.dat
+32	./IBM13/SURFACE/00028650.dat
+32	./IBM13/SURFACE/00019000.dat
+32	./IBM13/SURFACE/00037550.dat
+32	./IBM13/SURFACE/00025650.dat
+32	./IBM13/SURFACE/00016600.dat
+32	./IBM13/SURFACE/00022650.dat
+32	./IBM13/SURFACE/00043750.dat
+32	./IBM13/SURFACE/00017150.dat
+32	./IBM13/SURFACE/00032700.dat
+32	./IBM13/SURFACE/00016850.dat
+32	./IBM13/SURFACE/00025800.dat
+32	./IBM13/SURFACE/00033000.dat
+32	./IBM13/SURFACE/00031250.dat
+32	./IBM13/SURFACE/00031200.dat
+32	./IBM13/SURFACE/00021250.dat
+32	./IBM13/SURFACE/00009300.dat
+32	./IBM13/SURFACE/00044200.dat
+32	./IBM13/SURFACE/00010200.dat
+32	./IBM13/SURFACE/00027050.dat
+32	./IBM13/SURFACE/00036600.dat
+32	./IBM13/SURFACE/00020200.dat
+32	./IBM13/SURFACE/00035350.dat
+32	./IBM13/SURFACE/00017500.dat
+32	./IBM13/SURFACE/00040500.dat
+32	./IBM13/SURFACE/00038250.dat
+32	./IBM13/SURFACE/00039050.dat
+32	./IBM13/SURFACE/00030100.dat
+32	./IBM13/SURFACE/00023400.dat
+32	./IBM13/SURFACE/00022600.dat
+32	./IBM13/SURFACE/00018700.dat
+32	./IBM13/SURFACE/00014650.dat
+32	./IBM13/SURFACE/00033450.dat
+32	./IBM13/SURFACE/00019650.dat
+32	./IBM13/SURFACE/00027950.dat
+32	./IBM13/SURFACE/00029550.dat
+32	./IBM13/SURFACE/00013450.dat
+32	./IBM13/SURFACE/00019900.dat
+32	./IBM13/SURFACE/00026100.dat
+32	./IBM13/SURFACE/00026600.dat
+32	./IBM13/SURFACE/00007850.dat
+32	./IBM13/SURFACE/00003350.dat
+32	./IBM13/SURFACE/00001350.dat
+32	./IBM13/SURFACE/00036700.dat
+32	./IBM13/SURFACE/00016900.dat
+32	./IBM13/SURFACE/00046400.dat
+32	./IBM13/SURFACE/00039000.dat
+32	./IBM13/SURFACE/00039150.dat
+32	./IBM13/SURFACE/00027300.dat
+32	./IBM13/SURFACE/00025050.dat
+32	./IBM13/SURFACE/00038700.dat
+32	./IBM13/SURFACE/00019250.dat
+32	./IBM13/SURFACE/00009550.dat
+32	./IBM13/SURFACE/00015550.dat
+32	./IBM13/SURFACE/00009600.dat
+32	./IBM13/SURFACE/00046250.dat
+32	./IBM13/SURFACE/00031150.dat
+32	./IBM13/SURFACE/00036800.dat
+32	./IBM13/SURFACE/00045100.dat
+32	./IBM13/SURFACE/00006800.dat
+32	./IBM13/SURFACE/00032250.dat
+32	./IBM13/SURFACE/00020250.dat
+32	./IBM13/SURFACE/00024750.dat
+32	./IBM13/SURFACE/00014150.dat
+32	./IBM13/SURFACE/00046650.dat
+32	./IBM13/SURFACE/00001150.dat
+32	./IBM13/SURFACE/00038400.dat
+32	./IBM13/SURFACE/00041400.dat
+32	./IBM13/SURFACE/00045350.dat
+32	./IBM13/SURFACE/00027400.dat
+32	./IBM13/SURFACE/00014900.dat
+32	./IBM13/SURFACE/00032000.dat
+32	./IBM13/SURFACE/00026400.dat
+32	./IBM13/SURFACE/00022800.dat
+32	./IBM13/SURFACE/00012000.dat
+32	./IBM13/SURFACE/00040350.dat
+32	./IBM13/SURFACE/00006500.dat
+32	./IBM13/SURFACE/00026950.dat
+32	./IBM13/SURFACE/00042350.dat
+32	./IBM13/SURFACE/00030750.dat
+32	./IBM13/SURFACE/00020500.dat
+32	./IBM13/SURFACE/00026350.dat
+32	./IBM13/SURFACE/00031300.dat
+32	./IBM13/SURFACE/00031650.dat
+32	./IBM13/SURFACE/00045000.dat
+32	./IBM13/SURFACE/00015400.dat
+32	./IBM13/SURFACE/00015500.dat
+32	./IBM13/SURFACE/00015900.dat
+32	./IBM13/SURFACE/00047350.dat
+32	./IBM13/SURFACE/00030350.dat
+32	./IBM13/SURFACE/00040550.dat
+32	./IBM13/SURFACE/00027850.dat
+32	./IBM13/SURFACE/00007400.dat
+32	./IBM13/SURFACE/00043350.dat
+32	./IBM13/SURFACE/00037800.dat
+32	./IBM13/SURFACE/00008900.dat
+32	./IBM13/SURFACE/00021850.dat
+32	./IBM13/SURFACE/00033100.dat
+32	./IBM13/SURFACE/00016400.dat
+32	./IBM13/SURFACE/00043100.dat
+32	./IBM13/SURFACE/00035800.dat
+32	./IBM13/SURFACE/00045550.dat
+32	./IBM13/SURFACE/00009500.dat
+32	./IBM13/SURFACE/00014500.dat
+32	./IBM13/SURFACE/00045450.dat
+32	./IBM13/SURFACE/00008600.dat
+32	./IBM13/SURFACE/00015950.dat
+32	./IBM13/SURFACE/00010750.dat
+32	./IBM13/SURFACE/00046150.dat
+32	./IBM13/SURFACE/00026850.dat
+32	./IBM13/SURFACE/00008550.dat
+32	./IBM13/SURFACE/00027350.dat
+32	./IBM13/SURFACE/00018650.dat
+32	./IBM13/SURFACE/00022250.dat
+32	./IBM13/SURFACE/00006650.dat
+32	./IBM13/SURFACE/00042500.dat
+32	./IBM13/SURFACE/00040700.dat
+32	./IBM13/SURFACE/00013000.dat
+32	./IBM13/SURFACE/00003050.dat
+32	./IBM13/SURFACE/00014700.dat
+32	./IBM13/SURFACE/00033500.dat
+32	./IBM13/SURFACE/00001750.dat
+32	./IBM13/SURFACE/00037950.dat
+32	./IBM13/SURFACE/00006900.dat
+32	./IBM13/SURFACE/00031000.dat
+32	./IBM13/SURFACE/00038050.dat
+32	./IBM13/SURFACE/00039900.dat
+32	./IBM13/SURFACE/00042700.dat
+32	./IBM13/SURFACE/00032400.dat
+32	./IBM13/SURFACE/00027250.dat
+32	./IBM13/SURFACE/00026550.dat
+32	./IBM13/SURFACE/00041650.dat
+32	./IBM13/SURFACE/00001250.dat
+32	./IBM13/SURFACE/00023650.dat
+32	./IBM13/SURFACE/00022400.dat
+32	./IBM13/SURFACE/00014750.dat
+32	./IBM13/SURFACE/00030800.dat
+32	./IBM13/SURFACE/00037650.dat
+32	./IBM13/SURFACE/00032200.dat
+32	./IBM13/SURFACE/00034800.dat
+32	./IBM13/SURFACE/00044850.dat
+32	./IBM13/SURFACE/00038850.dat
+32	./IBM13/SURFACE/00024650.dat
+32	./IBM13/SURFACE/00024250.dat
+32	./IBM13/SURFACE/00010350.dat
+32	./IBM13/SURFACE/00028500.dat
+32	./IBM13/SURFACE/00018300.dat
+32	./IBM13/SURFACE/00005600.dat
+32	./IBM13/SURFACE/00039850.dat
+32	./IBM13/SURFACE/00042400.dat
+32	./IBM13/SURFACE/00004200.dat
+32	./IBM13/SURFACE/00035950.dat
+32	./IBM13/SURFACE/00015100.dat
+32	./IBM13/SURFACE/00001800.dat
+32	./IBM13/SURFACE/00017900.dat
+32	./IBM13/SURFACE/00018350.dat
+32	./IBM13/SURFACE/00027650.dat
+32	./IBM13/SURFACE/00045900.dat
+32	./IBM13/SURFACE/00009350.dat
+32	./IBM13/SURFACE/00037000.dat
+32	./IBM13/SURFACE/00033350.dat
+32	./IBM13/SURFACE/00043900.dat
+32	./IBM13/SURFACE/00028350.dat
+32	./IBM13/SURFACE/00008250.dat
+32	./IBM13/SURFACE/00012150.dat
+32	./IBM13/SURFACE/00000250.dat
+32	./IBM13/SURFACE/00012500.dat
+32	./IBM13/SURFACE/00035200.dat
+32	./IBM13/SURFACE/00045800.dat
+32	./IBM13/SURFACE/00022750.dat
+32	./IBM13/SURFACE/00044800.dat
+32	./IBM13/SURFACE/00038150.dat
+32	./IBM13/SURFACE/00024850.dat
+32	./IBM13/SURFACE/00006050.dat
+32	./IBM13/SURFACE/00033650.dat
+32	./IBM13/SURFACE/00011850.dat
+32	./IBM13/SURFACE/00042200.dat
+32	./IBM13/SURFACE/00012950.dat
+32	./IBM13/SURFACE/00046600.dat
+32	./IBM13/SURFACE/00040100.dat
+32	./IBM13/SURFACE/00020100.dat
+32	./IBM13/SURFACE/00019350.dat
+32	./IBM13/SURFACE/00035550.dat
+32	./IBM13/SURFACE/00045650.dat
+32	./IBM13/SURFACE/00030600.dat
+32	./IBM13/SURFACE/00011450.dat
+32	./IBM13/SURFACE/00028150.dat
+32	./IBM13/SURFACE/00000950.dat
+32	./IBM13/SURFACE/00025600.dat
+32	./IBM13/SURFACE/00015600.dat
+32	./IBM13/SURFACE/00013050.dat
+32	./IBM13/SURFACE/00023350.dat
+32	./IBM13/SURFACE/00028000.dat
+32	./IBM13/SURFACE/00037150.dat
+32	./IBM13/SURFACE/00038600.dat
+32	./IBM13/SURFACE/00043600.dat
+32	./IBM13/SURFACE/00005950.dat
+32	./IBM13/SURFACE/00033300.dat
+32	./IBM13/SURFACE/00016950.dat
+32	./IBM13/SURFACE/00010850.dat
+32	./IBM13/SURFACE/00042100.dat
+32	./IBM13/SURFACE/00017250.dat
+32	./IBM13/SURFACE/00013850.dat
+32	./IBM13/SURFACE/00004600.dat
+32	./IBM13/SURFACE/00013750.dat
+32	./IBM13/SURFACE/00009800.dat
+32	./IBM13/SURFACE/00025500.dat
+32	./IBM13/SURFACE/00017700.dat
+32	./IBM13/SURFACE/00024100.dat
+32	./IBM13/SURFACE/00030150.dat
+32	./IBM13/SURFACE/00002100.dat
+32	./IBM13/SURFACE/00002050.dat
+32	./IBM13/SURFACE/00019550.dat
+32	./IBM13/SURFACE/00034950.dat
+32	./IBM13/SURFACE/00014200.dat
+32	./IBM13/SURFACE/00009050.dat
+32	./IBM13/SURFACE/00026300.dat
+32	./IBM13/SURFACE/00005350.dat
+32	./IBM13/SURFACE/00020550.dat
+32	./IBM13/SURFACE/00020400.dat
+32	./IBM13/SURFACE/00014400.dat
+32	./IBM13/SURFACE/00039350.dat
+32	./IBM13/SURFACE/00033600.dat
+32	./IBM13/SURFACE/00023600.dat
+32	./IBM13/SURFACE/00001450.dat
+32	./IBM13/SURFACE/00023500.dat
+32	./IBM13/SURFACE/00001200.dat
+32	./IBM13/SURFACE/00011050.dat
+32	./IBM13/SURFACE/00013200.dat
+32	./IBM13/SURFACE/00026450.dat
+32	./IBM13/SURFACE/00025450.dat
+32	./IBM13/SURFACE/00016200.dat
+32	./IBM13/SURFACE/00026650.dat
+32	./IBM13/SURFACE/00043550.dat
+32	./IBM13/SURFACE/00034550.dat
+32	./IBM13/SURFACE/00011250.dat
+32	./IBM13/SURFACE/00003400.dat
+32	./IBM13/SURFACE/00014550.dat
+32	./IBM13/SURFACE/00045050.dat
+32	./IBM13/SURFACE/00008700.dat
+32	./IBM13/SURFACE/00046350.dat
+32	./IBM13/SURFACE/00005250.dat
+32	./IBM13/SURFACE/00003650.dat
+32	./IBM13/SURFACE/00038800.dat
+32	./IBM13/SURFACE/00031100.dat
+32	./IBM13/SURFACE/00014600.dat
+32	./IBM13/SURFACE/00002400.dat
+32	./IBM13/SURFACE/00011200.dat
+32	./IBM13/SURFACE/00037250.dat
+32	./IBM13/SURFACE/00008050.dat
+32	./IBM13/SURFACE/00044350.dat
+32	./IBM13/SURFACE/00026150.dat
+32	./IBM13/SURFACE/00033250.dat
+32	./IBM13/SURFACE/00001850.dat
+32	./IBM13/SURFACE/00042950.dat
+32	./IBM13/SURFACE/00028450.dat
+32	./IBM13/SURFACE/00006200.dat
+32	./IBM13/SURFACE/00024800.dat
+32	./IBM13/SURFACE/00029700.dat
+32	./IBM13/SURFACE/00007900.dat
+32	./IBM13/SURFACE/00041100.dat
+32	./IBM13/SURFACE/00040400.dat
+32	./IBM13/SURFACE/00013950.dat
+32	./IBM13/SURFACE/00042600.dat
+32	./IBM13/SURFACE/00022550.dat
+32	./IBM13/SURFACE/00013900.dat
+32	./IBM13/SURFACE/00040050.dat
+32	./IBM13/SURFACE/00000300.dat
+32	./IBM13/SURFACE/00030950.dat
+32	./IBM13/SURFACE/00013800.dat
+32	./IBM13/SURFACE/00021600.dat
+32	./IBM13/SURFACE/00027900.dat
+32	./IBM13/SURFACE/00008400.dat
+32	./IBM13/SURFACE/00018250.dat
+32	./IBM13/SURFACE/00007650.dat
+32	./IBM13/SURFACE/00044250.dat
+32	./IBM13/SURFACE/00047200.dat
+32	./IBM13/SURFACE/00010100.dat
+32	./IBM13/SURFACE/00010300.dat
+32	./IBM13/SURFACE/00004400.dat
+32	./IBM13/SURFACE/00040900.dat
+32	./IBM13/SURFACE/00043500.dat
+32	./IBM13/SURFACE/00012900.dat
+32	./IBM13/SURFACE/00046200.dat
+32	./IBM13/SURFACE/00021100.dat
+32	./IBM13/SURFACE/00005800.dat
+32	./IBM13/SURFACE/00045250.dat
+32	./IBM13/SURFACE/00003200.dat
+32	./IBM13/SURFACE/00015450.dat
+32	./IBM13/SURFACE/00011900.dat
+32	./IBM13/SURFACE/00023750.dat
+32	./IBM13/SURFACE/00002450.dat
+32	./IBM13/SURFACE/00040450.dat
+32	./IBM13/SURFACE/00016150.dat
+32	./IBM13/SURFACE/00034050.dat
+32	./IBM13/SURFACE/00031800.dat
+32	./IBM13/SURFACE/00039600.dat
+32	./IBM13/SURFACE/00023050.dat
+32	./IBM13/SURFACE/00005150.dat
+32	./IBM13/SURFACE/00014950.dat
+32	./IBM13/SURFACE/00005100.dat
+32	./IBM13/SURFACE/00015000.dat
+32	./IBM13/SURFACE/00031900.dat
+32	./IBM13/SURFACE/00019050.dat
+32	./IBM13/SURFACE/00033150.dat
+32	./IBM13/SURFACE/00041350.dat
+32	./IBM13/SURFACE/00003000.dat
+32	./IBM13/SURFACE/00012700.dat
+32	./IBM13/SURFACE/00046100.dat
+32	./IBM13/SURFACE/00032450.dat
+32	./IBM13/SURFACE/00005450.dat
+32	./IBM13/SURFACE/00016700.dat
+32	./IBM13/SURFACE/00044550.dat
+32	./IBM13/SURFACE/00032750.dat
+32	./IBM13/SURFACE/00004800.dat
+32	./IBM13/SURFACE/00024550.dat
+32	./IBM13/SURFACE/00046800.dat
+32	./IBM13/SURFACE/00038900.dat
+32	./IBM13/SURFACE/00023100.dat
+32	./IBM13/SURFACE/00001300.dat
+32	./IBM13/SURFACE/00036150.dat
+32	./IBM13/SURFACE/00008300.dat
+32	./IBM13/SURFACE/00003500.dat
+32	./IBM13/SURFACE/00012550.dat
+32	./IBM13/SURFACE/00008850.dat
+32	./IBM13/SURFACE/00043800.dat
+32	./IBM13/SURFACE/00008500.dat
+32	./IBM13/SURFACE/00038100.dat
+32	./IBM13/SURFACE/00018850.dat
+32	./IBM13/SURFACE/00018450.dat
+32	./IBM13/SURFACE/00027150.dat
+32	./IBM13/SURFACE/00000500.dat
+32	./IBM13/SURFACE/00044450.dat
+32	./IBM13/SURFACE/00022900.dat
+32	./IBM13/SURFACE/00026750.dat
+32	./IBM13/SURFACE/00034450.dat
+32	./IBM13/SURFACE/00036250.dat
+32	./IBM13/SURFACE/00038750.dat
+32	./IBM13/SURFACE/00015650.dat
+32	./IBM13/SURFACE/00044650.dat
+32	./IBM13/SURFACE/00010000.dat
+32	./IBM13/SURFACE/00036550.dat
+32	./IBM13/SURFACE/00006150.dat
+32	./IBM13/SURFACE/00034300.dat
+32	./IBM13/SURFACE/00003550.dat
+32	./IBM13/SURFACE/00007550.dat
+32	./IBM13/SURFACE/00043850.dat
+32	./IBM13/SURFACE/00011500.dat
+32	./IBM13/SURFACE/00012200.dat
+32	./IBM13/SURFACE/00044100.dat
+32	./IBM13/SURFACE/00003900.dat
+32	./IBM13/SURFACE/00033800.dat
+32	./IBM13/SURFACE/00013550.dat
+32	./IBM13/SURFACE/00041250.dat
+32	./IBM13/SURFACE/00045300.dat
+32	./IBM13/SURFACE/00046850.dat
+32	./IBM13/SURFACE/00012400.dat
+32	./IBM13/SURFACE/00032050.dat
+32	./IBM13/SURFACE/00031500.dat
+32	./IBM13/SURFACE/00027500.dat
+32	./IBM13/SURFACE/00037500.dat
+32	./IBM13/SURFACE/00012850.dat
+32	./IBM13/SURFACE/00010600.dat
+32	./IBM13/SURFACE/00018200.dat
+32	./IBM13/SURFACE/00013250.dat
+32	./IBM13/SURFACE/00034900.dat
+32	./IBM13/SURFACE/00041450.dat
+32	./IBM13/SURFACE/00017200.dat
+32	./IBM13/SURFACE/00008200.dat
+32	./IBM13/SURFACE/00014350.dat
+32	./IBM13/SURFACE/00022150.dat
+32	./IBM13/SURFACE/00042800.dat
+32	./IBM13/SURFACE/00042750.dat
+32	./IBM13/SURFACE/00030250.dat
+32	./IBM13/SURFACE/00001950.dat
+32	./IBM13/SURFACE/00004850.dat
+32	./IBM13/SURFACE/00025300.dat
+32	./IBM13/SURFACE/00044400.dat
+32	./IBM13/SURFACE/00001400.dat
+32	./IBM13/SURFACE/00028400.dat
+32	./IBM13/SURFACE/00045700.dat
+32	./IBM13/SURFACE/00000800.dat
+32	./IBM13/SURFACE/00003800.dat
+32	./IBM13/SURFACE/00021150.dat
+32	./IBM13/SURFACE/00029600.dat
+32	./IBM13/SURFACE/00016000.dat
+32	./IBM13/SURFACE/00030700.dat
+32	./IBM13/SURFACE/00047250.dat
+30368	./IBM13/SURFACE
+4	./IBM13/prof_step
+4	./IBM13/Beforemaking
+4	./IBM13/MID/TIME.MID
+8	./IBM13/MID
+du: cannot access `./IBM13/PRIO_GENERATE_GRID/Makefile': Permission denied
+du: cannot access `./IBM13/PRIO_GENERATE_GRID/genegrid': Permission denied
+du: cannot access `./IBM13/PRIO_GENERATE_GRID/GENEGRID.F90': Permission denied
+4	./IBM13/PRIO_GENERATE_GRID
+196118268	./IBM13
+916	./IBM16/libtecio.a
+du: cannot access `./IBM16/INCLUDE/INCLUDE_FFT.FI': Permission denied
+du: cannot access `./IBM16/INCLUDE/INCLUDE_CINTERFACE.FI': Permission denied
+du: cannot access `./IBM16/INCLUDE/INCLUDE_LES.FI': Permission denied
+du: cannot access `./IBM16/INCLUDE/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM16/INCLUDE/INCLUDE_WAVEGENERATOR.FI': Permission denied
+du: cannot access `./IBM16/INCLUDE/INCLUDE_PARALLEL.FI': Permission denied
+du: cannot access `./IBM16/INCLUDE/INCLUDE_PETSC.FI': Permission denied
+du: cannot access `./IBM16/INCLUDE/INCLUDE_ASSIMILATION.FI': Permission denied
+du: cannot access `./IBM16/INCLUDE/INCLUDE_IBM.FI': Permission denied
+du: cannot access `./IBM16/INCLUDE/variables_new.h': Permission denied
+du: cannot access `./IBM16/INCLUDE/INCLUDE_PARAMETER.FI': Permission denied
+du: cannot access `./IBM16/INCLUDE/mpm_vars_new.h': Permission denied
+du: cannot access `./IBM16/INCLUDE/INCLUDE_SCALAR.FI': Permission denied
+du: cannot access `./IBM16/INCLUDE/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM16/INCLUDE/INCLUDE_STATS.FI': Permission denied
+du: cannot access `./IBM16/INCLUDE/INCLUDE_POISSON.FI': Permission denied
+4	./IBM16/INCLUDE
+4	./IBM16/vorcenterp.sh
+452	./IBM16/GEOMETRY/PSI.0074
+452	./IBM16/GEOMETRY/PSI.0012
+452	./IBM16/GEOMETRY/PSI.0026
+452	./IBM16/GEOMETRY/PSI.0048
+452	./IBM16/GEOMETRY/PSI.0054
+452	./IBM16/GEOMETRY/PSI.0084
+452	./IBM16/GEOMETRY/PSI.0019
+452	./IBM16/GEOMETRY/PSI.0066
+452	./IBM16/GEOMETRY/PSI.0015
+452	./IBM16/GEOMETRY/PSI.0094
+452	./IBM16/GEOMETRY/PSI.0088
+452	./IBM16/GEOMETRY/PSI.0032
+452	./IBM16/GEOMETRY/PSI.0081
+452	./IBM16/GEOMETRY/PSI.0005
+452	./IBM16/GEOMETRY/PSI.0007
+452	./IBM16/GEOMETRY/PSI.0050
+452	./IBM16/GEOMETRY/PSI.0098
+452	./IBM16/GEOMETRY/PSI.0021
+452	./IBM16/GEOMETRY/PSI.0079
+452	./IBM16/GEOMETRY/PSI.0043
+452	./IBM16/GEOMETRY/PSI.0104
+452	./IBM16/GEOMETRY/PSI.0060
+452	./IBM16/GEOMETRY/PSI.0061
+452	./IBM16/GEOMETRY/PSI.0095
+452	./IBM16/GEOMETRY/PSI.0082
+452	./IBM16/GEOMETRY/PSI.0080
+452	./IBM16/GEOMETRY/PSI.0087
+452	./IBM16/GEOMETRY/PSI.0027
+452	./IBM16/GEOMETRY/PSI.0023
+452	./IBM16/GEOMETRY/PSI.0003
+452	./IBM16/GEOMETRY/PSI.0014
+452	./IBM16/GEOMETRY/PSI.0062
+452	./IBM16/GEOMETRY/PSI.0086
+452	./IBM16/GEOMETRY/PSI.0008
+452	./IBM16/GEOMETRY/PSI.0058
+452	./IBM16/GEOMETRY/PSI.0034
+452	./IBM16/GEOMETRY/PSI.0120
+452	./IBM16/GEOMETRY/PSI.0089
+452	./IBM16/GEOMETRY/PSI.0118
+452	./IBM16/GEOMETRY/PSI.0044
+452	./IBM16/GEOMETRY/PSI.0125
+452	./IBM16/GEOMETRY/PSI.0036
+452	./IBM16/GEOMETRY/PSI.0052
+452	./IBM16/GEOMETRY/PSI.0031
+452	./IBM16/GEOMETRY/PSI.0076
+452	./IBM16/GEOMETRY/PSI.0037
+452	./IBM16/GEOMETRY/PSI.0024
+452	./IBM16/GEOMETRY/PSI.0100
+452	./IBM16/GEOMETRY/PSI.0030
+452	./IBM16/GEOMETRY/PSI.0069
+452	./IBM16/GEOMETRY/PSI.0075
+452	./IBM16/GEOMETRY/PSI.0068
+452	./IBM16/GEOMETRY/PSI.0002
+452	./IBM16/GEOMETRY/PSI.0000
+452	./IBM16/GEOMETRY/PSI.0020
+452	./IBM16/GEOMETRY/PSI.0010
+452	./IBM16/GEOMETRY/PSI.0110
+452	./IBM16/GEOMETRY/PSI.0124
+452	./IBM16/GEOMETRY/PSI.0051
+452	./IBM16/GEOMETRY/PSI.0121
+452	./IBM16/GEOMETRY/PSI.0116
+452	./IBM16/GEOMETRY/PSI.0053
+452	./IBM16/GEOMETRY/PSI.0073
+452	./IBM16/GEOMETRY/PSI.0018
+452	./IBM16/GEOMETRY/PSI.0106
+452	./IBM16/GEOMETRY/PSI.0004
+452	./IBM16/GEOMETRY/PSI.0035
+452	./IBM16/GEOMETRY/PSI.0083
+452	./IBM16/GEOMETRY/PSI.0013
+452	./IBM16/GEOMETRY/PSI.0022
+452	./IBM16/GEOMETRY/PSI.0101
+452	./IBM16/GEOMETRY/PSI.0122
+452	./IBM16/GEOMETRY/PSI.0016
+452	./IBM16/GEOMETRY/PSI.0119
+452	./IBM16/GEOMETRY/PSI.0067
+452	./IBM16/GEOMETRY/PSI.0072
+452	./IBM16/GEOMETRY/PSI.0112
+452	./IBM16/GEOMETRY/PSI.0039
+452	./IBM16/GEOMETRY/PSI.0017
+452	./IBM16/GEOMETRY/PSI.0097
+452	./IBM16/GEOMETRY/PSI.0107
+452	./IBM16/GEOMETRY/PSI.0108
+452	./IBM16/GEOMETRY/PSI.0123
+452	./IBM16/GEOMETRY/PSI.0063
+452	./IBM16/GEOMETRY/PSI.0102
+452	./IBM16/GEOMETRY/PSI.0047
+452	./IBM16/GEOMETRY/PSI.0045
+452	./IBM16/GEOMETRY/PSI.0070
+452	./IBM16/GEOMETRY/PSI.0038
+452	./IBM16/GEOMETRY/PSI.0127
+452	./IBM16/GEOMETRY/PSI.0056
+452	./IBM16/GEOMETRY/PSI.0078
+452	./IBM16/GEOMETRY/PSI.0126
+452	./IBM16/GEOMETRY/PSI.0046
+452	./IBM16/GEOMETRY/PSI.0064
+452	./IBM16/GEOMETRY/PSI.0096
+452	./IBM16/GEOMETRY/PSI.0077
+452	./IBM16/GEOMETRY/PSI.0025
+452	./IBM16/GEOMETRY/PSI.0040
+452	./IBM16/GEOMETRY/PSI.0011
+452	./IBM16/GEOMETRY/PSI.0041
+452	./IBM16/GEOMETRY/PSI.0109
+452	./IBM16/GEOMETRY/PSI.0090
+452	./IBM16/GEOMETRY/PSI.0042
+452	./IBM16/GEOMETRY/PSI.0105
+452	./IBM16/GEOMETRY/PSI.0009
+452	./IBM16/GEOMETRY/PSI.0028
+452	./IBM16/GEOMETRY/PSI.0114
+452	./IBM16/GEOMETRY/PSI.0006
+452	./IBM16/GEOMETRY/PSI.0033
+452	./IBM16/GEOMETRY/PSI.0055
+452	./IBM16/GEOMETRY/PSI.0071
+452	./IBM16/GEOMETRY/PSI.0113
+452	./IBM16/GEOMETRY/PSI.0049
+452	./IBM16/GEOMETRY/PSI.0103
+452	./IBM16/GEOMETRY/PSI.0001
+452	./IBM16/GEOMETRY/PSI.0099
+452	./IBM16/GEOMETRY/PSI.0065
+452	./IBM16/GEOMETRY/PSI.0111
+452	./IBM16/GEOMETRY/PSI.0059
+452	./IBM16/GEOMETRY/PSI.0085
+452	./IBM16/GEOMETRY/PSI.0029
+452	./IBM16/GEOMETRY/PSI.0057
+452	./IBM16/GEOMETRY/PSI.0115
+452	./IBM16/GEOMETRY/PSI.0117
+452	./IBM16/GEOMETRY/PSI.0091
+452	./IBM16/GEOMETRY/PSI.0092
+452	./IBM16/GEOMETRY/PSI.0093
+57868	./IBM16/GEOMETRY
+du: cannot access `./IBM16/CALCULATE/FDM_026_PD_SPE.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_043_VOF.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_123_WALLMODEL_POWERLAW.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_023_SMOOTHING.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_027_RK.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_302_WAVYVOR_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_033_IBM_INTFORCING.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_010_INIT_PARALLEL.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_110_RNG.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_025_PD.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_070_PARALLEL.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_121_WALLMODEL_KANG.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_304_ASSIMILATION_WAVY.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_032_IBM_EXTFORCING.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_111_GERMANO.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_023_SMOOTHING.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_122_WALLMODEL_ROMAN.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_304_ASSIMILATION_WAVY.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_000_MAIN.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_032_IBM_EXTFORCING.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_042_LS.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_123_WALLMODEL_POWERLAW.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_030_IBM.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_044_PRESCRIBEWAVE.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_080_FFT.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_020_PRESOLVE.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_091_SEDIMENT.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_300_ASSIMILATION.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_060_STATS_TS.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_303_MEANFLUC_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_070_PARALLEL.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_305_ASSIMILATION_VORT.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_301_ASSIMILATION_GEOMETRY.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_033_IBM_INTFORCING.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_030_IBM.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_306_ASSIMILATION_TOTAL.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_027_RK.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_020_PRESOLVE.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_021_RHS.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_111_GERMANO.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_999_FINALIZE.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_090_DYE.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_062_STRAINRATE.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_130_INT.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_051_IO.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_063_CIRCVELO.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_061_STATS_TA.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_062_STRAINRATE.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_022_WG.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_050_OUTPUT.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_121_WALLMODEL_KANG.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_043_VOF.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_090_DYE.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_130_INT.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_120_WALLMODEL_TBL.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_021_RHS.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_303_MEANFLUC_DECOMPOSITION.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_306_ASSIMILATION_TOTAL.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_100_LES.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_031_IBM_INIT.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_061_STATS_TA.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_301_ASSIMILATION_GEOMETRY.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_300_ASSIMILATION.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_010_INIT_PARALLEL.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_050_OUTPUT.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_044_PRESCRIBEWAVE.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/tags': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_051_IO.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_110_RNG.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_022_WG.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_025_PD.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_122_WALLMODEL_ROMAN.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_012_INIT_FIELD.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_200_PETSC_SOLVER.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_307_TRACER.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_001_FSTRANSFER.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_305_ASSIMILATION_VORT.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_100_LES.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_060_STATS_TS.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_091_SEDIMENT.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_307_TRACER.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_031_IBM_INIT.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_302_WAVYVOR_DECOMPOSITION.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_080_FFT.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_120_WALLMODEL_TBL.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_026_PD_SPE.F90': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_012_INIT_FIELD.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_063_CIRCVELO.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_000_MAIN.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_042_LS.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_011_INIT_CONSTANTS.o': Permission denied
+du: cannot access `./IBM16/CALCULATE/FDM_200_PETSC_SOLVER.o': Permission denied
+12	./IBM16/CALCULATE
+8	./IBM16/volume.dat
+575400	./IBM16/DATA/V00008200.H5
+575400	./IBM16/DATA/V00008000.H5
+467240	./IBM16/DATA/V00019000.H5
+575400	./IBM16/DATA/V00001800.H5
+575400	./IBM16/DATA/V00003800.H5
+467240	./IBM16/DATA/V00018600.H5
+575400	./IBM16/DATA/V00011000.H5
+467240	./IBM16/DATA/V00019200.H5
+467240	./IBM16/DATA/V00018000.H5
+467240	./IBM16/DATA/V00015200.H5
+575400	./IBM16/DATA/V00000200.H5
+575400	./IBM16/DATA/V00009600.H5
+467240	./IBM16/DATA/V00018800.H5
+575400	./IBM16/DATA/V00005200.H5
+575400	./IBM16/DATA/V00012800.H5
+575400	./IBM16/DATA/V00011400.H5
+575400	./IBM16/DATA/V00012200.H5
+467240	./IBM16/DATA/V00019800.H5
+575400	./IBM16/DATA/V00014800.H5
+575400	./IBM16/DATA/V00007600.H5
+575400	./IBM16/DATA/V00006600.H5
+575400	./IBM16/DATA/V00013200.H5
+467240	./IBM16/DATA/V00018200.H5
+467240	./IBM16/DATA/V00019600.H5
+467240	./IBM16/DATA/V00015400.H5
+575400	./IBM16/DATA/V00005800.H5
+467240	./IBM16/DATA/V00016400.H5
+575400	./IBM16/DATA/V00005600.H5
+575400	./IBM16/DATA/V00009200.H5
+575400	./IBM16/DATA/V00001000.H5
+575400	./IBM16/DATA/V00014600.H5
+575400	./IBM16/DATA/V00005000.H5
+467240	./IBM16/DATA/V00016800.H5
+575400	./IBM16/DATA/V00009400.H5
+575400	./IBM16/DATA/V00000800.H5
+575400	./IBM16/DATA/V00007200.H5
+575400	./IBM16/DATA/V00010400.H5
+575400	./IBM16/DATA/V00012400.H5
+575400	./IBM16/DATA/V00010600.H5
+575400	./IBM16/DATA/V00007400.H5
+575400	./IBM16/DATA/V00007000.H5
+575400	./IBM16/DATA/V00002600.H5
+575400	./IBM16/DATA/V00002000.H5
+575400	./IBM16/DATA/V00010000.H5
+575400	./IBM16/DATA/V00006000.H5
+575400	./IBM16/DATA/V00004000.H5
+575400	./IBM16/DATA/V00013600.H5
+575400	./IBM16/DATA/V00010200.H5
+575400	./IBM16/DATA/V00004800.H5
+575400	./IBM16/DATA/V00013800.H5
+467240	./IBM16/DATA/V00017600.H5
+575400	./IBM16/DATA/V00012000.H5
+575400	./IBM16/DATA/V00001200.H5
+575400	./IBM16/DATA/V00013000.H5
+575400	./IBM16/DATA/V00007800.H5
+575400	./IBM16/DATA/V00001400.H5
+467240	./IBM16/DATA/V00016000.H5
+575400	./IBM16/DATA/V00009800.H5
+575400	./IBM16/DATA/V00000400.H5
+575400	./IBM16/DATA/V00011800.H5
+575400	./IBM16/DATA/V00015000.H5
+575400	./IBM16/DATA/V00003400.H5
+467240	./IBM16/DATA/V00017200.H5
+467240	./IBM16/DATA/V00015600.H5
+575400	./IBM16/DATA/V00011200.H5
+575400	./IBM16/DATA/V00004200.H5
+575400	./IBM16/DATA/V00012600.H5
+575400	./IBM16/DATA/V00006200.H5
+575400	./IBM16/DATA/V00003200.H5
+575400	./IBM16/DATA/V00008400.H5
+575400	./IBM16/DATA/V00002400.H5
+575400	./IBM16/DATA/V00004400.H5
+467240	./IBM16/DATA/V00018400.H5
+575400	./IBM16/DATA/V00009000.H5
+575400	./IBM16/DATA/V00008800.H5
+575400	./IBM16/DATA/V00000000.H5
+575400	./IBM16/DATA/V00006800.H5
+467240	./IBM16/DATA/V00017800.H5
+575400	./IBM16/DATA/V00000600.H5
+467240	./IBM16/DATA/V00015800.H5
+575400	./IBM16/DATA/V00014200.H5
+575400	./IBM16/DATA/V00014000.H5
+575400	./IBM16/DATA/V00003600.H5
+467240	./IBM16/DATA/V00016600.H5
+575400	./IBM16/DATA/V00001600.H5
+575400	./IBM16/DATA/V00014400.H5
+575400	./IBM16/DATA/V00002800.H5
+467240	./IBM16/DATA/V00017400.H5
+575400	./IBM16/DATA/V00011600.H5
+575400	./IBM16/DATA/V00005400.H5
+467240	./IBM16/DATA/V00017000.H5
+467240	./IBM16/DATA/V00019400.H5
+575400	./IBM16/DATA/V00013400.H5
+575400	./IBM16/DATA/V00006400.H5
+575400	./IBM16/DATA/V00003000.H5
+575400	./IBM16/DATA/V00008600.H5
+575400	./IBM16/DATA/V00010800.H5
+575400	./IBM16/DATA/V00002200.H5
+575400	./IBM16/DATA/V00004600.H5
+467240	./IBM16/DATA/V00016200.H5
+54944180	./IBM16/DATA
+du: cannot access `./IBM16/POST_BASIC/POST_020_STATS.F90': Permission denied
+du: cannot access `./IBM16/POST_BASIC/POST_030_READFILE.F90': Permission denied
+du: cannot access `./IBM16/POST_BASIC/POST_031_PARALLEL.F90': Permission denied
+du: cannot access `./IBM16/POST_BASIC/POST_000_MAIN.F90': Permission denied
+du: cannot access `./IBM16/POST_BASIC/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM16/POST_BASIC/POST_040_AVERAGE.F90': Permission denied
+du: cannot access `./IBM16/POST_BASIC/POST_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM16/POST_BASIC/POST_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM16/POST_BASIC/POST_050_WRITEFILE.F90': Permission denied
+du: cannot access `./IBM16/POST_BASIC/POST_010_INIT_PARALLEL.F90': Permission denied
+4	./IBM16/POST_BASIC
+464	./IBM16/gatherdata
+12	./IBM16/POST_TKE/TKEDATA_IBM.F90
+4	./IBM16/POST_TKE/TKE_IO.F90
+4	./IBM16/POST_TKE/INCLUDE_IO.FI
+8	./IBM16/POST_TKE/TKEPRE.F90
+4	./IBM16/POST_TKE/TKEPS.F90
+12	./IBM16/POST_TKE/tecio.f90
+48	./IBM16/POST_TKE
+4	./IBM16/aegean_stream.sh
+8	./IBM16/Makefile
+303220	./IBM16/VORCENTER_PRE/00029800.DAT
+373524	./IBM16/VORCENTER_PRE/00011000.DAT
+303220	./IBM16/VORCENTER_PRE/00044200.DAT
+303220	./IBM16/VORCENTER_PRE/00024600.DAT
+303220	./IBM16/VORCENTER_PRE/00031800.DAT
+303220	./IBM16/VORCENTER_PRE/00033200.DAT
+303220	./IBM16/VORCENTER_PRE/00015200.DAT
+303220	./IBM16/VORCENTER_PRE/00036000.DAT
+373524	./IBM16/VORCENTER_PRE/00013800.DAT
+303220	./IBM16/VORCENTER_PRE/00016800.DAT
+303220	./IBM16/VORCENTER_PRE/00027000.DAT
+303220	./IBM16/VORCENTER_PRE/00021400.DAT
+303220	./IBM16/VORCENTER_PRE/00040000.DAT
+373524	./IBM16/VORCENTER_PRE/00007800.DAT
+303220	./IBM16/VORCENTER_PRE/00022000.DAT
+303220	./IBM16/VORCENTER_PRE/00014600.DAT
+303220	./IBM16/VORCENTER_PRE/00033000.DAT
+303220	./IBM16/VORCENTER_PRE/00034200.DAT
+303220	./IBM16/VORCENTER_PRE/00028000.DAT
+303220	./IBM16/VORCENTER_PRE/00032800.DAT
+373524	./IBM16/VORCENTER_PRE/00007400.DAT
+303220	./IBM16/VORCENTER_PRE/00024400.DAT
+303220	./IBM16/VORCENTER_PRE/00016400.DAT
+373524	./IBM16/VORCENTER_PRE/00006400.DAT
+373524	./IBM16/VORCENTER_PRE/00006600.DAT
+303220	./IBM16/VORCENTER_PRE/00016200.DAT
+373524	./IBM16/VORCENTER_PRE/00005600.DAT
+303220	./IBM16/VORCENTER_PRE/00026400.DAT
+303220	./IBM16/VORCENTER_PRE/00021200.DAT
+303220	./IBM16/VORCENTER_PRE/00023400.DAT
+303220	./IBM16/VORCENTER_PRE/00027600.DAT
+303220	./IBM16/VORCENTER_PRE/00018800.DAT
+303220	./IBM16/VORCENTER_PRE/00044800.DAT
+303220	./IBM16/VORCENTER_PRE/00043400.DAT
+303220	./IBM16/VORCENTER_PRE/00022400.DAT
+303220	./IBM16/VORCENTER_PRE/00026800.DAT
+303220	./IBM16/VORCENTER_PRE/00042800.DAT
+373524	./IBM16/VORCENTER_PRE/00004600.DAT
+303220	./IBM16/VORCENTER_PRE/00019400.DAT
+303220	./IBM16/VORCENTER_PRE/00029600.DAT
+373524	./IBM16/VORCENTER_PRE/00004800.DAT
+303220	./IBM16/VORCENTER_PRE/00040200.DAT
+303220	./IBM16/VORCENTER_PRE/00039200.DAT
+303220	./IBM16/VORCENTER_PRE/00024000.DAT
+303220	./IBM16/VORCENTER_PRE/00024800.DAT
+303220	./IBM16/VORCENTER_PRE/00033800.DAT
+373524	./IBM16/VORCENTER_PRE/00002000.DAT
+303220	./IBM16/VORCENTER_PRE/00041400.DAT
+373524	./IBM16/VORCENTER_PRE/00012400.DAT
+373524	./IBM16/VORCENTER_PRE/00000200.DAT
+373524	./IBM16/VORCENTER_PRE/00008200.DAT
+303220	./IBM16/VORCENTER_PRE/00035200.DAT
+303220	./IBM16/VORCENTER_PRE/00020200.DAT
+303220	./IBM16/VORCENTER_PRE/00029200.DAT
+303220	./IBM16/VORCENTER_PRE/00041800.DAT
+303220	./IBM16/VORCENTER_PRE/00035400.DAT
+373524	./IBM16/VORCENTER_PRE/00009400.DAT
+303220	./IBM16/VORCENTER_PRE/00020600.DAT
+303220	./IBM16/VORCENTER_PRE/00031000.DAT
+303220	./IBM16/VORCENTER_PRE/00020400.DAT
+373524	./IBM16/VORCENTER_PRE/00011600.DAT
+303220	./IBM16/VORCENTER_PRE/00042600.DAT
+373524	./IBM16/VORCENTER_PRE/00002200.DAT
+303220	./IBM16/VORCENTER_PRE/00023200.DAT
+303220	./IBM16/VORCENTER_PRE/00037400.DAT
+303220	./IBM16/VORCENTER_PRE/00028400.DAT
+303220	./IBM16/VORCENTER_PRE/00032600.DAT
+303220	./IBM16/VORCENTER_PRE/00038000.DAT
+303220	./IBM16/VORCENTER_PRE/00034400.DAT
+303220	./IBM16/VORCENTER_PRE/00025600.DAT
+303220	./IBM16/VORCENTER_PRE/00030800.DAT
+373524	./IBM16/VORCENTER_PRE/00008800.DAT
+373524	./IBM16/VORCENTER_PRE/00003200.DAT
+303220	./IBM16/VORCENTER_PRE/00015400.DAT
+373524	./IBM16/VORCENTER_PRE/00001800.DAT
+303220	./IBM16/VORCENTER_PRE/00029000.DAT
+303220	./IBM16/VORCENTER_PRE/00043800.DAT
+373524	./IBM16/VORCENTER_PRE/00002400.DAT
+303220	./IBM16/VORCENTER_PRE/00040800.DAT
+303220	./IBM16/VORCENTER_PRE/00017800.DAT
+373524	./IBM16/VORCENTER_PRE/00002600.DAT
+303220	./IBM16/VORCENTER_PRE/00015800.DAT
+303220	./IBM16/VORCENTER_PRE/00037000.DAT
+373524	./IBM16/VORCENTER_PRE/00011200.DAT
+303220	./IBM16/VORCENTER_PRE/00030600.DAT
+303220	./IBM16/VORCENTER_PRE/00036600.DAT
+303220	./IBM16/VORCENTER_PRE/00030200.DAT
+303220	./IBM16/VORCENTER_PRE/00032400.DAT
+373524	./IBM16/VORCENTER_PRE/00009800.DAT
+373524	./IBM16/VORCENTER_PRE/00001200.DAT
+373524	./IBM16/VORCENTER_PRE/00010000.DAT
+373524	./IBM16/VORCENTER_PRE/00001000.DAT
+303220	./IBM16/VORCENTER_PRE/00014400.DAT
+303220	./IBM16/VORCENTER_PRE/00034600.DAT
+303220	./IBM16/VORCENTER_PRE/00020800.DAT
+303220	./IBM16/VORCENTER_PRE/00022600.DAT
+303220	./IBM16/VORCENTER_PRE/00037200.DAT
+373524	./IBM16/VORCENTER_PRE/00001600.DAT
+373524	./IBM16/VORCENTER_PRE/00004400.DAT
+373524	./IBM16/VORCENTER_PRE/00010600.DAT
+303220	./IBM16/VORCENTER_PRE/00037800.DAT
+303220	./IBM16/VORCENTER_PRE/00018000.DAT
+303220	./IBM16/VORCENTER_PRE/00043200.DAT
+303220	./IBM16/VORCENTER_PRE/00014200.DAT
+303220	./IBM16/VORCENTER_PRE/00034800.DAT
+373524	./IBM16/VORCENTER_PRE/00001400.DAT
+373524	./IBM16/VORCENTER_PRE/00006800.DAT
+373524	./IBM16/VORCENTER_PRE/00003600.DAT
+303220	./IBM16/VORCENTER_PRE/00026200.DAT
+303220	./IBM16/VORCENTER_PRE/00027400.DAT
+303220	./IBM16/VORCENTER_PRE/00042000.DAT
+303220	./IBM16/VORCENTER_PRE/00028800.DAT
+303220	./IBM16/VORCENTER_PRE/00031200.DAT
+303220	./IBM16/VORCENTER_PRE/00016600.DAT
+303220	./IBM16/VORCENTER_PRE/00036800.DAT
+373524	./IBM16/VORCENTER_PRE/00007200.DAT
+303220	./IBM16/VORCENTER_PRE/00032200.DAT
+303220	./IBM16/VORCENTER_PRE/00044400.DAT
+303220	./IBM16/VORCENTER_PRE/00033600.DAT
+303220	./IBM16/VORCENTER_PRE/00031600.DAT
+303220	./IBM16/VORCENTER_PRE/00030000.DAT
+303220	./IBM16/VORCENTER_PRE/00017000.DAT
+303220	./IBM16/VORCENTER_PRE/00042200.DAT
+303220	./IBM16/VORCENTER_PRE/00026000.DAT
+303220	./IBM16/VORCENTER_PRE/00023600.DAT
+303220	./IBM16/VORCENTER_PRE/00040400.DAT
+303220	./IBM16/VORCENTER_PRE/00041200.DAT
+303220	./IBM16/VORCENTER_PRE/00028600.DAT
+303220	./IBM16/VORCENTER_PRE/00038800.DAT
+303220	./IBM16/VORCENTER_PRE/00039400.DAT
+303220	./IBM16/VORCENTER_PRE/00025400.DAT
+303220	./IBM16/VORCENTER_PRE/00040600.DAT
+373524	./IBM16/VORCENTER_PRE/00010800.DAT
+303220	./IBM16/VORCENTER_PRE/00039800.DAT
+303220	./IBM16/VORCENTER_PRE/00025200.DAT
+373524	./IBM16/VORCENTER_PRE/00007600.DAT
+303220	./IBM16/VORCENTER_PRE/00020000.DAT
+373524	./IBM16/VORCENTER_PRE/00000800.DAT
+303220	./IBM16/VORCENTER_PRE/00018400.DAT
+303220	./IBM16/VORCENTER_PRE/00043600.DAT
+303220	./IBM16/VORCENTER_PRE/00024200.DAT
+373524	./IBM16/VORCENTER_PRE/00005800.DAT
+373524	./IBM16/VORCENTER_PRE/00012000.DAT
+373524	./IBM16/VORCENTER_PRE/00000400.DAT
+373524	./IBM16/VORCENTER_PRE/00006000.DAT
+373524	./IBM16/VORCENTER_PRE/00008600.DAT
+373524	./IBM16/VORCENTER_PRE/00003800.DAT
+303220	./IBM16/VORCENTER_PRE/00027200.DAT
+303220	./IBM16/VORCENTER_PRE/00021600.DAT
+373524	./IBM16/VORCENTER_PRE/00013000.DAT
+373524	./IBM16/VORCENTER_PRE/00013200.DAT
+373524	./IBM16/VORCENTER_PRE/00000600.DAT
+303220	./IBM16/VORCENTER_PRE/00015000.DAT
+373524	./IBM16/VORCENTER_PRE/00004000.DAT
+303220	./IBM16/VORCENTER_PRE/00041600.DAT
+303220	./IBM16/VORCENTER_PRE/00036200.DAT
+303220	./IBM16/VORCENTER_PRE/00019800.DAT
+303220	./IBM16/VORCENTER_PRE/00035000.DAT
+373524	./IBM16/VORCENTER_PRE/00012800.DAT
+303220	./IBM16/VORCENTER_PRE/00038400.DAT
+373524	./IBM16/VORCENTER_PRE/00004200.DAT
+373524	./IBM16/VORCENTER_PRE/00010200.DAT
+303220	./IBM16/VORCENTER_PRE/00041000.DAT
+373524	./IBM16/VORCENTER_PRE/00011400.DAT
+303220	./IBM16/VORCENTER_PRE/00023800.DAT
+303220	./IBM16/VORCENTER_PRE/00032000.DAT
+303220	./IBM16/VORCENTER_PRE/00026600.DAT
+303220	./IBM16/VORCENTER_PRE/00037600.DAT
+303220	./IBM16/VORCENTER_PRE/00038600.DAT
+373524	./IBM16/VORCENTER_PRE/00005000.DAT
+373524	./IBM16/VORCENTER_PRE/00005200.DAT
+303220	./IBM16/VORCENTER_PRE/00023000.DAT
+303220	./IBM16/VORCENTER_PRE/00039600.DAT
+303220	./IBM16/VORCENTER_PRE/00019600.DAT
+303220	./IBM16/VORCENTER_PRE/00028200.DAT
+303220	./IBM16/VORCENTER_PRE/00021000.DAT
+373524	./IBM16/VORCENTER_PRE/00010400.DAT
+373524	./IBM16/VORCENTER_PRE/00011800.DAT
+303220	./IBM16/VORCENTER_PRE/00017600.DAT
+303220	./IBM16/VORCENTER_PRE/00018600.DAT
+373524	./IBM16/VORCENTER_PRE/00012200.DAT
+303220	./IBM16/VORCENTER_PRE/00033400.DAT
+303220	./IBM16/VORCENTER_PRE/00019200.DAT
+373524	./IBM16/VORCENTER_PRE/00012600.DAT
+373524	./IBM16/VORCENTER_PRE/00005400.DAT
+303220	./IBM16/VORCENTER_PRE/00017400.DAT
+373524	./IBM16/VORCENTER_PRE/00003000.DAT
+373524	./IBM16/VORCENTER_PRE/00009600.DAT
+303220	./IBM16/VORCENTER_PRE/00016000.DAT
+303220	./IBM16/VORCENTER_PRE/00030400.DAT
+303220	./IBM16/VORCENTER_PRE/00014000.DAT
+303220	./IBM16/VORCENTER_PRE/00014800.DAT
+303220	./IBM16/VORCENTER_PRE/00038200.DAT
+303220	./IBM16/VORCENTER_PRE/00035600.DAT
+303220	./IBM16/VORCENTER_PRE/00043000.DAT
+303220	./IBM16/VORCENTER_PRE/00031400.DAT
+373524	./IBM16/VORCENTER_PRE/00013600.DAT
+303220	./IBM16/VORCENTER_PRE/00021800.DAT
+303220	./IBM16/VORCENTER_PRE/00018200.DAT
+303220	./IBM16/VORCENTER_PRE/00025800.DAT
+303220	./IBM16/VORCENTER_PRE/00042400.DAT
+303220	./IBM16/VORCENTER_PRE/00015600.DAT
+303220	./IBM16/VORCENTER_PRE/00039000.DAT
+303220	./IBM16/VORCENTER_PRE/00035800.DAT
+303220	./IBM16/VORCENTER_PRE/00000000.DAT
+303220	./IBM16/VORCENTER_PRE/00044000.DAT
+373524	./IBM16/VORCENTER_PRE/00009000.DAT
+373524	./IBM16/VORCENTER_PRE/00008400.DAT
+373524	./IBM16/VORCENTER_PRE/00006200.DAT
+303220	./IBM16/VORCENTER_PRE/00017200.DAT
+303220	./IBM16/VORCENTER_PRE/00029400.DAT
+373524	./IBM16/VORCENTER_PRE/00007000.DAT
+373524	./IBM16/VORCENTER_PRE/00013400.DAT
+303220	./IBM16/VORCENTER_PRE/00019000.DAT
+303220	./IBM16/VORCENTER_PRE/00034000.DAT
+303220	./IBM16/VORCENTER_PRE/00022200.DAT
+373524	./IBM16/VORCENTER_PRE/00002800.DAT
+303220	./IBM16/VORCENTER_PRE/00025000.DAT
+373524	./IBM16/VORCENTER_PRE/00008000.DAT
+303220	./IBM16/VORCENTER_PRE/00036400.DAT
+373524	./IBM16/VORCENTER_PRE/00009200.DAT
+373524	./IBM16/VORCENTER_PRE/00003400.DAT
+303220	./IBM16/VORCENTER_PRE/00027800.DAT
+303220	./IBM16/VORCENTER_PRE/00022800.DAT
+303220	./IBM16/VORCENTER_PRE/00044600.DAT
+73075492	./IBM16/VORCENTER_PRE
+4	./IBM16/WAVE
+4	./IBM16/RESTART_SOLID
+632100	./IBM16/STATS/BASIC.H5
+4	./IBM16/STATS/STAT_STEP
+632108	./IBM16/STATS
+4	./IBM16/vor.sh
+du: cannot access `./IBM16/batchrun/main.py': Permission denied
+du: cannot access `./IBM16/batchrun/grid.py': Permission denied
+du: cannot access `./IBM16/batchrun/param.py': Permission denied
+du: cannot access `./IBM16/batchrun/compile.py': Permission denied
+du: cannot access `./IBM16/batchrun/control.py': Permission denied
+du: cannot access `./IBM16/batchrun/directory.py': Permission denied
+du: cannot access `./IBM16/batchrun/ReadMe.md': Permission denied
+du: cannot access `./IBM16/batchrun/script.py': Permission denied
+4	./IBM16/batchrun
+4	./IBM16/resga
+11472	./IBM16/sour.dat
+4	./IBM16/aga.sh
+du: cannot access `./IBM16/POST/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM16/POST/post': Permission denied
+du: cannot access `./IBM16/POST/POST_TKE.F90': Permission denied
+du: cannot access `./IBM16/POST/POST_SURFACE.F90': Permission denied
+du: cannot access `./IBM16/POST/POST_IO.F90': Permission denied
+4	./IBM16/POST
+4	./IBM16/PARAM.IN
+4	./IBM16/CIRC_VELO
+4	./IBM16/vorcenter.sh
+12292	./IBM16/TIME_SERIES/MAXUVW.DAT
+2184	./IBM16/TIME_SERIES/YTIP.DAT
+7336	./IBM16/TIME_SERIES/CDCF.DAT
+21816	./IBM16/TIME_SERIES
+du: cannot access `./IBM16/GATHERDATA/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM16/GATHERDATA/GATHER_IO.o': Permission denied
+du: cannot access `./IBM16/GATHERDATA/tecio.f90': Permission denied
+du: cannot access `./IBM16/GATHERDATA/GATHER_IO.F90': Permission denied
+du: cannot access `./IBM16/GATHERDATA/GATHERDATA.o': Permission denied
+du: cannot access `./IBM16/GATHERDATA/GATHERDATA.F90': Permission denied
+4	./IBM16/GATHERDATA
+du: cannot access `./IBM16/POST_VORTEX/FDM_064_VORENSTROPHY.F90': Permission denied
+du: cannot access `./IBM16/POST_VORTEX/VORTEXP.F90': Permission denied
+du: cannot access `./IBM16/POST_VORTEX/VORDYNAMIC.F90': Permission denied
+du: cannot access `./IBM16/POST_VORTEX/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBM16/POST_VORTEX/POST_VORTEX.F90': Permission denied
+du: cannot access `./IBM16/POST_VORTEX/VORMAX.F90': Permission denied
+du: cannot access `./IBM16/POST_VORTEX/tecio.f90': Permission denied
+du: cannot access `./IBM16/POST_VORTEX/VORTEX_IO.F90': Permission denied
+du: cannot access `./IBM16/POST_VORTEX/VORTEX_IBM.F90': Permission denied
+du: cannot access `./IBM16/POST_VORTEX/tags': Permission denied
+du: cannot access `./IBM16/POST_VORTEX/VORTEX.F90': Permission denied
+du: cannot access `./IBM16/POST_VORTEX/VORTEX_X.F90': Permission denied
+du: cannot access `./IBM16/POST_VORTEX/VORDYNAMIC_TH.F90': Permission denied
+du: cannot access `./IBM16/POST_VORTEX/VORDYNAMIC_Y.F90': Permission denied
+4	./IBM16/POST_VORTEX
+17612	./IBM16/wave
+du: cannot access `./IBM16/POST_WAVY_WALL/POST_030_READFILE.F90': Permission denied
+du: cannot access `./IBM16/POST_WAVY_WALL/POST_000_MAIN.F90': Permission denied
+du: cannot access `./IBM16/POST_WAVY_WALL/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBM16/POST_WAVY_WALL/POST_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBM16/POST_WAVY_WALL/POST_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBM16/POST_WAVY_WALL/POST_040_WRITEFILE.F90': Permission denied
+du: cannot access `./IBM16/POST_WAVY_WALL/POST_020_AVERAGE.F90': Permission denied
+du: cannot access `./IBM16/POST_WAVY_WALL/POST_010_INIT_PARALLEL.F90': Permission denied
+4	./IBM16/POST_WAVY_WALL
+4	./IBM16/TRACER
+8	./IBM16/GRID.IN
+320412	./IBM16/INSTANTANEOUS/3D00011400.plt
+320404	./IBM16/INSTANTANEOUS/3D00005600.plt
+320412	./IBM16/INSTANTANEOUS/3D00012600.plt
+320412	./IBM16/INSTANTANEOUS/3D00007800.plt
+320412	./IBM16/INSTANTANEOUS/3D00013400.plt
+320412	./IBM16/INSTANTANEOUS/3D00006200.plt
+320404	./IBM16/INSTANTANEOUS/3D00001000.plt
+320412	./IBM16/INSTANTANEOUS/3D00012800.plt
+320412	./IBM16/INSTANTANEOUS/3D00008600.plt
+320412	./IBM16/INSTANTANEOUS/3D00011000.plt
+320404	./IBM16/INSTANTANEOUS/3D00004200.plt
+320404	./IBM16/INSTANTANEOUS/3D00001400.plt
+320412	./IBM16/INSTANTANEOUS/3D00012400.plt
+320404	./IBM16/INSTANTANEOUS/3D00003600.plt
+320404	./IBM16/INSTANTANEOUS/3D00001600.plt
+320412	./IBM16/INSTANTANEOUS/3D00012200.plt
+320412	./IBM16/INSTANTANEOUS/3D00010200.plt
+320404	./IBM16/INSTANTANEOUS/3D00004800.plt
+320404	./IBM16/INSTANTANEOUS/3D00002400.plt
+320412	./IBM16/INSTANTANEOUS/3D00008000.plt
+320404	./IBM16/INSTANTANEOUS/3D00003400.plt
+320404	./IBM16/INSTANTANEOUS/3D00003800.plt
+320404	./IBM16/INSTANTANEOUS/3D00004000.plt
+320412	./IBM16/INSTANTANEOUS/3D00011200.plt
+320412	./IBM16/INSTANTANEOUS/3D00011600.plt
+320404	./IBM16/INSTANTANEOUS/3D00004600.plt
+320412	./IBM16/INSTANTANEOUS/3D00006600.plt
+320412	./IBM16/INSTANTANEOUS/3D00013200.plt
+320404	./IBM16/INSTANTANEOUS/3D00000400.plt
+320412	./IBM16/INSTANTANEOUS/3D00008400.plt
+320412	./IBM16/INSTANTANEOUS/3D00008200.plt
+320412	./IBM16/INSTANTANEOUS/3D00009800.plt
+320412	./IBM16/INSTANTANEOUS/3D00013000.plt
+320412	./IBM16/INSTANTANEOUS/3D00013600.plt
+320404	./IBM16/INSTANTANEOUS/3D00003000.plt
+320412	./IBM16/INSTANTANEOUS/3D00010600.plt
+320412	./IBM16/INSTANTANEOUS/3D00009600.plt
+320404	./IBM16/INSTANTANEOUS/3D00004400.plt
+320412	./IBM16/INSTANTANEOUS/3D00007200.plt
+320412	./IBM16/INSTANTANEOUS/3D00012000.plt
+320404	./IBM16/INSTANTANEOUS/3D00003200.plt
+320412	./IBM16/INSTANTANEOUS/3D00009000.plt
+320404	./IBM16/INSTANTANEOUS/3D00001800.plt
+320404	./IBM16/INSTANTANEOUS/3D00005800.plt
+320404	./IBM16/INSTANTANEOUS/3D00002200.plt
+320412	./IBM16/INSTANTANEOUS/3D00010400.plt
+320412	./IBM16/INSTANTANEOUS/3D00008800.plt
+320412	./IBM16/INSTANTANEOUS/3D00013800.plt
+320404	./IBM16/INSTANTANEOUS/3D00005200.plt
+320412	./IBM16/INSTANTANEOUS/3D00010000.plt
+320412	./IBM16/INSTANTANEOUS/3D00006800.plt
+320404	./IBM16/INSTANTANEOUS/3D00005000.plt
+320404	./IBM16/INSTANTANEOUS/3D00000600.plt
+320412	./IBM16/INSTANTANEOUS/3D00007600.plt
+320412	./IBM16/INSTANTANEOUS/3D00007000.plt
+320404	./IBM16/INSTANTANEOUS/3D00005400.plt
+320404	./IBM16/INSTANTANEOUS/3D00001200.plt
+320404	./IBM16/INSTANTANEOUS/3D00006000.plt
+320412	./IBM16/INSTANTANEOUS/3D00009200.plt
+320412	./IBM16/INSTANTANEOUS/3D00011800.plt
+320404	./IBM16/INSTANTANEOUS/3D00002600.plt
+320412	./IBM16/INSTANTANEOUS/3D00007400.plt
+320404	./IBM16/INSTANTANEOUS/3D00000200.plt
+320404	./IBM16/INSTANTANEOUS/3D00000800.plt
+320404	./IBM16/INSTANTANEOUS/3D00002000.plt
+320404	./IBM16/INSTANTANEOUS/3D00002800.plt
+320412	./IBM16/INSTANTANEOUS/3D00010800.plt
+320412	./IBM16/INSTANTANEOUS/3D00006400.plt
+320412	./IBM16/INSTANTANEOUS/3D00009400.plt
+22108192	./IBM16/INSTANTANEOUS
+496	./IBM16/results_aegean
+32	./IBM16/SURFACE/00033050.dat
+32	./IBM16/SURFACE/00039800.dat
+32	./IBM16/SURFACE/00024400.dat
+32	./IBM16/SURFACE/00035300.dat
+36	./IBM16/SURFACE/00002850.dat
+32	./IBM16/SURFACE/00046450.dat
+32	./IBM16/SURFACE/00025200.dat
+32	./IBM16/SURFACE/00047800.dat
+32	./IBM16/SURFACE/00047900.dat
+32	./IBM16/SURFACE/00048750.dat
+36	./IBM16/SURFACE/00003250.dat
+32	./IBM16/SURFACE/00048050.dat
+32	./IBM16/SURFACE/00031850.dat
+36	./IBM16/SURFACE/00005900.dat
+36	./IBM16/SURFACE/00010950.dat
+32	./IBM16/SURFACE/00016350.dat
+36	./IBM16/SURFACE/00010700.dat
+32	./IBM16/SURFACE/00028100.dat
+32	./IBM16/SURFACE/00032950.dat
+32	./IBM16/SURFACE/00041300.dat
+32	./IBM16/SURFACE/00016500.dat
+36	./IBM16/SURFACE/00012650.dat
+36	./IBM16/SURFACE/00009400.dat
+32	./IBM16/SURFACE/00047100.dat
+32	./IBM16/SURFACE/00018950.dat
+32	./IBM16/SURFACE/00043250.dat
+32	./IBM16/SURFACE/00024900.dat
+32	./IBM16/SURFACE/00032650.dat
+36	./IBM16/SURFACE/00009850.dat
+32	./IBM16/SURFACE/00040800.dat
+32	./IBM16/SURFACE/00035500.dat
+32	./IBM16/SURFACE/00034200.dat
+36	./IBM16/SURFACE/00013150.dat
+32	./IBM16/SURFACE/00019950.dat
+32	./IBM16/SURFACE/00029450.dat
+32	./IBM16/SURFACE/00028750.dat
+32	./IBM16/SURFACE/00026250.dat
+32	./IBM16/SURFACE/00031550.dat
+32	./IBM16/SURFACE/00032900.dat
+36	./IBM16/SURFACE/00014300.dat
+32	./IBM16/SURFACE/00042450.dat
+36	./IBM16/SURFACE/00007200.dat
+32	./IBM16/SURFACE/00031350.dat
+32	./IBM16/SURFACE/00021400.dat
+32	./IBM16/SURFACE/00018550.dat
+36	./IBM16/SURFACE/00013600.dat
+36	./IBM16/SURFACE/00004950.dat
+36	./IBM16/SURFACE/00004450.dat
+32	./IBM16/SURFACE/00033900.dat
+32	./IBM16/SURFACE/00020800.dat
+36	./IBM16/SURFACE/00009000.dat
+36	./IBM16/SURFACE/00014250.dat
+32	./IBM16/SURFACE/00024300.dat
+32	./IBM16/SURFACE/00036750.dat
+32	./IBM16/SURFACE/00040300.dat
+32	./IBM16/SURFACE/00043700.dat
+32	./IBM16/SURFACE/00035450.dat
+36	./IBM16/SURFACE/00009450.dat
+32	./IBM16/SURFACE/00039950.dat
+36	./IBM16/SURFACE/00011600.dat
+36	./IBM16/SURFACE/00002950.dat
+36	./IBM16/SURFACE/00001650.dat
+32	./IBM16/SURFACE/00026050.dat
+32	./IBM16/SURFACE/00039200.dat
+32	./IBM16/SURFACE/00034350.dat
+32	./IBM16/SURFACE/00041700.dat
+32	./IBM16/SURFACE/00047050.dat
+32	./IBM16/SURFACE/00026900.dat
+32	./IBM16/SURFACE/00030550.dat
+32	./IBM16/SURFACE/00042850.dat
+36	./IBM16/SURFACE/00010800.dat
+32	./IBM16/SURFACE/00028900.dat
+32	./IBM16/SURFACE/00034750.dat
+32	./IBM16/SURFACE/00024350.dat
+36	./IBM16/SURFACE/00006100.dat
+32	./IBM16/SURFACE/00015700.dat
+32	./IBM16/SURFACE/00048000.dat
+32	./IBM16/SURFACE/00016750.dat
+32	./IBM16/SURFACE/00040600.dat
+32	./IBM16/SURFACE/00015200.dat
+32	./IBM16/SURFACE/00046500.dat
+32	./IBM16/SURFACE/00016250.dat
+36	./IBM16/SURFACE/00011100.dat
+36	./IBM16/SURFACE/00004300.dat
+36	./IBM16/SURFACE/00012350.dat
+32	./IBM16/SURFACE/00021000.dat
+32	./IBM16/SURFACE/00048100.dat
+32	./IBM16/SURFACE/00022300.dat
+32	./IBM16/SURFACE/00042050.dat
+32	./IBM16/SURFACE/00033950.dat
+36	./IBM16/SURFACE/00005000.dat
+32	./IBM16/SURFACE/00037300.dat
+32	./IBM16/SURFACE/00030450.dat
+32	./IBM16/SURFACE/00041550.dat
+36	./IBM16/SURFACE/00006250.dat
+32	./IBM16/SURFACE/00040250.dat
+32	./IBM16/SURFACE/00037400.dat
+32	./IBM16/SURFACE/00019300.dat
+32	./IBM16/SURFACE/00044300.dat
+32	./IBM16/SURFACE/00023300.dat
+32	./IBM16/SURFACE/00048550.dat
+36	./IBM16/SURFACE/00007050.dat
+36	./IBM16/SURFACE/00012600.dat
+32	./IBM16/SURFACE/00037600.dat
+32	./IBM16/SURFACE/00040650.dat
+32	./IBM16/SURFACE/00026200.dat
+32	./IBM16/SURFACE/00044900.dat
+32	./IBM16/SURFACE/00033400.dat
+36	./IBM16/SURFACE/00001500.dat
+32	./IBM16/SURFACE/00036900.dat
+32	./IBM16/SURFACE/00037350.dat
+36	./IBM16/SURFACE/00011300.dat
+32	./IBM16/SURFACE/00042300.dat
+32	./IBM16/SURFACE/00023200.dat
+32	./IBM16/SURFACE/00047000.dat
+36	./IBM16/SURFACE/00003300.dat
+36	./IBM16/SURFACE/00007300.dat
+32	./IBM16/SURFACE/00017400.dat
+36	./IBM16/SURFACE/00004550.dat
+36	./IBM16/SURFACE/00007950.dat
+32	./IBM16/SURFACE/00022000.dat
+36	./IBM16/SURFACE/00008100.dat
+32	./IBM16/SURFACE/00027700.dat
+32	./IBM16/SURFACE/00034700.dat
+36	./IBM16/SURFACE/00014850.dat
+32	./IBM16/SURFACE/00039650.dat
+36	./IBM16/SURFACE/00007800.dat
+36	./IBM16/SURFACE/00005300.dat
+32	./IBM16/SURFACE/00018000.dat
+36	./IBM16/SURFACE/00005700.dat
+32	./IBM16/SURFACE/00020300.dat
+36	./IBM16/SURFACE/00004500.dat
+32	./IBM16/SURFACE/00018800.dat
+32	./IBM16/SURFACE/00017750.dat
+36	./IBM16/SURFACE/00003100.dat
+32	./IBM16/SURFACE/00018400.dat
+32	./IBM16/SURFACE/00043200.dat
+32	./IBM16/SURFACE/00035100.dat
+32	./IBM16/SURFACE/00041600.dat
+32	./IBM16/SURFACE/00034400.dat
+32	./IBM16/SURFACE/00023250.dat
+36	./IBM16/SURFACE/00008650.dat
+32	./IBM16/SURFACE/00023150.dat
+36	./IBM16/SURFACE/00007450.dat
+32	./IBM16/SURFACE/00043950.dat
+32	./IBM16/SURFACE/00029250.dat
+36	./IBM16/SURFACE/00013400.dat
+36	./IBM16/SURFACE/00004150.dat
+32	./IBM16/SURFACE/00041050.dat
+32	./IBM16/SURFACE/00016050.dat
+32	./IBM16/SURFACE/00036650.dat
+32	./IBM16/SURFACE/00025700.dat
+32	./IBM16/SURFACE/00036350.dat
+32	./IBM16/SURFACE/00020650.dat
+36	./IBM16/SURFACE/00006850.dat
+32	./IBM16/SURFACE/00046300.dat
+32	./IBM16/SURFACE/00039400.dat
+32	./IBM16/SURFACE/00037450.dat
+32	./IBM16/SURFACE/00046950.dat
+32	./IBM16/SURFACE/00027000.dat
+36	./IBM16/SURFACE/00009650.dat
+36	./IBM16/SURFACE/00000750.dat
+32	./IBM16/SURFACE/00046900.dat
+32	./IBM16/SURFACE/00019750.dat
+32	./IBM16/SURFACE/00041750.dat
+32	./IBM16/SURFACE/00030500.dat
+32	./IBM16/SURFACE/00040850.dat
+36	./IBM16/SURFACE/00000100.dat
+32	./IBM16/SURFACE/00028700.dat
+36	./IBM16/SURFACE/00002700.dat
+32	./IBM16/SURFACE/00040750.dat
+32	./IBM16/SURFACE/00038500.dat
+36	./IBM16/SURFACE/00005650.dat
+32	./IBM16/SURFACE/00043050.dat
+32	./IBM16/SURFACE/00041500.dat
+36	./IBM16/SURFACE/00003450.dat
+32	./IBM16/SURFACE/00042550.dat
+36	./IBM16/SURFACE/00009100.dat
+32	./IBM16/SURFACE/00041800.dat
+32	./IBM16/SURFACE/00019150.dat
+36	./IBM16/SURFACE/00010400.dat
+36	./IBM16/SURFACE/00009250.dat
+32	./IBM16/SURFACE/00034600.dat
+32	./IBM16/SURFACE/00037100.dat
+36	./IBM16/SURFACE/00012800.dat
+32	./IBM16/SURFACE/00024050.dat
+32	./IBM16/SURFACE/00047150.dat
+32	./IBM16/SURFACE/00028550.dat
+32	./IBM16/SURFACE/00029000.dat
+32	./IBM16/SURFACE/00028850.dat
+32	./IBM16/SURFACE/00021800.dat
+36	./IBM16/SURFACE/00000200.dat
+32	./IBM16/SURFACE/00030400.dat
+36	./IBM16/SURFACE/00011750.dat
+32	./IBM16/SURFACE/00029350.dat
+32	./IBM16/SURFACE/00025950.dat
+32	./IBM16/SURFACE/00033850.dat
+36	./IBM16/SURFACE/00000900.dat
+32	./IBM16/SURFACE/00029200.dat
+36	./IBM16/SURFACE/00001900.dat
+32	./IBM16/SURFACE/00046050.dat
+36	./IBM16/SURFACE/00008450.dat
+32	./IBM16/SURFACE/00018500.dat
+32	./IBM16/SURFACE/00023850.dat
+32	./IBM16/SURFACE/00025250.dat
+32	./IBM16/SURFACE/00041150.dat
+32	./IBM16/SURFACE/00026000.dat
+32	./IBM16/SURFACE/00030850.dat
+32	./IBM16/SURFACE/00045500.dat
+32	./IBM16/SURFACE/00038450.dat
+32	./IBM16/SURFACE/00030050.dat
+36	./IBM16/SURFACE/00010900.dat
+36	./IBM16/SURFACE/00012300.dat
+32	./IBM16/SURFACE/00048500.dat
+32	./IBM16/SURFACE/00039100.dat
+32	./IBM16/SURFACE/00020150.dat
+32	./IBM16/SURFACE/00043300.dat
+36	./IBM16/SURFACE/00010250.dat
+36	./IBM16/SURFACE/00004000.dat
+32	./IBM16/SURFACE/00041950.dat
+32	./IBM16/SURFACE/00042650.dat
+36	./IBM16/SURFACE/00014050.dat
+32	./IBM16/SURFACE/00036050.dat
+32	./IBM16/SURFACE/00023450.dat
+32	./IBM16/SURFACE/00019450.dat
+32	./IBM16/SURFACE/00016650.dat
+32	./IBM16/SURFACE/00048950.dat
+36	./IBM16/SURFACE/00002900.dat
+32	./IBM16/SURFACE/00035850.dat
+32	./IBM16/SURFACE/00045200.dat
+32	./IBM16/SURFACE/00024000.dat
+32	./IBM16/SURFACE/00018100.dat
+32	./IBM16/SURFACE/00047450.dat
+32	./IBM16/SURFACE/00045950.dat
+36	./IBM16/SURFACE/00005850.dat
+36	./IBM16/SURFACE/00009750.dat
+32	./IBM16/SURFACE/00039300.dat
+32	./IBM16/SURFACE/00031950.dat
+32	./IBM16/SURFACE/00035650.dat
+32	./IBM16/SURFACE/00047750.dat
+36	./IBM16/SURFACE/00002800.dat
+32	./IBM16/SURFACE/00044600.dat
+36	./IBM16/SURFACE/00014450.dat
+36	./IBM16/SURFACE/00012250.dat
+32	./IBM16/SURFACE/00017000.dat
+36	./IBM16/SURFACE/00001700.dat
+32	./IBM16/SURFACE/00029300.dat
+32	./IBM16/SURFACE/00038550.dat
+32	./IBM16/SURFACE/00044700.dat
+36	./IBM16/SURFACE/00006400.dat
+32	./IBM16/SURFACE/00015050.dat
+32	./IBM16/SURFACE/00029850.dat
+32	./IBM16/SURFACE/00029400.dat
+32	./IBM16/SURFACE/00046000.dat
+32	./IBM16/SURFACE/00016300.dat
+36	./IBM16/SURFACE/00006550.dat
+36	./IBM16/SURFACE/00003950.dat
+36	./IBM16/SURFACE/00002200.dat
+32	./IBM16/SURFACE/00021350.dat
+32	./IBM16/SURFACE/00036450.dat
+32	./IBM16/SURFACE/00039500.dat
+32	./IBM16/SURFACE/00045850.dat
+32	./IBM16/SURFACE/00027800.dat
+32	./IBM16/SURFACE/00032100.dat
+32	./IBM16/SURFACE/00019700.dat
+36	./IBM16/SURFACE/00010450.dat
+36	./IBM16/SURFACE/00011150.dat
+32	./IBM16/SURFACE/00015350.dat
+32	./IBM16/SURFACE/00032150.dat
+36	./IBM16/SURFACE/00004750.dat
+36	./IBM16/SURFACE/00000850.dat
+32	./IBM16/SURFACE/00048800.dat
+32	./IBM16/SURFACE/00048350.dat
+32	./IBM16/SURFACE/00023550.dat
+32	./IBM16/SURFACE/00034100.dat
+32	./IBM16/SURFACE/00020600.dat
+32	./IBM16/SURFACE/00043000.dat
+32	./IBM16/SURFACE/00022050.dat
+32	./IBM16/SURFACE/00037050.dat
+36	./IBM16/SURFACE/00004350.dat
+32	./IBM16/SURFACE/00047500.dat
+32	./IBM16/SURFACE/00044500.dat
+36	./IBM16/SURFACE/00007500.dat
+32	./IBM16/SURFACE/00035250.dat
+32	./IBM16/SURFACE/00033700.dat
+32	./IBM16/SURFACE/00046700.dat
+36	./IBM16/SURFACE/00013300.dat
+36	./IBM16/SURFACE/00002000.dat
+32	./IBM16/SURFACE/00023900.dat
+36	./IBM16/SURFACE/00013350.dat
+32	./IBM16/SURFACE/00034850.dat
+32	./IBM16/SURFACE/00037750.dat
+32	./IBM16/SURFACE/00016450.dat
+32	./IBM16/SURFACE/00031750.dat
+32	./IBM16/SURFACE/00039250.dat
+36	./IBM16/SURFACE/00007700.dat
+32	./IBM16/SURFACE/00023800.dat
+36	./IBM16/SURFACE/00011700.dat
+32	./IBM16/SURFACE/00024500.dat
+32	./IBM16/SURFACE/00034150.dat
+32	./IBM16/SURFACE/00018050.dat
+36	./IBM16/SURFACE/00002350.dat
+32	./IBM16/SURFACE/00024700.dat
+32	./IBM16/SURFACE/00025150.dat
+32	./IBM16/SURFACE/00017650.dat
+32	./IBM16/SURFACE/00017800.dat
+32	./IBM16/SURFACE/00040200.dat
+32	./IBM16/SURFACE/00027200.dat
+36	./IBM16/SURFACE/00004100.dat
+32	./IBM16/SURFACE/00040950.dat
+32	./IBM16/SURFACE/00038200.dat
+32	./IBM16/SURFACE/00036100.dat
+32	./IBM16/SURFACE/00029950.dat
+36	./IBM16/SURFACE/00006300.dat
+36	./IBM16/SURFACE/00014100.dat
+32	./IBM16/SURFACE/00017950.dat
+36	./IBM16/SURFACE/00002550.dat
+32	./IBM16/SURFACE/00015300.dat
+36	./IBM16/SURFACE/00001100.dat
+32	./IBM16/SURFACE/00045600.dat
+32	./IBM16/SURFACE/00016100.dat
+32	./IBM16/SURFACE/00025900.dat
+36	./IBM16/SURFACE/00005750.dat
+32	./IBM16/SURFACE/00036300.dat
+32	./IBM16/SURFACE/00021950.dat
+32	./IBM16/SURFACE/00048900.dat
+32	./IBM16/SURFACE/00022450.dat
+36	./IBM16/SURFACE/00002500.dat
+32	./IBM16/SURFACE/00037850.dat
+32	./IBM16/SURFACE/00035600.dat
+32	./IBM16/SURFACE/00023000.dat
+36	./IBM16/SURFACE/00008800.dat
+32	./IBM16/SURFACE/00023950.dat
+32	./IBM16/SURFACE/00045750.dat
+32	./IBM16/SURFACE/00037700.dat
+32	./IBM16/SURFACE/00028800.dat
+32	./IBM16/SURFACE/00015150.dat
+36	./IBM16/SURFACE/00011650.dat
+32	./IBM16/SURFACE/00043150.dat
+32	./IBM16/SURFACE/00030000.dat
+36	./IBM16/SURFACE/00003700.dat
+32	./IBM16/SURFACE/00031450.dat
+32	./IBM16/SURFACE/00037900.dat
+32	./IBM16/SURFACE/00039550.dat
+32	./IBM16/SURFACE/00031400.dat
+32	./IBM16/SURFACE/00045150.dat
+32	./IBM16/SURFACE/00032350.dat
+36	./IBM16/SURFACE/00005400.dat
+36	./IBM16/SURFACE/00008750.dat
+32	./IBM16/SURFACE/00043650.dat
+32	./IBM16/SURFACE/00021050.dat
+36	./IBM16/SURFACE/00011950.dat
+32	./IBM16/SURFACE/00017550.dat
+36	./IBM16/SURFACE/00011550.dat
+32	./IBM16/SURFACE/00022850.dat
+36	./IBM16/SURFACE/00005500.dat
+36	./IBM16/SURFACE/00009950.dat
+32	./IBM16/SURFACE/00024450.dat
+36	./IBM16/SURFACE/00009150.dat
+36	./IBM16/SURFACE/00007000.dat
+32	./IBM16/SURFACE/00044750.dat
+32	./IBM16/SURFACE/00024950.dat
+32	./IBM16/SURFACE/00034250.dat
+32	./IBM16/SURFACE/00048250.dat
+32	./IBM16/SURFACE/00028950.dat
+36	./IBM16/SURFACE/00013100.dat
+32	./IBM16/SURFACE/00031700.dat
+32	./IBM16/SURFACE/00017300.dat
+32	./IBM16/SURFACE/00039750.dat
+32	./IBM16/SURFACE/00015250.dat
+36	./IBM16/SURFACE/00003150.dat
+36	./IBM16/SURFACE/00010150.dat
+32	./IBM16/SURFACE/00017050.dat
+32	./IBM16/SURFACE/00021550.dat
+32	./IBM16/SURFACE/00041000.dat
+32	./IBM16/SURFACE/00029750.dat
+36	./IBM16/SURFACE/00004700.dat
+32	./IBM16/SURFACE/00028200.dat
+32	./IBM16/SURFACE/00016800.dat
+32	./IBM16/SURFACE/00032550.dat
+36	./IBM16/SURFACE/00000400.dat
+32	./IBM16/SURFACE/00017350.dat
+32	./IBM16/SURFACE/00035700.dat
+32	./IBM16/SURFACE/00038300.dat
+36	./IBM16/SURFACE/00006450.dat
+32	./IBM16/SURFACE/00048700.dat
+36	./IBM16/SURFACE/00004650.dat
+32	./IBM16/SURFACE/00048400.dat
+32	./IBM16/SURFACE/00048600.dat
+32	./IBM16/SURFACE/00017850.dat
+32	./IBM16/SURFACE/00029100.dat
+36	./IBM16/SURFACE/00007750.dat
+36	./IBM16/SURFACE/00006350.dat
+32	./IBM16/SURFACE/00020050.dat
+36	./IBM16/SURFACE/00009200.dat
+32	./IBM16/SURFACE/00031050.dat
+32	./IBM16/SURFACE/00030300.dat
+36	./IBM16/SURFACE/00004900.dat
+32	./IBM16/SURFACE/00022950.dat
+36	./IBM16/SURFACE/00012750.dat
+32	./IBM16/SURFACE/00046750.dat
+36	./IBM16/SURFACE/00000150.dat
+32	./IBM16/SURFACE/00025350.dat
+32	./IBM16/SURFACE/00026500.dat
+36	./IBM16/SURFACE/00008000.dat
+36	./IBM16/SURFACE/00010500.dat
+32	./IBM16/SURFACE/00034000.dat
+32	./IBM16/SURFACE/00021450.dat
+32	./IBM16/SURFACE/00037200.dat
+32	./IBM16/SURFACE/00020900.dat
+32	./IBM16/SURFACE/00020700.dat
+36	./IBM16/SURFACE/00007100.dat
+36	./IBM16/SURFACE/00009700.dat
+32	./IBM16/SURFACE/00048650.dat
+32	./IBM16/SURFACE/00047300.dat
+32	./IBM16/SURFACE/00038000.dat
+32	./IBM16/SURFACE/00021650.dat
+36	./IBM16/SURFACE/00004250.dat
+32	./IBM16/SURFACE/00015800.dat
+36	./IBM16/SURFACE/00001550.dat
+32	./IBM16/SURFACE/00019800.dat
+36	./IBM16/SURFACE/00010550.dat
+32	./IBM16/SURFACE/00021750.dat
+32	./IBM16/SURFACE/00025550.dat
+32	./IBM16/SURFACE/00028300.dat
+36	./IBM16/SURFACE/00013500.dat
+32	./IBM16/SURFACE/00025100.dat
+36	./IBM16/SURFACE/00005200.dat
+32	./IBM16/SURFACE/00027550.dat
+36	./IBM16/SURFACE/00012450.dat
+36	./IBM16/SURFACE/00014800.dat
+36	./IBM16/SURFACE/00011350.dat
+32	./IBM16/SURFACE/00035150.dat
+36	./IBM16/SURFACE/00002300.dat
+32	./IBM16/SURFACE/00041850.dat
+36	./IBM16/SURFACE/00014000.dat
+36	./IBM16/SURFACE/00007250.dat
+32	./IBM16/SURFACE/00029900.dat
+36	./IBM16/SURFACE/00002650.dat
+36	./IBM16/SURFACE/00006600.dat
+32	./IBM16/SURFACE/00019850.dat
+36	./IBM16/SURFACE/00011400.dat
+32	./IBM16/SURFACE/00029150.dat
+36	./IBM16/SURFACE/00013650.dat
+32	./IBM16/SURFACE/00030200.dat
+36	./IBM16/SURFACE/00006950.dat
+32	./IBM16/SURFACE/00018900.dat
+32	./IBM16/SURFACE/00033750.dat
+36	./IBM16/SURFACE/00006000.dat
+32	./IBM16/SURFACE/00024150.dat
+36	./IBM16/SURFACE/00012050.dat
+32	./IBM16/SURFACE/00029050.dat
+36	./IBM16/SURFACE/00006750.dat
+36	./IBM16/SURFACE/00003850.dat
+36	./IBM16/SURFACE/00008150.dat
+36	./IBM16/SURFACE/00001050.dat
+32	./IBM16/SURFACE/00033550.dat
+32	./IBM16/SURFACE/00036000.dat
+32	./IBM16/SURFACE/00029650.dat
+32	./IBM16/SURFACE/00020450.dat
+32	./IBM16/SURFACE/00036950.dat
+32	./IBM16/SURFACE/00035900.dat
+32	./IBM16/SURFACE/00018600.dat
+32	./IBM16/SURFACE/00026800.dat
+32	./IBM16/SURFACE/00030650.dat
+36	./IBM16/SURFACE/00007600.dat
+32	./IBM16/SURFACE/00036500.dat
+32	./IBM16/SURFACE/00038650.dat
+36	./IBM16/SURFACE/00000600.dat
+32	./IBM16/SURFACE/00020000.dat
+32	./IBM16/SURFACE/00042150.dat
+32	./IBM16/SURFACE/00024600.dat
+32	./IBM16/SURFACE/00031600.dat
+32	./IBM16/SURFACE/00019600.dat
+36	./IBM16/SURFACE/00013700.dat
+32	./IBM16/SURFACE/00041200.dat
+36	./IBM16/SURFACE/00000700.dat
+32	./IBM16/SURFACE/00040000.dat
+36	./IBM16/SURFACE/00007350.dat
+36	./IBM16/SURFACE/00003600.dat
+36	./IBM16/SURFACE/00000450.dat
+32	./IBM16/SURFACE/00017450.dat
+32	./IBM16/SURFACE/00022100.dat
+32	./IBM16/SURFACE/00028250.dat
+32	./IBM16/SURFACE/00023700.dat
+36	./IBM16/SURFACE/00001000.dat
+36	./IBM16/SURFACE/00009900.dat
+32	./IBM16/SURFACE/00045400.dat
+32	./IBM16/SURFACE/00035400.dat
+36	./IBM16/SURFACE/00000350.dat
+36	./IBM16/SURFACE/00010650.dat
+32	./IBM16/SURFACE/00019500.dat
+32	./IBM16/SURFACE/00025000.dat
+32	./IBM16/SURFACE/00028600.dat
+32	./IBM16/SURFACE/00017100.dat
+32	./IBM16/SURFACE/00019400.dat
+32	./IBM16/SURFACE/00027100.dat
+32	./IBM16/SURFACE/00033200.dat
+36	./IBM16/SURFACE/00001600.dat
+32	./IBM16/SURFACE/00047650.dat
+32	./IBM16/SURFACE/00032300.dat
+36	./IBM16/SURFACE/00005550.dat
+32	./IBM16/SURFACE/00018150.dat
+32	./IBM16/SURFACE/00017600.dat
+32	./IBM16/SURFACE/00021900.dat
+32	./IBM16/SURFACE/00021300.dat
+32	./IBM16/SURFACE/00034650.dat
+32	./IBM16/SURFACE/00027450.dat
+32	./IBM16/SURFACE/00029800.dat
+32	./IBM16/SURFACE/00021200.dat
+36	./IBM16/SURFACE/00000050.dat
+32	./IBM16/SURFACE/00032850.dat
+32	./IBM16/SURFACE/00038950.dat
+36	./IBM16/SURFACE/00002250.dat
+36	./IBM16/SURFACE/00005050.dat
+32	./IBM16/SURFACE/00022500.dat
+32	./IBM16/SURFACE/00020950.dat
+36	./IBM16/SURFACE/00008950.dat
+32	./IBM16/SURFACE/00038350.dat
+36	./IBM16/SURFACE/00000650.dat
+32	./IBM16/SURFACE/00028050.dat
+32	./IBM16/SURFACE/00022350.dat
+32	./IBM16/SURFACE/00039450.dat
+36	./IBM16/SURFACE/00003750.dat
+32	./IBM16/SURFACE/00020350.dat
+32	./IBM16/SURFACE/00026700.dat
+32	./IBM16/SURFACE/00046550.dat
+32	./IBM16/SURFACE/00036200.dat
+32	./IBM16/SURFACE/00022700.dat
+32	./IBM16/SURFACE/00043400.dat
+32	./IBM16/SURFACE/00024200.dat
+32	./IBM16/SURFACE/00030900.dat
+32	./IBM16/SURFACE/00035050.dat
+32	./IBM16/SURFACE/00043450.dat
+36	./IBM16/SURFACE/00006700.dat
+32	./IBM16/SURFACE/00044000.dat
+32	./IBM16/SURFACE/00027600.dat
+36	./IBM16/SURFACE/00004050.dat
+36	./IBM16/SURFACE/00008350.dat
+32	./IBM16/SURFACE/00039700.dat
+32	./IBM16/SURFACE/00040150.dat
+32	./IBM16/SURFACE/00032800.dat
+36	./IBM16/SURFACE/00011800.dat
+36	./IBM16/SURFACE/00010050.dat
+32	./IBM16/SURFACE/00020750.dat
+32	./IBM16/SURFACE/00035000.dat
+32	./IBM16/SURFACE/00027750.dat
+36	./IBM16/SURFACE/00002750.dat
+32	./IBM16/SURFACE/00019200.dat
+32	./IBM16/SURFACE/00019100.dat
+32	./IBM16/SURFACE/00015850.dat
+32	./IBM16/SURFACE/00044950.dat
+36	./IBM16/SURFACE/00002150.dat
+32	./IBM16/SURFACE/00016550.dat
+32	./IBM16/SURFACE/00034500.dat
+32	./IBM16/SURFACE/00025750.dat
+32	./IBM16/SURFACE/00042000.dat
+32	./IBM16/SURFACE/00025850.dat
+32	./IBM16/SURFACE/00042900.dat
+32	./IBM16/SURFACE/00021500.dat
+36	./IBM16/SURFACE/00011000.dat
+32	./IBM16/SURFACE/00025400.dat
+32	./IBM16/SURFACE/00032600.dat
+32	./IBM16/SURFACE/00015750.dat
+32	./IBM16/SURFACE/00042250.dat
+36	./IBM16/SURFACE/00002600.dat
+32	./IBM16/SURFACE/00020850.dat
+32	./IBM16/SURFACE/00029500.dat
+32	./IBM16/SURFACE/00021700.dat
+32	./IBM16/SURFACE/00035750.dat
+32	./IBM16/SURFACE/00041900.dat
+32	./IBM16/SURFACE/00018750.dat
+32	./IBM16/SURFACE/00044150.dat
+36	./IBM16/SURFACE/00007150.dat
+32	./IBM16/SURFACE/00022200.dat
+32	./IBM16/SURFACE/00036850.dat
+36	./IBM16/SURFACE/00012100.dat
+32	./IBM16/SURFACE/00032500.dat
+36	./IBM16/SURFACE/00000550.dat
+32	./IBM16/SURFACE/00044050.dat
+32	./IBM16/SURFACE/00036400.dat
+32	./IBM16/SURFACE/00028650.dat
+32	./IBM16/SURFACE/00019000.dat
+32	./IBM16/SURFACE/00037550.dat
+32	./IBM16/SURFACE/00025650.dat
+32	./IBM16/SURFACE/00016600.dat
+32	./IBM16/SURFACE/00022650.dat
+32	./IBM16/SURFACE/00043750.dat
+32	./IBM16/SURFACE/00017150.dat
+32	./IBM16/SURFACE/00032700.dat
+32	./IBM16/SURFACE/00016850.dat
+32	./IBM16/SURFACE/00025800.dat
+32	./IBM16/SURFACE/00033000.dat
+32	./IBM16/SURFACE/00031250.dat
+32	./IBM16/SURFACE/00031200.dat
+32	./IBM16/SURFACE/00021250.dat
+36	./IBM16/SURFACE/00009300.dat
+32	./IBM16/SURFACE/00048150.dat
+32	./IBM16/SURFACE/00044200.dat
+36	./IBM16/SURFACE/00010200.dat
+32	./IBM16/SURFACE/00027050.dat
+32	./IBM16/SURFACE/00036600.dat
+32	./IBM16/SURFACE/00020200.dat
+32	./IBM16/SURFACE/00035350.dat
+32	./IBM16/SURFACE/00017500.dat
+32	./IBM16/SURFACE/00040500.dat
+32	./IBM16/SURFACE/00038250.dat
+32	./IBM16/SURFACE/00039050.dat
+32	./IBM16/SURFACE/00030100.dat
+32	./IBM16/SURFACE/00023400.dat
+32	./IBM16/SURFACE/00022600.dat
+32	./IBM16/SURFACE/00018700.dat
+36	./IBM16/SURFACE/00014650.dat
+32	./IBM16/SURFACE/00047400.dat
+32	./IBM16/SURFACE/00033450.dat
+32	./IBM16/SURFACE/00019650.dat
+32	./IBM16/SURFACE/00027950.dat
+32	./IBM16/SURFACE/00029550.dat
+36	./IBM16/SURFACE/00013450.dat
+32	./IBM16/SURFACE/00019900.dat
+32	./IBM16/SURFACE/00026100.dat
+32	./IBM16/SURFACE/00026600.dat
+36	./IBM16/SURFACE/00007850.dat
+36	./IBM16/SURFACE/00003350.dat
+36	./IBM16/SURFACE/00001350.dat
+32	./IBM16/SURFACE/00036700.dat
+32	./IBM16/SURFACE/00016900.dat
+32	./IBM16/SURFACE/00046400.dat
+32	./IBM16/SURFACE/00039000.dat
+32	./IBM16/SURFACE/00039150.dat
+32	./IBM16/SURFACE/00027300.dat
+32	./IBM16/SURFACE/00025050.dat
+32	./IBM16/SURFACE/00038700.dat
+32	./IBM16/SURFACE/00019250.dat
+36	./IBM16/SURFACE/00009550.dat
+32	./IBM16/SURFACE/00015550.dat
+36	./IBM16/SURFACE/00009600.dat
+32	./IBM16/SURFACE/00046250.dat
+32	./IBM16/SURFACE/00031150.dat
+32	./IBM16/SURFACE/00036800.dat
+32	./IBM16/SURFACE/00045100.dat
+36	./IBM16/SURFACE/00006800.dat
+32	./IBM16/SURFACE/00032250.dat
+32	./IBM16/SURFACE/00020250.dat
+32	./IBM16/SURFACE/00024750.dat
+36	./IBM16/SURFACE/00014150.dat
+32	./IBM16/SURFACE/00046650.dat
+36	./IBM16/SURFACE/00001150.dat
+32	./IBM16/SURFACE/00038400.dat
+32	./IBM16/SURFACE/00041400.dat
+32	./IBM16/SURFACE/00045350.dat
+32	./IBM16/SURFACE/00027400.dat
+36	./IBM16/SURFACE/00014900.dat
+32	./IBM16/SURFACE/00032000.dat
+32	./IBM16/SURFACE/00026400.dat
+32	./IBM16/SURFACE/00022800.dat
+36	./IBM16/SURFACE/00012000.dat
+32	./IBM16/SURFACE/00040350.dat
+36	./IBM16/SURFACE/00006500.dat
+32	./IBM16/SURFACE/00026950.dat
+32	./IBM16/SURFACE/00042350.dat
+32	./IBM16/SURFACE/00030750.dat
+32	./IBM16/SURFACE/00020500.dat
+32	./IBM16/SURFACE/00026350.dat
+32	./IBM16/SURFACE/00031300.dat
+32	./IBM16/SURFACE/00031650.dat
+32	./IBM16/SURFACE/00045000.dat
+32	./IBM16/SURFACE/00015400.dat
+32	./IBM16/SURFACE/00015500.dat
+32	./IBM16/SURFACE/00015900.dat
+32	./IBM16/SURFACE/00047350.dat
+32	./IBM16/SURFACE/00030350.dat
+32	./IBM16/SURFACE/00040550.dat
+32	./IBM16/SURFACE/00027850.dat
+36	./IBM16/SURFACE/00007400.dat
+32	./IBM16/SURFACE/00043350.dat
+32	./IBM16/SURFACE/00037800.dat
+36	./IBM16/SURFACE/00008900.dat
+32	./IBM16/SURFACE/00021850.dat
+32	./IBM16/SURFACE/00033100.dat
+32	./IBM16/SURFACE/00047950.dat
+32	./IBM16/SURFACE/00016400.dat
+32	./IBM16/SURFACE/00043100.dat
+32	./IBM16/SURFACE/00035800.dat
+32	./IBM16/SURFACE/00045550.dat
+36	./IBM16/SURFACE/00009500.dat
+36	./IBM16/SURFACE/00014500.dat
+32	./IBM16/SURFACE/00045450.dat
+36	./IBM16/SURFACE/00008600.dat
+32	./IBM16/SURFACE/00015950.dat
+36	./IBM16/SURFACE/00010750.dat
+32	./IBM16/SURFACE/00046150.dat
+32	./IBM16/SURFACE/00026850.dat
+36	./IBM16/SURFACE/00008550.dat
+32	./IBM16/SURFACE/00027350.dat
+32	./IBM16/SURFACE/00018650.dat
+32	./IBM16/SURFACE/00022250.dat
+36	./IBM16/SURFACE/00006650.dat
+32	./IBM16/SURFACE/00042500.dat
+32	./IBM16/SURFACE/00040700.dat
+36	./IBM16/SURFACE/00013000.dat
+36	./IBM16/SURFACE/00003050.dat
+36	./IBM16/SURFACE/00014700.dat
+32	./IBM16/SURFACE/00033500.dat
+36	./IBM16/SURFACE/00001750.dat
+32	./IBM16/SURFACE/00037950.dat
+36	./IBM16/SURFACE/00006900.dat
+32	./IBM16/SURFACE/00031000.dat
+32	./IBM16/SURFACE/00038050.dat
+32	./IBM16/SURFACE/00039900.dat
+32	./IBM16/SURFACE/00042700.dat
+32	./IBM16/SURFACE/00032400.dat
+32	./IBM16/SURFACE/00027250.dat
+32	./IBM16/SURFACE/00026550.dat
+32	./IBM16/SURFACE/00041650.dat
+36	./IBM16/SURFACE/00001250.dat
+32	./IBM16/SURFACE/00023650.dat
+32	./IBM16/SURFACE/00022400.dat
+36	./IBM16/SURFACE/00014750.dat
+32	./IBM16/SURFACE/00030800.dat
+32	./IBM16/SURFACE/00037650.dat
+32	./IBM16/SURFACE/00032200.dat
+32	./IBM16/SURFACE/00034800.dat
+32	./IBM16/SURFACE/00044850.dat
+32	./IBM16/SURFACE/00038850.dat
+32	./IBM16/SURFACE/00024650.dat
+32	./IBM16/SURFACE/00024250.dat
+36	./IBM16/SURFACE/00010350.dat
+32	./IBM16/SURFACE/00028500.dat
+32	./IBM16/SURFACE/00018300.dat
+36	./IBM16/SURFACE/00005600.dat
+32	./IBM16/SURFACE/00039850.dat
+32	./IBM16/SURFACE/00042400.dat
+36	./IBM16/SURFACE/00004200.dat
+32	./IBM16/SURFACE/00035950.dat
+32	./IBM16/SURFACE/00048850.dat
+32	./IBM16/SURFACE/00015100.dat
+36	./IBM16/SURFACE/00001800.dat
+32	./IBM16/SURFACE/00017900.dat
+32	./IBM16/SURFACE/00018350.dat
+32	./IBM16/SURFACE/00027650.dat
+32	./IBM16/SURFACE/00045900.dat
+36	./IBM16/SURFACE/00009350.dat
+32	./IBM16/SURFACE/00037000.dat
+32	./IBM16/SURFACE/00033350.dat
+32	./IBM16/SURFACE/00043900.dat
+32	./IBM16/SURFACE/00028350.dat
+36	./IBM16/SURFACE/00008250.dat
+36	./IBM16/SURFACE/00012150.dat
+36	./IBM16/SURFACE/00000250.dat
+36	./IBM16/SURFACE/00012500.dat
+32	./IBM16/SURFACE/00035200.dat
+32	./IBM16/SURFACE/00045800.dat
+32	./IBM16/SURFACE/00022750.dat
+32	./IBM16/SURFACE/00044800.dat
+32	./IBM16/SURFACE/00038150.dat
+32	./IBM16/SURFACE/00024850.dat
+36	./IBM16/SURFACE/00006050.dat
+32	./IBM16/SURFACE/00033650.dat
+36	./IBM16/SURFACE/00011850.dat
+32	./IBM16/SURFACE/00042200.dat
+36	./IBM16/SURFACE/00012950.dat
+32	./IBM16/SURFACE/00046600.dat
+32	./IBM16/SURFACE/00040100.dat
+32	./IBM16/SURFACE/00020100.dat
+32	./IBM16/SURFACE/00019350.dat
+32	./IBM16/SURFACE/00035550.dat
+32	./IBM16/SURFACE/00045650.dat
+32	./IBM16/SURFACE/00030600.dat
+36	./IBM16/SURFACE/00011450.dat
+32	./IBM16/SURFACE/00028150.dat
+36	./IBM16/SURFACE/00000950.dat
+32	./IBM16/SURFACE/00025600.dat
+32	./IBM16/SURFACE/00015600.dat
+36	./IBM16/SURFACE/00013050.dat
+32	./IBM16/SURFACE/00023350.dat
+32	./IBM16/SURFACE/00028000.dat
+32	./IBM16/SURFACE/00037150.dat
+32	./IBM16/SURFACE/00038600.dat
+32	./IBM16/SURFACE/00048300.dat
+32	./IBM16/SURFACE/00043600.dat
+36	./IBM16/SURFACE/00005950.dat
+32	./IBM16/SURFACE/00033300.dat
+32	./IBM16/SURFACE/00016950.dat
+36	./IBM16/SURFACE/00010850.dat
+32	./IBM16/SURFACE/00042100.dat
+32	./IBM16/SURFACE/00017250.dat
+36	./IBM16/SURFACE/00013850.dat
+32	./IBM16/SURFACE/00047850.dat
+36	./IBM16/SURFACE/00004600.dat
+36	./IBM16/SURFACE/00013750.dat
+36	./IBM16/SURFACE/00009800.dat
+32	./IBM16/SURFACE/00025500.dat
+32	./IBM16/SURFACE/00017700.dat
+32	./IBM16/SURFACE/00024100.dat
+32	./IBM16/SURFACE/00030150.dat
+36	./IBM16/SURFACE/00002100.dat
+36	./IBM16/SURFACE/00002050.dat
+32	./IBM16/SURFACE/00019550.dat
+32	./IBM16/SURFACE/00034950.dat
+36	./IBM16/SURFACE/00014200.dat
+36	./IBM16/SURFACE/00009050.dat
+32	./IBM16/SURFACE/00026300.dat
+36	./IBM16/SURFACE/00005350.dat
+32	./IBM16/SURFACE/00020550.dat
+32	./IBM16/SURFACE/00020400.dat
+36	./IBM16/SURFACE/00014400.dat
+32	./IBM16/SURFACE/00039350.dat
+32	./IBM16/SURFACE/00033600.dat
+32	./IBM16/SURFACE/00023600.dat
+36	./IBM16/SURFACE/00001450.dat
+32	./IBM16/SURFACE/00023500.dat
+36	./IBM16/SURFACE/00001200.dat
+36	./IBM16/SURFACE/00011050.dat
+36	./IBM16/SURFACE/00013200.dat
+32	./IBM16/SURFACE/00026450.dat
+32	./IBM16/SURFACE/00025450.dat
+32	./IBM16/SURFACE/00016200.dat
+32	./IBM16/SURFACE/00026650.dat
+32	./IBM16/SURFACE/00043550.dat
+32	./IBM16/SURFACE/00034550.dat
+36	./IBM16/SURFACE/00011250.dat
+36	./IBM16/SURFACE/00003400.dat
+36	./IBM16/SURFACE/00014550.dat
+32	./IBM16/SURFACE/00045050.dat
+36	./IBM16/SURFACE/00008700.dat
+32	./IBM16/SURFACE/00046350.dat
+36	./IBM16/SURFACE/00005250.dat
+36	./IBM16/SURFACE/00003650.dat
+32	./IBM16/SURFACE/00038800.dat
+32	./IBM16/SURFACE/00031100.dat
+36	./IBM16/SURFACE/00014600.dat
+36	./IBM16/SURFACE/00002400.dat
+36	./IBM16/SURFACE/00011200.dat
+32	./IBM16/SURFACE/00037250.dat
+36	./IBM16/SURFACE/00008050.dat
+32	./IBM16/SURFACE/00044350.dat
+32	./IBM16/SURFACE/00026150.dat
+32	./IBM16/SURFACE/00033250.dat
+36	./IBM16/SURFACE/00001850.dat
+32	./IBM16/SURFACE/00042950.dat
+32	./IBM16/SURFACE/00028450.dat
+36	./IBM16/SURFACE/00006200.dat
+32	./IBM16/SURFACE/00024800.dat
+32	./IBM16/SURFACE/00029700.dat
+32	./IBM16/SURFACE/00048200.dat
+36	./IBM16/SURFACE/00007900.dat
+32	./IBM16/SURFACE/00041100.dat
+32	./IBM16/SURFACE/00040400.dat
+36	./IBM16/SURFACE/00013950.dat
+32	./IBM16/SURFACE/00042600.dat
+32	./IBM16/SURFACE/00022550.dat
+36	./IBM16/SURFACE/00013900.dat
+32	./IBM16/SURFACE/00040050.dat
+36	./IBM16/SURFACE/00000300.dat
+32	./IBM16/SURFACE/00030950.dat
+32	./IBM16/SURFACE/00013800.dat
+32	./IBM16/SURFACE/00021600.dat
+32	./IBM16/SURFACE/00027900.dat
+36	./IBM16/SURFACE/00008400.dat
+32	./IBM16/SURFACE/00018250.dat
+36	./IBM16/SURFACE/00007650.dat
+32	./IBM16/SURFACE/00044250.dat
+32	./IBM16/SURFACE/00047200.dat
+36	./IBM16/SURFACE/00010100.dat
+36	./IBM16/SURFACE/00010300.dat
+36	./IBM16/SURFACE/00004400.dat
+32	./IBM16/SURFACE/00047600.dat
+32	./IBM16/SURFACE/00040900.dat
+32	./IBM16/SURFACE/00043500.dat
+36	./IBM16/SURFACE/00012900.dat
+32	./IBM16/SURFACE/00046200.dat
+32	./IBM16/SURFACE/00021100.dat
+36	./IBM16/SURFACE/00005800.dat
+32	./IBM16/SURFACE/00045250.dat
+36	./IBM16/SURFACE/00003200.dat
+32	./IBM16/SURFACE/00015450.dat
+32	./IBM16/SURFACE/00047550.dat
+36	./IBM16/SURFACE/00011900.dat
+32	./IBM16/SURFACE/00023750.dat
+36	./IBM16/SURFACE/00002450.dat
+32	./IBM16/SURFACE/00040450.dat
+32	./IBM16/SURFACE/00016150.dat
+32	./IBM16/SURFACE/00034050.dat
+32	./IBM16/SURFACE/00031800.dat
+32	./IBM16/SURFACE/00039600.dat
+32	./IBM16/SURFACE/00023050.dat
+36	./IBM16/SURFACE/00005150.dat
+36	./IBM16/SURFACE/00014950.dat
+36	./IBM16/SURFACE/00005100.dat
+36	./IBM16/SURFACE/00015000.dat
+32	./IBM16/SURFACE/00031900.dat
+32	./IBM16/SURFACE/00019050.dat
+32	./IBM16/SURFACE/00033150.dat
+32	./IBM16/SURFACE/00041350.dat
+36	./IBM16/SURFACE/00003000.dat
+36	./IBM16/SURFACE/00012700.dat
+32	./IBM16/SURFACE/00046100.dat
+32	./IBM16/SURFACE/00032450.dat
+36	./IBM16/SURFACE/00005450.dat
+32	./IBM16/SURFACE/00016700.dat
+32	./IBM16/SURFACE/00044550.dat
+32	./IBM16/SURFACE/00032750.dat
+36	./IBM16/SURFACE/00004800.dat
+32	./IBM16/SURFACE/00024550.dat
+32	./IBM16/SURFACE/00046800.dat
+32	./IBM16/SURFACE/00038900.dat
+32	./IBM16/SURFACE/00023100.dat
+36	./IBM16/SURFACE/00001300.dat
+32	./IBM16/SURFACE/00036150.dat
+36	./IBM16/SURFACE/00008300.dat
+36	./IBM16/SURFACE/00003500.dat
+36	./IBM16/SURFACE/00012550.dat
+36	./IBM16/SURFACE/00008850.dat
+32	./IBM16/SURFACE/00043800.dat
+36	./IBM16/SURFACE/00008500.dat
+32	./IBM16/SURFACE/00038100.dat
+32	./IBM16/SURFACE/00018850.dat
+32	./IBM16/SURFACE/00018450.dat
+32	./IBM16/SURFACE/00027150.dat
+36	./IBM16/SURFACE/00000500.dat
+32	./IBM16/SURFACE/00044450.dat
+32	./IBM16/SURFACE/00022900.dat
+32	./IBM16/SURFACE/00026750.dat
+32	./IBM16/SURFACE/00034450.dat
+32	./IBM16/SURFACE/00036250.dat
+32	./IBM16/SURFACE/00038750.dat
+32	./IBM16/SURFACE/00015650.dat
+32	./IBM16/SURFACE/00044650.dat
+36	./IBM16/SURFACE/00010000.dat
+32	./IBM16/SURFACE/00036550.dat
+36	./IBM16/SURFACE/00006150.dat
+32	./IBM16/SURFACE/00034300.dat
+36	./IBM16/SURFACE/00003550.dat
+36	./IBM16/SURFACE/00007550.dat
+32	./IBM16/SURFACE/00043850.dat
+36	./IBM16/SURFACE/00011500.dat
+36	./IBM16/SURFACE/00012200.dat
+32	./IBM16/SURFACE/00044100.dat
+36	./IBM16/SURFACE/00003900.dat
+32	./IBM16/SURFACE/00033800.dat
+36	./IBM16/SURFACE/00013550.dat
+32	./IBM16/SURFACE/00041250.dat
+32	./IBM16/SURFACE/00047700.dat
+32	./IBM16/SURFACE/00045300.dat
+32	./IBM16/SURFACE/00046850.dat
+36	./IBM16/SURFACE/00012400.dat
+32	./IBM16/SURFACE/00032050.dat
+32	./IBM16/SURFACE/00031500.dat
+32	./IBM16/SURFACE/00027500.dat
+32	./IBM16/SURFACE/00037500.dat
+36	./IBM16/SURFACE/00012850.dat
+36	./IBM16/SURFACE/00010600.dat
+32	./IBM16/SURFACE/00018200.dat
+36	./IBM16/SURFACE/00013250.dat
+32	./IBM16/SURFACE/00034900.dat
+32	./IBM16/SURFACE/00041450.dat
+32	./IBM16/SURFACE/00017200.dat
+36	./IBM16/SURFACE/00008200.dat
+36	./IBM16/SURFACE/00014350.dat
+32	./IBM16/SURFACE/00022150.dat
+32	./IBM16/SURFACE/00042800.dat
+32	./IBM16/SURFACE/00042750.dat
+32	./IBM16/SURFACE/00048450.dat
+32	./IBM16/SURFACE/00030250.dat
+36	./IBM16/SURFACE/00001950.dat
+36	./IBM16/SURFACE/00004850.dat
+32	./IBM16/SURFACE/00025300.dat
+32	./IBM16/SURFACE/00044400.dat
+36	./IBM16/SURFACE/00001400.dat
+32	./IBM16/SURFACE/00028400.dat
+32	./IBM16/SURFACE/00045700.dat
+36	./IBM16/SURFACE/00000800.dat
+36	./IBM16/SURFACE/00003800.dat
+32	./IBM16/SURFACE/00021150.dat
+32	./IBM16/SURFACE/00029600.dat
+32	./IBM16/SURFACE/00016000.dat
+32	./IBM16/SURFACE/00030700.dat
+32	./IBM16/SURFACE/00047250.dat
+32588	./IBM16/SURFACE
+4	./IBM16/prof_step
+4	./IBM16/Beforemaking
+4	./IBM16/MID/TIME.MID
+8	./IBM16/MID
+du: cannot access `./IBM16/PRIO_GENERATE_GRID/Makefile': Permission denied
+du: cannot access `./IBM16/PRIO_GENERATE_GRID/genegrid': Permission denied
+du: cannot access `./IBM16/PRIO_GENERATE_GRID/GENEGRID.F90': Permission denied
+4	./IBM16/PRIO_GENERATE_GRID
+150903384	./IBM16
+du: cannot read directory `./st208': Permission denied
+4	./st208
+du: cannot access `./st124_c/FDM_026_PD_SPE.o': Permission denied
+du: cannot access `./st124_c/FDM_043_VOF.F90': Permission denied
+du: cannot access `./st124_c/Makefile_copper': Permission denied
+du: cannot access `./st124_c/FDM_123_WALLMODEL_POWERLAW.o': Permission denied
+du: cannot access `./st124_c/FDM_023_SMOOTHING.F90': Permission denied
+du: cannot access `./st124_c/SHOWGEO': Permission denied
+du: cannot access `./st124_c/FDM_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./st124_c/libtecio.a': Permission denied
+du: cannot access `./st124_c/FDM_027_RK.F90': Permission denied
+du: cannot access `./st124_c/FDM_302_WAVYVOR_DECOMPOSITION.F90': Permission denied
+du: cannot access `./st124_c/FDM_033_IBM_INTFORCING.F90': Permission denied
+du: cannot access `./st124_c/FDM_010_INIT_PARALLEL.o': Permission denied
+du: cannot access `./st124_c/GEOMETRY': Permission denied
+du: cannot access `./st124_c/FDM_110_RNG.o': Permission denied
+du: cannot access `./st124_c/FDM_025_PD.F90': Permission denied
+du: cannot access `./st124_c/FDM_070_PARALLEL.F90': Permission denied
+du: cannot access `./st124_c/FDM_121_WALLMODEL_KANG.F90': Permission denied
+du: cannot access `./st124_c/DATA': Permission denied
+du: cannot access `./st124_c/FDM_304_ASSIMILATION_WAVY.o': Permission denied
+du: cannot access `./st124_c/FDM_032_IBM_EXTFORCING.o': Permission denied
+du: cannot access `./st124_c/FDM_111_GERMANO.F90': Permission denied
+du: cannot access `./st124_c/FDM_023_SMOOTHING.o': Permission denied
+du: cannot access `./st124_c/FDM_122_WALLMODEL_ROMAN.F90': Permission denied
+du: cannot access `./st124_c/POST_BASIC': Permission denied
+du: cannot access `./st124_c/FDM_304_ASSIMILATION_WAVY.F90': Permission denied
+du: cannot access `./st124_c/FDM_000_MAIN.F90': Permission denied
+du: cannot access `./st124_c/FDM_032_IBM_EXTFORCING.F90': Permission denied
+du: cannot access `./st124_c/FDM_042_LS.F90': Permission denied
+du: cannot access `./st124_c/INCLUDE_FFT.FI': Permission denied
+du: cannot access `./st124_c/FDM_123_WALLMODEL_POWERLAW.F90': Permission denied
+du: cannot access `./st124_c/FDM_030_IBM.o': Permission denied
+du: cannot access `./st124_c/FDM_044_PRESCRIBEWAVE.F90': Permission denied
+du: cannot access `./st124_c/FDM_080_FFT.F90': Permission denied
+du: cannot access `./st124_c/submit_p': Permission denied
+du: cannot access `./st124_c/FDM_020_PRESOLVE.o': Permission denied
+du: cannot access `./st124_c/FDM_091_SEDIMENT.F90': Permission denied
+du: cannot access `./st124_c/FDM_300_ASSIMILATION.o': Permission denied
+du: cannot access `./st124_c/FDM_060_STATS_TS.o': Permission denied
+du: cannot access `./st124_c/aegean_stream.sh': Permission denied
+du: cannot access `./st124_c/INCLUDE_LES.FI': Permission denied
+du: cannot access `./st124_c/INCLUDE_IO.FI': Permission denied
+du: cannot access `./st124_c/Makefile': Permission denied
+du: cannot access `./st124_c/DYE.IN': Permission denied
+du: cannot access `./st124_c/INCLUDE_WAVEGENERATOR.FI': Permission denied
+du: cannot access `./st124_c/FDM_303_MEANFLUC_DECOMPOSITION.F90': Permission denied
+du: cannot access `./st124_c/FDM_070_PARALLEL.o': Permission denied
+du: cannot access `./st124_c/FDM_305_ASSIMILATION_VORT.o': Permission denied
+du: cannot access `./st124_c/submit_data': Permission denied
+du: cannot access `./st124_c/FDM_301_ASSIMILATION_GEOMETRY.F90': Permission denied
+du: cannot access `./st124_c/WAVE': Permission denied
+du: cannot access `./st124_c/INCLUDE_PARALLEL.FI': Permission denied
+du: cannot access `./st124_c/FDM_033_IBM_INTFORCING.o': Permission denied
+du: cannot access `./st124_c/FDM_030_IBM.F90': Permission denied
+du: cannot access `./st124_c/STATS': Permission denied
+du: cannot access `./st124_c/FDM_306_ASSIMILATION_TOTAL.o': Permission denied
+du: cannot access `./st124_c/FDM_027_RK.o': Permission denied
+du: cannot access `./st124_c/FDM_020_PRESOLVE.F90': Permission denied
+du: cannot access `./st124_c/FDM_021_RHS.o': Permission denied
+du: cannot access `./st124_c/submit': Permission denied
+du: cannot access `./st124_c/FDM_111_GERMANO.o': Permission denied
+du: cannot access `./st124_c/FDM_999_FINALIZE.o': Permission denied
+du: cannot access `./st124_c/FDM_090_DYE.o': Permission denied
+du: cannot access `./st124_c/resga': Permission denied
+du: cannot access `./st124_c/FDM_051_IO.F90': Permission denied
+du: cannot access `./st124_c/FDM_061_STATS_TA.F90': Permission denied
+du: cannot access `./st124_c/aga.sh': Permission denied
+du: cannot access `./st124_c/FDM_022_WG.F90': Permission denied
+du: cannot access `./st124_c/FDM_050_OUTPUT.o': Permission denied
+du: cannot access `./st124_c/TAGS': Permission denied
+du: cannot access `./st124_c/POST': Permission denied
+du: cannot access `./st124_c/INCLUDE_ASSIMILATION.FI': Permission denied
+du: cannot access `./st124_c/FDM_121_WALLMODEL_KANG.o': Permission denied
+du: cannot access `./st124_c/PARAM.IN': Permission denied
+du: cannot access `./st124_c/FDM_043_VOF.o': Permission denied
+du: cannot access `./st124_c/FDM_090_DYE.F90': Permission denied
+du: cannot access `./st124_c/INCLUDE_IBM.FI': Permission denied
+du: cannot access `./st124_c/FDM_120_WALLMODEL_TBL.o': Permission denied
+du: cannot access `./st124_c/INCLUDE_SINKPARAM.FI': Permission denied
+du: cannot access `./st124_c/INCLUDE_PARAMETER.FI': Permission denied
+du: cannot access `./st124_c/FDM_021_RHS.F90': Permission denied
+du: cannot access `./st124_c/FDM_303_MEANFLUC_DECOMPOSITION.o': Permission denied
+du: cannot access `./st124_c/FDM_306_ASSIMILATION_TOTAL.F90': Permission denied
+du: cannot access `./st124_c/FDM_100_LES.F90': Permission denied
+du: cannot access `./st124_c/FDM_031_IBM_INIT.F90': Permission denied
+du: cannot access `./st124_c/FDM_061_STATS_TA.o': Permission denied
+du: cannot access `./st124_c/FDM_301_ASSIMILATION_GEOMETRY.o': Permission denied
+du: cannot access `./st124_c/TIME_SERIES': Permission denied
+du: cannot access `./st124_c/FDM_300_ASSIMILATION.F90': Permission denied
+du: cannot access `./st124_c/FDM_010_INIT_PARALLEL.F90': Permission denied
+du: cannot access `./st124_c/FDM_050_OUTPUT.F90': Permission denied
+du: cannot access `./st124_c/GATHERDATA': Permission denied
+du: cannot access `./st124_c/FDM_044_PRESCRIBEWAVE.o': Permission denied
+du: cannot access `./st124_c/INCLUDE_SCALAR.FI': Permission denied
+du: cannot access `./st124_c/README.md': Permission denied
+du: cannot access `./st124_c/tags': Permission denied
+du: cannot access `./st124_c/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./st124_c/wave': Permission denied
+du: cannot access `./st124_c/POST_WAVY_WALL': Permission denied
+du: cannot access `./st124_c/TRACER': Permission denied
+du: cannot access `./st124_c/FDM_051_IO.o': Permission denied
+du: cannot access `./st124_c/FDM_110_RNG.F90': Permission denied
+du: cannot access `./st124_c/FDM_022_WG.o': Permission denied
+du: cannot access `./st124_c/GRID.IN': Permission denied
+du: cannot access `./st124_c/FDM_999_FINALIZE.F90': Permission denied
+du: cannot access `./st124_c/FDM_025_PD.o': Permission denied
+du: cannot access `./st124_c/FDM_122_WALLMODEL_ROMAN.o': Permission denied
+du: cannot access `./st124_c/FDM_012_INIT_FIELD.F90': Permission denied
+du: cannot access `./st124_c/FDM_200_PETSC_SOLVER.F90': Permission denied
+du: cannot access `./st124_c/results_aegean': Permission denied
+du: cannot access `./st124_c/FDM_307_TRACER.F90': Permission denied
+du: cannot access `./st124_c/FDM_305_ASSIMILATION_VORT.F90': Permission denied
+du: cannot access `./st124_c/SURFACE': Permission denied
+du: cannot access `./st124_c/INCLUDE_STATS.FI': Permission denied
+du: cannot access `./st124_c/FDM_100_LES.o': Permission denied
+du: cannot access `./st124_c/FDM_060_STATS_TS.F90': Permission denied
+du: cannot access `./st124_c/FDM_091_SEDIMENT.o': Permission denied
+du: cannot access `./st124_c/FDM_307_TRACER.o': Permission denied
+du: cannot access `./st124_c/FDM_031_IBM_INIT.o': Permission denied
+du: cannot access `./st124_c/FDM_302_WAVYVOR_DECOMPOSITION.o': Permission denied
+du: cannot access `./st124_c/FDM_080_FFT.o': Permission denied
+du: cannot access `./st124_c/FDM_120_WALLMODEL_TBL.F90': Permission denied
+du: cannot access `./st124_c/FDM_026_PD_SPE.F90': Permission denied
+du: cannot access `./st124_c/FDM_012_INIT_FIELD.o': Permission denied
+du: cannot access `./st124_c/prof_step': Permission denied
+du: cannot access `./st124_c/post_skewness': Permission denied
+du: cannot access `./st124_c/FDM_000_MAIN.o': Permission denied
+du: cannot access `./st124_c/FDM_042_LS.o': Permission denied
+du: cannot access `./st124_c/FDM_011_INIT_CONSTANTS.o': Permission denied
+du: cannot access `./st124_c/FDM_200_PETSC_SOLVER.o': Permission denied
+du: cannot access `./st124_c/MID': Permission denied
+du: cannot access `./st124_c/INCLUDE_POISSON.FI': Permission denied
+du: cannot access `./st124_c/PRIO_GENERATE_GRID': Permission denied
+12	./st124_c
+du: cannot access `./IBM9/libtecio.a': Permission denied
+du: cannot access `./IBM9/INCLUDE': Permission denied
+du: cannot access `./IBM9/tp1WnHZ4f': Permission denied
+du: cannot access `./IBM9/GEOMETRY': Permission denied
+du: cannot access `./IBM9/CALCULATE': Permission denied
+du: cannot access `./IBM9/volume.dat': Permission denied
+du: cannot access `./IBM9/DATA': Permission denied
+du: cannot access `./IBM9/LIB': Permission denied
+du: cannot access `./IBM9/POST_BASIC': Permission denied
+du: cannot access `./IBM9/gatherdata': Permission denied
+du: cannot access `./IBM9/submit_p': Permission denied
+du: cannot access `./IBM9/aegean_stream.sh': Permission denied
+du: cannot access `./IBM9/screen': Permission denied
+du: cannot access `./IBM9/Makefile': Permission denied
+du: cannot access `./IBM9/submit_data': Permission denied
+du: cannot access `./IBM9/WAVE': Permission denied
+du: cannot access `./IBM9/RESTART_SOLID': Permission denied
+du: cannot access `./IBM9/tp15v3tMD': Permission denied
+du: cannot access `./IBM9/STATS': Permission denied
+du: cannot access `./IBM9/submit': Permission denied
+du: cannot access `./IBM9/batchrun': Permission denied
+du: cannot access `./IBM9/resga': Permission denied
+du: cannot access `./IBM9/sour.dat': Permission denied
+du: cannot access `./IBM9/aga.sh': Permission denied
+du: cannot access `./IBM9/PARAM.IN': Permission denied
+du: cannot access `./IBM9/CIRC_VELO': Permission denied
+du: cannot access `./IBM9/TIME_SERIES': Permission denied
+du: cannot access `./IBM9/screenga': Permission denied
+du: cannot access `./IBM9/tp1BDe3Lo': Permission denied
+du: cannot access `./IBM9/GATHERDATA': Permission denied
+du: cannot access `./IBM9/wave': Permission denied
+du: cannot access `./IBM9/POST_WAVY_WALL': Permission denied
+du: cannot access `./IBM9/TRACER': Permission denied
+du: cannot access `./IBM9/GRID.IN': Permission denied
+du: cannot access `./IBM9/INSTANTANEOUS': Permission denied
+du: cannot access `./IBM9/results_aegean': Permission denied
+du: cannot access `./IBM9/SURFACE': Permission denied
+du: cannot access `./IBM9/phi-f.mcr': Permission denied
+du: cannot access `./IBM9/vortex.mcr': Permission denied
+du: cannot access `./IBM9/prof_step': Permission denied
+du: cannot access `./IBM9/Beforemaking': Permission denied
+du: cannot access `./IBM9/MID': Permission denied
+du: cannot access `./IBM9/PRIO_GENERATE_GRID': Permission denied
+4	./IBM9
+du: cannot access `./IBMsinkhole/FDM_043_VOF.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_023_SMOOTHING.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./IBMsinkhole/libtecio.a': Permission denied
+du: cannot access `./IBMsinkhole/FDM_027_RK.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_302_WAVYVOR_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_033_IBM_INTFORCING.F90': Permission denied
+du: cannot access `./IBMsinkhole/GEOMETRY': Permission denied
+du: cannot access `./IBMsinkhole/FDM_025_PD.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_070_PARALLEL.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_121_WALLMODEL_KANG.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_111_GERMANO.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_122_WALLMODEL_ROMAN.F90': Permission denied
+du: cannot access `./IBMsinkhole/POST_BASIC': Permission denied
+du: cannot access `./IBMsinkhole/FDM_304_ASSIMILATION_WAVY.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_000_MAIN.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_032_IBM_EXTFORCING.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_042_LS.F90': Permission denied
+du: cannot access `./IBMsinkhole/INCLUDE_FFT.FI': Permission denied
+du: cannot access `./IBMsinkhole/FDM_123_WALLMODEL_POWERLAW.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_044_PRESCRIBEWAVE.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_080_FFT.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_091_SEDIMENT.F90': Permission denied
+du: cannot access `./IBMsinkhole/aegean_stream.sh': Permission denied
+du: cannot access `./IBMsinkhole/INCLUDE_LES.FI': Permission denied
+du: cannot access `./IBMsinkhole/screen': Permission denied
+du: cannot access `./IBMsinkhole/INCLUDE_IO.FI': Permission denied
+du: cannot access `./IBMsinkhole/FDM_031_IBM_INIT_M.F90': Permission denied
+du: cannot access `./IBMsinkhole/Makefile': Permission denied
+du: cannot access `./IBMsinkhole/DYE.IN': Permission denied
+du: cannot access `./IBMsinkhole/INCLUDE_WAVEGENERATOR.FI': Permission denied
+du: cannot access `./IBMsinkhole/FDM_303_MEANFLUC_DECOMPOSITION.F90': Permission denied
+du: cannot access `./IBMsinkhole/submit_data': Permission denied
+du: cannot access `./IBMsinkhole/FDM_301_ASSIMILATION_GEOMETRY.F90': Permission denied
+du: cannot access `./IBMsinkhole/WAVE': Permission denied
+du: cannot access `./IBMsinkhole/INCLUDE_PARALLEL.FI': Permission denied
+du: cannot access `./IBMsinkhole/FDM_030_IBM.F90': Permission denied
+du: cannot access `./IBMsinkhole/STATS': Permission denied
+du: cannot access `./IBMsinkhole/FDM_020_PRESOLVE.F90': Permission denied
+du: cannot access `./IBMsinkhole/GRID.dat': Permission denied
+du: cannot access `./IBMsinkhole/submit': Permission denied
+du: cannot access `./IBMsinkhole/resga': Permission denied
+du: cannot access `./IBMsinkhole/FDM_051_IO.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_061_STATS_TA.F90': Permission denied
+du: cannot access `./IBMsinkhole/aga.sh': Permission denied
+du: cannot access `./IBMsinkhole/FDM_022_WG.F90': Permission denied
+du: cannot access `./IBMsinkhole/TAGS': Permission denied
+du: cannot access `./IBMsinkhole/core': Permission denied
+du: cannot access `./IBMsinkhole/INCLUDE_ASSIMILATION.FI': Permission denied
+du: cannot access `./IBMsinkhole/PARAM.IN': Permission denied
+du: cannot access `./IBMsinkhole/FDM_090_DYE.F90': Permission denied
+du: cannot access `./IBMsinkhole/INCLUDE_IBM.FI': Permission denied
+du: cannot access `./IBMsinkhole/INCLUDE_SINKPARAM.FI': Permission denied
+du: cannot access `./IBMsinkhole/INCLUDE_PARAMETER.FI': Permission denied
+du: cannot access `./IBMsinkhole/PARAM_Liu.IN': Permission denied
+du: cannot access `./IBMsinkhole/FDM_021_RHS.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_306_ASSIMILATION_TOTAL.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_100_LES.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_031_IBM_INIT.F90': Permission denied
+du: cannot access `./IBMsinkhole/TIME_SERIES': Permission denied
+du: cannot access `./IBMsinkhole/screenga': Permission denied
+du: cannot access `./IBMsinkhole/FDM_300_ASSIMILATION.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_010_INIT_PARALLEL.F90': Permission denied
+du: cannot access `./IBMsinkhole/IBM': Permission denied
+du: cannot access `./IBMsinkhole/FDM_050_OUTPUT.F90': Permission denied
+du: cannot access `./IBMsinkhole/GATHERDATA': Permission denied
+du: cannot access `./IBMsinkhole/INCLUDE_SCALAR.FI': Permission denied
+du: cannot access `./IBMsinkhole/README.md': Permission denied
+du: cannot access `./IBMsinkhole/FDM_025_PD_Liu.F90': Permission denied
+du: cannot access `./IBMsinkhole/tags': Permission denied
+du: cannot access `./IBMsinkhole/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./IBMsinkhole/POST_WAVY_WALL': Permission denied
+du: cannot access `./IBMsinkhole/TRACER': Permission denied
+du: cannot access `./IBMsinkhole/FDM_110_RNG.F90': Permission denied
+du: cannot access `./IBMsinkhole/GRID.IN': Permission denied
+du: cannot access `./IBMsinkhole/FDM_999_FINALIZE.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_012_INIT_FIELD.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_200_PETSC_SOLVER.F90': Permission denied
+du: cannot access `./IBMsinkhole/results_aegean': Permission denied
+du: cannot access `./IBMsinkhole/FDM_307_TRACER.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_305_ASSIMILATION_VORT.F90': Permission denied
+du: cannot access `./IBMsinkhole/INCLUDE_STATS.FI': Permission denied
+du: cannot access `./IBMsinkhole/FDM_060_STATS_TS.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_120_WALLMODEL_TBL.F90': Permission denied
+du: cannot access `./IBMsinkhole/FDM_026_PD_SPE.F90': Permission denied
+du: cannot access `./IBMsinkhole/prof_step': Permission denied
+du: cannot access `./IBMsinkhole/post_skewness': Permission denied
+du: cannot access `./IBMsinkhole/MID': Permission denied
+du: cannot access `./IBMsinkhole/INCLUDE_POISSON.FI': Permission denied
+du: cannot access `./IBMsinkhole/PRIO_GENERATE_GRID': Permission denied
+12	./IBMsinkhole
+du: cannot access `./IBM18/libtecio.a': Permission denied
+du: cannot access `./IBM18/INCLUDE': Permission denied
+du: cannot access `./IBM18/GEOMETRY': Permission denied
+du: cannot access `./IBM18/CALCULATE': Permission denied
+du: cannot access `./IBM18/volume.dat': Permission denied
+du: cannot access `./IBM18/DATA': Permission denied
+du: cannot access `./IBM18/POST_BASIC': Permission denied
+du: cannot access `./IBM18/gatherdata': Permission denied
+du: cannot access `./IBM18/submit_p': Permission denied
+du: cannot access `./IBM18/aegean_stream.sh': Permission denied
+du: cannot access `./IBM18/screen': Permission denied
+du: cannot access `./IBM18/sink.dat': Permission denied
+du: cannot access `./IBM18/Makefile': Permission denied
+du: cannot access `./IBM18/submit_data': Permission denied
+du: cannot access `./IBM18/WAVE': Permission denied
+du: cannot access `./IBM18/RESTART_SOLID': Permission denied
+du: cannot access `./IBM18/STATS': Permission denied
+du: cannot access `./IBM18/submit': Permission denied
+du: cannot access `./IBM18/batchrun': Permission denied
+du: cannot access `./IBM18/resga': Permission denied
+du: cannot access `./IBM18/sour.dat': Permission denied
+du: cannot access `./IBM18/aga.sh': Permission denied
+du: cannot access `./IBM18/PARAM.IN': Permission denied
+du: cannot access `./IBM18/CIRC_VELO': Permission denied
+du: cannot access `./IBM18/TIME_SERIES': Permission denied
+du: cannot access `./IBM18/screenga': Permission denied
+du: cannot access `./IBM18/GATHERDATA': Permission denied
+du: cannot access `./IBM18/wave': Permission denied
+du: cannot access `./IBM18/POST_WAVY_WALL': Permission denied
+du: cannot access `./IBM18/TRACER': Permission denied
+du: cannot access `./IBM18/GRID.IN': Permission denied
+du: cannot access `./IBM18/INSTANTANEOUS': Permission denied
+du: cannot access `./IBM18/results_aegean': Permission denied
+du: cannot access `./IBM18/SURFACE': Permission denied
+du: cannot access `./IBM18/prof_step': Permission denied
+du: cannot access `./IBM18/Beforemaking': Permission denied
+du: cannot access `./IBM18/MID': Permission denied
+du: cannot access `./IBM18/PRIO_GENERATE_GRID': Permission denied
+4	./IBM18
+du: cannot access `./IBM11/libtecio.a': Permission denied
+du: cannot access `./IBM11/INCLUDE': Permission denied
+du: cannot access `./IBM11/GEOMETRY': Permission denied
+du: cannot access `./IBM11/CALCULATE': Permission denied
+du: cannot access `./IBM11/LIB': Permission denied
+du: cannot access `./IBM11/POST_BASIC': Permission denied
+du: cannot access `./IBM11/gatherdata': Permission denied
+du: cannot access `./IBM11/submit_p': Permission denied
+du: cannot access `./IBM11/aegean_stream.sh': Permission denied
+du: cannot access `./IBM11/screen': Permission denied
+du: cannot access `./IBM11/Makefile': Permission denied
+du: cannot access `./IBM11/submit_data': Permission denied
+du: cannot access `./IBM11/WAVE': Permission denied
+du: cannot access `./IBM11/RESTART_SOLID': Permission denied
+du: cannot access `./IBM11/STATS': Permission denied
+du: cannot access `./IBM11/submit': Permission denied
+du: cannot access `./IBM11/batchrun': Permission denied
+du: cannot access `./IBM11/resga': Permission denied
+du: cannot access `./IBM11/phi-v.mcr': Permission denied
+du: cannot access `./IBM11/sour.dat': Permission denied
+du: cannot access `./IBM11/aga.sh': Permission denied
+du: cannot access `./IBM11/PARAM.IN': Permission denied
+du: cannot access `./IBM11/CIRC_VELO': Permission denied
+du: cannot access `./IBM11/TIME_SERIES': Permission denied
+du: cannot access `./IBM11/screenga': Permission denied
+du: cannot access `./IBM11/GATHERDATA': Permission denied
+du: cannot access `./IBM11/wave': Permission denied
+du: cannot access `./IBM11/POST_WAVY_WALL': Permission denied
+du: cannot access `./IBM11/TRACER': Permission denied
+du: cannot access `./IBM11/GRID.IN': Permission denied
+du: cannot access `./IBM11/FLUX': Permission denied
+du: cannot access `./IBM11/results_aegean': Permission denied
+du: cannot access `./IBM11/SURFACE': Permission denied
+du: cannot access `./IBM11/phi-f.mcr': Permission denied
+du: cannot access `./IBM11/prof_step': Permission denied
+du: cannot access `./IBM11/Beforemaking': Permission denied
+du: cannot access `./IBM11/MID': Permission denied
+du: cannot access `./IBM11/PRIO_GENERATE_GRID': Permission denied
+4	./IBM11
+882156	./:.
+4	./GATHERDATA/INCLUDE_IO.FI
+12	./GATHERDATA/GATHER_IO.o
+12	./GATHERDATA/tecio.f90
+4	./GATHERDATA/GATHER_IO.F90
+152	./GATHERDATA/GATHERDATA.o
+16	./GATHERDATA/GATHERDATA.F90
+204	./GATHERDATA
+8	./tmp.f90
+du: cannot access `./st171/FDM_043_VOF.F90': Permission denied
+du: cannot access `./st171/FDM_023_SMOOTHING.F90': Permission denied
+du: cannot access `./st171/SHOWGEO': Permission denied
+du: cannot access `./st171/FDM_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./st171/libtecio.a': Permission denied
+du: cannot access `./st171/FDM_027_RK.F90': Permission denied
+du: cannot access `./st171/FDM_064_VORENSTROPHY.F90': Permission denied
+du: cannot access `./st171/FDM_302_WAVYVOR_DECOMPOSITION.F90': Permission denied
+du: cannot access `./st171/msi': Permission denied
+du: cannot access `./st171/FDM_033_IBM_INTFORCING.F90': Permission denied
+du: cannot access `./st171/GEOMETRY': Permission denied
+du: cannot access `./st171/FDM_025_PD.F90': Permission denied
+du: cannot access `./st171/FDM_070_PARALLEL.F90': Permission denied
+du: cannot access `./st171/FDM_121_WALLMODEL_KANG.F90': Permission denied
+du: cannot access `./st171/FDM_111_GERMANO.F90': Permission denied
+du: cannot access `./st171/FDM_122_WALLMODEL_ROMAN.F90': Permission denied
+du: cannot access `./st171/POST_BASIC': Permission denied
+du: cannot access `./st171/FDM_304_ASSIMILATION_WAVY.F90': Permission denied
+du: cannot access `./st171/FDM_000_MAIN.F90': Permission denied
+du: cannot access `./st171/FDM_032_IBM_EXTFORCING.F90': Permission denied
+du: cannot access `./st171/FDM_042_LS.F90': Permission denied
+du: cannot access `./st171/INCLUDE_FFT.FI': Permission denied
+du: cannot access `./st171/FDM_123_WALLMODEL_POWERLAW.F90': Permission denied
+du: cannot access `./st171/FDM_044_PRESCRIBEWAVE.F90': Permission denied
+du: cannot access `./st171/FDM_080_FFT.F90': Permission denied
+du: cannot access `./st171/submit_p': Permission denied
+du: cannot access `./st171/FDM_091_SEDIMENT.F90': Permission denied
+du: cannot access `./st171/aegean_stream.sh': Permission denied
+du: cannot access `./st171/INCLUDE_LES.FI': Permission denied
+du: cannot access `./st171/INCLUDE_IO.FI': Permission denied
+du: cannot access `./st171/msi.o3404320': Permission denied
+du: cannot access `./st171/sink.dat': Permission denied
+du: cannot access `./st171/Makefile': Permission denied
+du: cannot access `./st171/DYE.IN': Permission denied
+du: cannot access `./st171/INCLUDE_WAVEGENERATOR.FI': Permission denied
+du: cannot access `./st171/FDM_303_MEANFLUC_DECOMPOSITION.F90': Permission denied
+du: cannot access `./st171/screenp': Permission denied
+du: cannot access `./st171/submit_data': Permission denied
+du: cannot access `./st171/FDM_301_ASSIMILATION_GEOMETRY.F90': Permission denied
+du: cannot access `./st171/WAVE': Permission denied
+du: cannot access `./st171/INCLUDE_PARALLEL.FI': Permission denied
+du: cannot access `./st171/FDM_030_IBM.F90': Permission denied
+du: cannot access `./st171/STATS': Permission denied
+du: cannot access `./st171/FDM_020_PRESOLVE.F90': Permission denied
+du: cannot access `./st171/submit': Permission denied
+du: cannot access `./st171/test3vof.dat': Permission denied
+du: cannot access `./st171/FDM_062_STRAINRATE.F90': Permission denied
+du: cannot access `./st171/resga': Permission denied
+du: cannot access `./st171/FDM_051_IO.F90': Permission denied
+du: cannot access `./st171/FDM_063_CIRCVELO.F90': Permission denied
+du: cannot access `./st171/FDM_061_STATS_TA.F90': Permission denied
+du: cannot access `./st171/aga.sh': Permission denied
+du: cannot access `./st171/FDM_022_WG.F90': Permission denied
+du: cannot access `./st171/TAGS': Permission denied
+du: cannot access `./st171/fort.101': Permission denied
+du: cannot access `./st171/POST': Permission denied
+du: cannot access `./st171/INCLUDE_ASSIMILATION.FI': Permission denied
+du: cannot access `./st171/PARAM.IN': Permission denied
+du: cannot access `./st171/FDM_090_DYE.F90': Permission denied
+du: cannot access `./st171/INCLUDE_IBM.FI': Permission denied
+du: cannot access `./st171/FDM_130_INT.F90': Permission denied
+du: cannot access `./st171/INCLUDE_SINKPARAM.FI': Permission denied
+du: cannot access `./st171/INCLUDE_PARAMETER.FI': Permission denied
+du: cannot access `./st171/FDM_021_RHS.F90': Permission denied
+du: cannot access `./st171/FDM_306_ASSIMILATION_TOTAL.F90': Permission denied
+du: cannot access `./st171/FDM_100_LES.F90': Permission denied
+du: cannot access `./st171/FDM_031_IBM_INIT.F90': Permission denied
+du: cannot access `./st171/error': Permission denied
+du: cannot access `./st171/TIME_SERIES': Permission denied
+du: cannot access `./st171/screenga': Permission denied
+du: cannot access `./st171/FDM_300_ASSIMILATION.F90': Permission denied
+du: cannot access `./st171/FDM_010_INIT_PARALLEL.F90': Permission denied
+du: cannot access `./st171/FDM_050_OUTPUT.F90': Permission denied
+du: cannot access `./st171/GATHERDATA': Permission denied
+du: cannot access `./st171/msi.o3404175': Permission denied
+du: cannot access `./st171/INCLUDE_SCALAR.FI': Permission denied
+du: cannot access `./st171/README.md': Permission denied
+du: cannot access `./st171/POST_VORTEX': Permission denied
+du: cannot access `./st171/tags': Permission denied
+du: cannot access `./st171/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./st171/POST_WAVY_WALL': Permission denied
+du: cannot access `./st171/TRACER': Permission denied
+du: cannot access `./st171/POST_SURFACE': Permission denied
+du: cannot access `./st171/FDM_110_RNG.F90': Permission denied
+du: cannot access `./st171/GRID.IN': Permission denied
+du: cannot access `./st171/FDM_999_FINALIZE.F90': Permission denied
+du: cannot access `./st171/FDM_012_INIT_FIELD.F90': Permission denied
+du: cannot access `./st171/FDM_200_PETSC_SOLVER.F90': Permission denied
+du: cannot access `./st171/results_aegean': Permission denied
+du: cannot access `./st171/FDM_307_TRACER.F90': Permission denied
+du: cannot access `./st171/FDM_305_ASSIMILATION_VORT.F90': Permission denied
+du: cannot access `./st171/SURFACE': Permission denied
+du: cannot access `./st171/INCLUDE_STATS.FI': Permission denied
+du: cannot access `./st171/VORTEX': Permission denied
+du: cannot access `./st171/FDM_060_STATS_TS.F90': Permission denied
+du: cannot access `./st171/results': Permission denied
+du: cannot access `./st171/FDM_120_WALLMODEL_TBL.F90': Permission denied
+du: cannot access `./st171/FDM_026_PD_SPE.F90': Permission denied
+du: cannot access `./st171/prof_step': Permission denied
+du: cannot access `./st171/post_skewness': Permission denied
+du: cannot access `./st171/MID': Permission denied
+du: cannot access `./st171/INCLUDE_POISSON.FI': Permission denied
+du: cannot access `./st171/PRIO_GENERATE_GRID': Permission denied
+12	./st171
+4	./st138/GEOMETRY
+310272	./st138/DATA/V00001800.H5
+310272	./st138/DATA/V00003800.H5
+310272	./st138/DATA/V00000200.H5
+310272	./st138/DATA/V00001000.H5
+310272	./st138/DATA/V00000800.H5
+310272	./st138/DATA/V00002600.H5
+310272	./st138/DATA/V00002000.H5
+310272	./st138/DATA/V00004000.H5
+310272	./st138/DATA/V00001200.H5
+310272	./st138/DATA/V00001400.H5
+310272	./st138/DATA/V00000400.H5
+310272	./st138/DATA/V00003400.H5
+310272	./st138/DATA/V00004200.H5
+310272	./st138/DATA/V00003200.H5
+310272	./st138/DATA/V00002400.H5
+310272	./st138/DATA/V00004400.H5
+310272	./st138/DATA/V00000000.H5
+310272	./st138/DATA/V00000600.H5
+310272	./st138/DATA/V00003600.H5
+310272	./st138/DATA/V00001600.H5
+310272	./st138/DATA/V00002800.H5
+310272	./st138/DATA/V00003000.H5
+310272	./st138/DATA/V00002200.H5
+7136260	./st138/DATA
+4	./st138/aegean_stream.sh
+460	./st138/sink.dat
+4	./st138/WAVE
+356440	./st138/STATS/BASIC.H5
+4	./st138/STATS/STAT_STEP
+356448	./st138/STATS
+232	./st138/test3vof.dat
+4	./st138/aga.sh
+4	./st138/PARAM.IN
+844	./st138/TIME_SERIES/MAXUVW.DAT
+476	./st138/TIME_SERIES/CDCF.DAT
+1324	./st138/TIME_SERIES
+16724	./st138/wave
+4	./st138/TRACER
+8	./st138/GRID.IN
+1216	./st138/results_aegean
+8	./st138/SURFACE/00002850.dat
+8	./st138/SURFACE/00003250.dat
+8	./st138/SURFACE/00002950.dat
+8	./st138/SURFACE/00001650.dat
+8	./st138/SURFACE/00004300.dat
+8	./st138/SURFACE/00001500.dat
+8	./st138/SURFACE/00003300.dat
+8	./st138/SURFACE/00003100.dat
+8	./st138/SURFACE/00004150.dat
+8	./st138/SURFACE/00000750.dat
+8	./st138/SURFACE/00000100.dat
+8	./st138/SURFACE/00002700.dat
+8	./st138/SURFACE/00003450.dat
+8	./st138/SURFACE/00000200.dat
+8	./st138/SURFACE/00000900.dat
+8	./st138/SURFACE/00001900.dat
+8	./st138/SURFACE/00004000.dat
+8	./st138/SURFACE/00002900.dat
+8	./st138/SURFACE/00002800.dat
+8	./st138/SURFACE/00001700.dat
+8	./st138/SURFACE/00003950.dat
+8	./st138/SURFACE/00002200.dat
+8	./st138/SURFACE/00000850.dat
+8	./st138/SURFACE/00004350.dat
+8	./st138/SURFACE/00002000.dat
+8	./st138/SURFACE/00002350.dat
+8	./st138/SURFACE/00004100.dat
+8	./st138/SURFACE/00002550.dat
+8	./st138/SURFACE/00001100.dat
+8	./st138/SURFACE/00002500.dat
+8	./st138/SURFACE/00003700.dat
+8	./st138/SURFACE/00003150.dat
+8	./st138/SURFACE/00000400.dat
+8	./st138/SURFACE/00000150.dat
+8	./st138/SURFACE/00004250.dat
+8	./st138/SURFACE/00001550.dat
+8	./st138/SURFACE/00002300.dat
+8	./st138/SURFACE/00002650.dat
+8	./st138/SURFACE/00003850.dat
+8	./st138/SURFACE/00001050.dat
+8	./st138/SURFACE/00000600.dat
+8	./st138/SURFACE/00000700.dat
+8	./st138/SURFACE/00003600.dat
+8	./st138/SURFACE/00000450.dat
+8	./st138/SURFACE/00001000.dat
+8	./st138/SURFACE/00000350.dat
+8	./st138/SURFACE/00001600.dat
+8	./st138/SURFACE/00000050.dat
+8	./st138/SURFACE/00002250.dat
+8	./st138/SURFACE/00000650.dat
+8	./st138/SURFACE/00003750.dat
+8	./st138/SURFACE/00004050.dat
+8	./st138/SURFACE/00002750.dat
+8	./st138/SURFACE/00002150.dat
+8	./st138/SURFACE/00002600.dat
+8	./st138/SURFACE/00000550.dat
+8	./st138/SURFACE/00003350.dat
+8	./st138/SURFACE/00001350.dat
+8	./st138/SURFACE/00001150.dat
+8	./st138/SURFACE/00003050.dat
+8	./st138/SURFACE/00001750.dat
+8	./st138/SURFACE/00001250.dat
+8	./st138/SURFACE/00004200.dat
+8	./st138/SURFACE/00001800.dat
+8	./st138/SURFACE/00000250.dat
+8	./st138/SURFACE/00000950.dat
+8	./st138/SURFACE/00002100.dat
+8	./st138/SURFACE/00002050.dat
+8	./st138/SURFACE/00001450.dat
+8	./st138/SURFACE/00001200.dat
+8	./st138/SURFACE/00003400.dat
+8	./st138/SURFACE/00003650.dat
+8	./st138/SURFACE/00002400.dat
+8	./st138/SURFACE/00001850.dat
+8	./st138/SURFACE/00000300.dat
+0	./st138/SURFACE/00004400.dat
+8	./st138/SURFACE/00003200.dat
+8	./st138/SURFACE/00002450.dat
+8	./st138/SURFACE/00003000.dat
+8	./st138/SURFACE/00001300.dat
+8	./st138/SURFACE/00003500.dat
+8	./st138/SURFACE/00000500.dat
+8	./st138/SURFACE/00003550.dat
+8	./st138/SURFACE/00003900.dat
+8	./st138/SURFACE/00001950.dat
+8	./st138/SURFACE/00001400.dat
+8	./st138/SURFACE/00000800.dat
+8	./st138/SURFACE/00003800.dat
+700	./st138/SURFACE
+4	./st138/prof_step
+4	./st138/MID/TIME.MID
+8	./st138/MID
+7513412	./st138
+112	./IBM_test1/FDM_026_PD_SPE.o
+36	./IBM_test1/FDM_043_VOF.F90
+20	./IBM_test1/FDM_123_WALLMODEL_POWERLAW.o
+16	./IBM_test1/FDM_023_SMOOTHING.F90
+12	./IBM_test1/SHOWGEO/tecio.f90
+4	./IBM_test1/SHOWGEO/SHOWGEO.F90
+16	./IBM_test1/SHOWGEO/SHOWGEO.o
+36	./IBM_test1/SHOWGEO
+16	./IBM_test1/FDM_011_INIT_CONSTANTS.F90
+648	./IBM_test1/libtecio.a
+4	./IBM_test1/FDM_027_RK.F90
+20	./IBM_test1/FDM_302_WAVYVOR_DECOMPOSITION.F90
+16	./IBM_test1/FDM_033_IBM_INTFORCING.F90
+12	./IBM_test1/FDM_010_INIT_PARALLEL.o
+516	./IBM_test1/GEOMETRY/PSI.0012
+516	./IBM_test1/GEOMETRY/PSI.0015
+516	./IBM_test1/GEOMETRY/PSI.0005
+516	./IBM_test1/GEOMETRY/PSI.0007
+520	./IBM_test1/GEOMETRY/PSI.0003
+516	./IBM_test1/GEOMETRY/PSI.0014
+516	./IBM_test1/GEOMETRY/PSI.0008
+520	./IBM_test1/GEOMETRY/PSI.0002
+520	./IBM_test1/GEOMETRY/PSI.0000
+516	./IBM_test1/GEOMETRY/PSI.0010
+516	./IBM_test1/GEOMETRY/PSI.0004
+516	./IBM_test1/GEOMETRY/PSI.0013
+516	./IBM_test1/GEOMETRY/PSI.0011
+516	./IBM_test1/GEOMETRY/PSI.0009
+516	./IBM_test1/GEOMETRY/PSI.0006
+520	./IBM_test1/GEOMETRY/PSI.0001
+8276	./IBM_test1/GEOMETRY
+24	./IBM_test1/FDM_110_RNG.o
+300	./IBM_test1/showgeo
+4	./IBM_test1/template1
+16	./IBM_test1/FDM_025_PD.F90
+40	./IBM_test1/FDM_070_PARALLEL.F90
+4	./IBM_test1/FDM_121_WALLMODEL_KANG.F90
+4	./IBM_test1/DATA
+108	./IBM_test1/FDM_304_ASSIMILATION_WAVY.o
+220	./IBM_test1/FDM_032_IBM_EXTFORCING.o
+4	./IBM_test1/FDM_111_GERMANO.F90
+328	./IBM_test1/FDM_023_SMOOTHING.o
+8	./IBM_test1/FDM_122_WALLMODEL_ROMAN.F90
+84	./IBM_test1/POST_BASIC/POST_020_STATS.o
+24	./IBM_test1/POST_BASIC/POST_032_IO.F90
+8	./IBM_test1/POST_BASIC/POST_020_STATS.F90
+12	./IBM_test1/POST_BASIC/POST_040_AVERAGE.o
+8	./IBM_test1/POST_BASIC/POST_010_INIT_PARALLEL.o
+56	./IBM_test1/POST_BASIC/POST_030_READFILE.o
+12	./IBM_test1/POST_BASIC/POST_030_READFILE.F90
+12	./IBM_test1/POST_BASIC/POST_031_PARALLEL.F90
+36	./IBM_test1/POST_BASIC/POST_011_INIT_CONSTANTS.o
+4	./IBM_test1/POST_BASIC/POST_000_MAIN.F90
+16	./IBM_test1/POST_BASIC/POST_031_PARALLEL.o
+8	./IBM_test1/POST_BASIC/INCLUDE_COMMON.FI
+4	./IBM_test1/POST_BASIC/POST_040_AVERAGE.F90
+16	./IBM_test1/POST_BASIC/POST_050_WRITEFILE.o
+12	./IBM_test1/POST_BASIC/POST_011_INIT_CONSTANTS.F90
+4	./IBM_test1/POST_BASIC/POST_999_FINALIZE.F90
+4	./IBM_test1/POST_BASIC/POST_050_WRITEFILE.F90
+4	./IBM_test1/POST_BASIC/POST_010_INIT_PARALLEL.F90
+8	./IBM_test1/POST_BASIC/POST_999_FINALIZE.o
+8	./IBM_test1/POST_BASIC/POST_000_MAIN.o
+344	./IBM_test1/POST_BASIC
+4	./IBM_test1/template3
+16	./IBM_test1/FDM_304_ASSIMILATION_WAVY.F90
+372	./IBM_test1/gatherdata
+8	./IBM_test1/FDM_000_MAIN.F90
+20	./IBM_test1/FDM_032_IBM_EXTFORCING.F90
+12	./IBM_test1/FDM_042_LS.F90
+4	./IBM_test1/INCLUDE_FFT.FI
+4	./IBM_test1/FDM_123_WALLMODEL_POWERLAW.F90
+140	./IBM_test1/FDM_030_IBM.o
+4	./IBM_test1/FDM_044_PRESCRIBEWAVE.F90
+4	./IBM_test1/FDM_080_FFT.F90
+56	./IBM_test1/FDM_020_PRESOLVE.o
+4	./IBM_test1/FDM_091_SEDIMENT.F90
+12	./IBM_test1/FDM_300_ASSIMILATION.o
+4	./IBM_test1/run.sh
+148	./IBM_test1/FDM_060_STATS_TS.o
+4	./IBM_test1/aegean_stream.sh
+4	./IBM_test1/INCLUDE_LES.FI
+4	./IBM_test1/INCLUDE_IO.FI
+36	./IBM_test1/FDM_031_IBM_INIT_M.F90
+4	./IBM_test1/Makefile
+4	./IBM_test1/DYE.IN
+4	./IBM_test1/INCLUDE_WAVEGENERATOR.FI
+8	./IBM_test1/FDM_303_MEANFLUC_DECOMPOSITION.F90
+120	./IBM_test1/FDM_070_PARALLEL.o
+20	./IBM_test1/FDM_305_ASSIMILATION_VORT.o
+32	./IBM_test1/FDM_301_ASSIMILATION_GEOMETRY.F90
+4	./IBM_test1/WAVE
+4	./IBM_test1/INCLUDE_PARALLEL.FI
+112	./IBM_test1/FDM_033_IBM_INTFORCING.o
+8	./IBM_test1/FDM_030_IBM.F90
+4	./IBM_test1/template2
+90212	./IBM_test1/STATS/BASIC.H5
+4	./IBM_test1/STATS/STAT_STEP
+90220	./IBM_test1/STATS
+248	./IBM_test1/FDM_306_ASSIMILATION_TOTAL.o
+12	./IBM_test1/FDM_027_RK.o
+8	./IBM_test1/FDM_020_PRESOLVE.F90
+1268	./IBM_test1/FDM_021_RHS.o
+4	./IBM_test1/submit
+4	./IBM_test1/template5
+44	./IBM_test1/FDM_111_GERMANO.o
+8	./IBM_test1/FDM_999_FINALIZE.o
+76	./IBM_test1/FDM_090_DYE.o
+4	./IBM_test1/resga
+28	./IBM_test1/FDM_051_IO.F90
+8	./IBM_test1/FDM_061_STATS_TA.F90
+4	./IBM_test1/aga.sh
+16	./IBM_test1/FDM_022_WG.F90
+100	./IBM_test1/FDM_050_OUTPUT.o
+12	./IBM_test1/TAGS
+4	./IBM_test1/INCLUDE_ASSIMILATION.FI
+8	./IBM_test1/FDM_121_WALLMODEL_KANG.o
+4	./IBM_test1/PARAM.IN
+412	./IBM_test1/FDM_043_VOF.o
+8	./IBM_test1/FDM_090_DYE.F90
+8	./IBM_test1/INCLUDE_IBM.FI
+4	./IBM_test1/script.sh
+16	./IBM_test1/template4
+48	./IBM_test1/FDM_120_WALLMODEL_TBL.o
+4	./IBM_test1/INCLUDE_SINKPARAM.FI
+4	./IBM_test1/INCLUDE_PARAMETER.FI
+4	./IBM_test1/PARAM_Liu.IN
+76	./IBM_test1/FDM_021_RHS.F90
+84	./IBM_test1/FDM_303_MEANFLUC_DECOMPOSITION.o
+20	./IBM_test1/FDM_306_ASSIMILATION_TOTAL.F90
+8	./IBM_test1/FDM_100_LES.F90
+36	./IBM_test1/FDM_031_IBM_INIT.F90
+64	./IBM_test1/FDM_061_STATS_TA.o
+280	./IBM_test1/FDM_301_ASSIMILATION_GEOMETRY.o
+3984	./IBM_test1/TIME_SERIES/MAXUVW.DAT
+1656	./IBM_test1/TIME_SERIES/CDCF.DAT
+5644	./IBM_test1/TIME_SERIES
+4	./IBM_test1/FDM_300_ASSIMILATION.F90
+4	./IBM_test1/FDM_010_INIT_PARALLEL.F90
+12	./IBM_test1/FDM_050_OUTPUT.F90
+4	./IBM_test1/GATHERDATA/INCLUDE_IO.FI
+12	./IBM_test1/GATHERDATA/GATHER_IO.o
+12	./IBM_test1/GATHERDATA/tecio.f90
+4	./IBM_test1/GATHERDATA/GATHER_IO.F90
+156	./IBM_test1/GATHERDATA/GATHERDATA.o
+16	./IBM_test1/GATHERDATA/GATHERDATA.F90
+208	./IBM_test1/GATHERDATA
+44	./IBM_test1/FDM_044_PRESCRIBEWAVE.o
+4	./IBM_test1/INCLUDE_SCALAR.FI
+4	./IBM_test1/README.md
+16	./IBM_test1/FDM_025_PD_Liu.F90
+12	./IBM_test1/INCLUDE_COMMON.FI
+16768	./IBM_test1/wave
+24	./IBM_test1/POST_WAVY_WALL/POST_032_IO.F90
+8	./IBM_test1/POST_WAVY_WALL/POST_010_INIT_PARALLEL.o
+32	./IBM_test1/POST_WAVY_WALL/POST_030_READFILE.o
+16	./IBM_test1/POST_WAVY_WALL/POST_040_WRITEFILE.o
+4	./IBM_test1/POST_WAVY_WALL/POST_030_READFILE.F90
+16	./IBM_test1/POST_WAVY_WALL/POST_011_INIT_CONSTANTS.o
+24	./IBM_test1/POST_WAVY_WALL/POST_020_AVERAGE.o
+4	./IBM_test1/POST_WAVY_WALL/POST_000_MAIN.F90
+4	./IBM_test1/POST_WAVY_WALL/tags
+8	./IBM_test1/POST_WAVY_WALL/INCLUDE_COMMON.FI
+4	./IBM_test1/POST_WAVY_WALL/POST_011_INIT_CONSTANTS.F90
+4	./IBM_test1/POST_WAVY_WALL/POST_999_FINALIZE.F90
+4	./IBM_test1/POST_WAVY_WALL/POST_040_WRITEFILE.F90
+4	./IBM_test1/POST_WAVY_WALL/POST_020_AVERAGE.F90
+4	./IBM_test1/POST_WAVY_WALL/POST_010_INIT_PARALLEL.F90
+8	./IBM_test1/POST_WAVY_WALL/POST_999_FINALIZE.o
+8	./IBM_test1/POST_WAVY_WALL/POST_000_MAIN.o
+180	./IBM_test1/POST_WAVY_WALL
+4	./IBM_test1/TRACER
+52	./IBM_test1/FDM_051_IO.o
+4	./IBM_test1/FDM_110_RNG.F90
+120	./IBM_test1/FDM_022_WG.o
+4	./IBM_test1/GRID.IN
+4	./IBM_test1/INSTANTANEOUS
+4	./IBM_test1/FDM_999_FINALIZE.F90
+184	./IBM_test1/FDM_025_PD.o
+52	./IBM_test1/FDM_122_WALLMODEL_ROMAN.o
+48	./IBM_test1/FDM_012_INIT_FIELD.F90
+12	./IBM_test1/FDM_200_PETSC_SOLVER.F90
+176	./IBM_test1/results_aegean
+8	./IBM_test1/FDM_307_TRACER.F90
+4	./IBM_test1/FDM_305_ASSIMILATION_VORT.F90
+4	./IBM_test1/INCLUDE_STATS.FI
+104	./IBM_test1/FDM_100_LES.o
+16	./IBM_test1/FDM_060_STATS_TS.F90
+80	./IBM_test1/FDM_091_SEDIMENT.o
+56	./IBM_test1/FDM_307_TRACER.o
+400	./IBM_test1/FDM_031_IBM_INIT.o
+188	./IBM_test1/FDM_302_WAVYVOR_DECOMPOSITION.o
+8	./IBM_test1/FDM_080_FFT.o
+8	./IBM_test1/FDM_120_WALLMODEL_TBL.F90
+4	./IBM_test1/run_post.sh
+16	./IBM_test1/FDM_026_PD_SPE.F90
+304	./IBM_test1/FDM_012_INIT_FIELD.o
+4	./IBM_test1/prof_step
+1116	./IBM_test1/post_skewness
+20	./IBM_test1/FDM_000_MAIN.o
+160	./IBM_test1/FDM_042_LS.o
+52	./IBM_test1/FDM_011_INIT_CONSTANTS.o
+48	./IBM_test1/FDM_200_PETSC_SOLVER.o
+4	./IBM_test1/MID/TIME.MID
+8	./IBM_test1/MID
+4	./IBM_test1/INCLUDE_POISSON.FI
+4	./IBM_test1/PRIO_GENERATE_GRID/Makefile
+12	./IBM_test1/PRIO_GENERATE_GRID/genegrid
+4	./IBM_test1/PRIO_GENERATE_GRID/GENEGRID.F90
+8	./IBM_test1/PRIO_GENERATE_GRID/GENEGRID.o
+32	./IBM_test1/PRIO_GENERATE_GRID
+131180	./IBM_test1
+du: cannot access `./IBM19/libtecio.a': Permission denied
+du: cannot access `./IBM19/INCLUDE': Permission denied
+du: cannot access `./IBM19/GEOMETRY': Permission denied
+du: cannot access `./IBM19/CALCULATE': Permission denied
+du: cannot access `./IBM19/volume.dat': Permission denied
+du: cannot access `./IBM19/DATA': Permission denied
+du: cannot access `./IBM19/POST_BASIC': Permission denied
+du: cannot access `./IBM19/gatherdata': Permission denied
+du: cannot access `./IBM19/submit_p': Permission denied
+du: cannot access `./IBM19/aegean_stream.sh': Permission denied
+du: cannot access `./IBM19/screen': Permission denied
+du: cannot access `./IBM19/sink.dat': Permission denied
+du: cannot access `./IBM19/Makefile': Permission denied
+du: cannot access `./IBM19/submit_data': Permission denied
+du: cannot access `./IBM19/WAVE': Permission denied
+du: cannot access `./IBM19/RESTART_SOLID': Permission denied
+du: cannot access `./IBM19/STATS': Permission denied
+du: cannot access `./IBM19/submit': Permission denied
+du: cannot access `./IBM19/batchrun': Permission denied
+du: cannot access `./IBM19/resga': Permission denied
+du: cannot access `./IBM19/sour.dat': Permission denied
+du: cannot access `./IBM19/aga.sh': Permission denied
+du: cannot access `./IBM19/PARAM.IN': Permission denied
+du: cannot access `./IBM19/CIRC_VELO': Permission denied
+du: cannot access `./IBM19/TIME_SERIES': Permission denied
+du: cannot access `./IBM19/screenga': Permission denied
+du: cannot access `./IBM19/GATHERDATA': Permission denied
+du: cannot access `./IBM19/wave': Permission denied
+du: cannot access `./IBM19/POST_WAVY_WALL': Permission denied
+du: cannot access `./IBM19/TRACER': Permission denied
+du: cannot access `./IBM19/GRID.IN': Permission denied
+du: cannot access `./IBM19/INSTANTANEOUS': Permission denied
+du: cannot access `./IBM19/FLUX': Permission denied
+du: cannot access `./IBM19/results_aegean': Permission denied
+du: cannot access `./IBM19/SURFACE': Permission denied
+du: cannot access `./IBM19/prof_step': Permission denied
+du: cannot access `./IBM19/Beforemaking': Permission denied
+du: cannot access `./IBM19/MID': Permission denied
+du: cannot access `./IBM19/PRIO_GENERATE_GRID': Permission denied
+4	./IBM19
+du: cannot access `./IBM8/libtecio.a': Permission denied
+du: cannot access `./IBM8/INCLUDE': Permission denied
+du: cannot access `./IBM8/GEOMETRY': Permission denied
+du: cannot access `./IBM8/CALCULATE': Permission denied
+du: cannot access `./IBM8/volume.dat': Permission denied
+du: cannot access `./IBM8/DATA': Permission denied
+du: cannot access `./IBM8/LIB': Permission denied
+du: cannot access `./IBM8/POST_BASIC': Permission denied
+du: cannot access `./IBM8/gatherdata': Permission denied
+du: cannot access `./IBM8/submit_p': Permission denied
+du: cannot access `./IBM8/aegean_stream.sh': Permission denied
+du: cannot access `./IBM8/screen': Permission denied
+du: cannot access `./IBM8/Makefile': Permission denied
+du: cannot access `./IBM8/submit_data': Permission denied
+du: cannot access `./IBM8/WAVE': Permission denied
+du: cannot access `./IBM8/RESTART_SOLID': Permission denied
+du: cannot access `./IBM8/STATS': Permission denied
+du: cannot access `./IBM8/submit': Permission denied
+du: cannot access `./IBM8/batchrun': Permission denied
+du: cannot access `./IBM8/resga': Permission denied
+du: cannot access `./IBM8/sour.dat': Permission denied
+du: cannot access `./IBM8/aga.sh': Permission denied
+du: cannot access `./IBM8/PARAM.IN': Permission denied
+du: cannot access `./IBM8/CIRC_VELO': Permission denied
+du: cannot access `./IBM8/TIME_SERIES': Permission denied
+du: cannot access `./IBM8/screenga': Permission denied
+du: cannot access `./IBM8/GATHERDATA': Permission denied
+du: cannot access `./IBM8/wave': Permission denied
+du: cannot access `./IBM8/POST_WAVY_WALL': Permission denied
+du: cannot access `./IBM8/TRACER': Permission denied
+du: cannot access `./IBM8/GRID.IN': Permission denied
+du: cannot access `./IBM8/results_aegean': Permission denied
+du: cannot access `./IBM8/SURFACE': Permission denied
+du: cannot access `./IBM8/phi-f.mcr': Permission denied
+du: cannot access `./IBM8/vortex.mcr': Permission denied
+du: cannot access `./IBM8/prof_step': Permission denied
+du: cannot access `./IBM8/Beforemaking': Permission denied
+du: cannot access `./IBM8/MID': Permission denied
+du: cannot access `./IBM8/PRIO_GENERATE_GRID': Permission denied
+4	./IBM8
+44	./code/FDM_043_VOF.F90
+12	./code/FDM_011_INIT_CONSTANTS.F90
+16	./code/FDM_033_IBM_INTFORCING.F90
+16	./code/FDM_025_PD.F90
+40	./code/FDM_070_PARALLEL.F90
+4	./code/FDM_000_MAIN.F90
+16	./code/FDM_032_IBM_EXTFORCING.F90
+28	./code/FDM_042_LS.F90
+4	./code/FDM_026_RK.F90
+12	./code/FDM_030_IBM.F90
+12	./code/FDM_020_PRESOLVE.F90
+4	./code/FDM_061_STATS_TA.F90
+4	./code/FDM_110_GERMANO.F90
+32	./code/FDM_021_RHS.F90
+8	./code/FDM_120_WALLMODEL.F90
+8	./code/FDM_100_LES.F90
+36	./code/FDM_031_IBM_INIT.F90
+4	./code/FDM_010_INIT_PARALLEL.F90
+4	./code/FDM_050_OUTPUT.F90
+8	./code/tags
+4	./code/FDM_999_FINALIZE.F90
+32	./code/FDM_012_INIT_FIELD.F90
+16	./code/FDM_200_PETSC_SOLVER.F90
+16	./code/FDM_060_STATS_TS.F90
+384	./code
+du: cannot access `./sinkc3phis1/FDM_026_PD_SPE.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_043_VOF.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_123_WALLMODEL_POWERLAW.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_023_SMOOTHING.F90': Permission denied
+du: cannot access `./sinkc3phis1/SHOWGEO': Permission denied
+du: cannot access `./sinkc3phis1/FDM_011_INIT_CONSTANTS.F90': Permission denied
+du: cannot access `./sinkc3phis1/libtecio.a': Permission denied
+du: cannot access `./sinkc3phis1/FDM_027_RK.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_302_WAVYVOR_DECOMPOSITION.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_033_IBM_INTFORCING.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_010_INIT_PARALLEL.o': Permission denied
+du: cannot access `./sinkc3phis1/GEOMETRY': Permission denied
+du: cannot access `./sinkc3phis1/FDM_110_RNG.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_025_PD.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_070_PARALLEL.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_121_WALLMODEL_KANG.F90': Permission denied
+du: cannot access `./sinkc3phis1/DATA': Permission denied
+du: cannot access `./sinkc3phis1/FDM_304_ASSIMILATION_WAVY.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_032_IBM_EXTFORCING.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_111_GERMANO.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_023_SMOOTHING.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_122_WALLMODEL_ROMAN.F90': Permission denied
+du: cannot access `./sinkc3phis1/POST_BASIC': Permission denied
+du: cannot access `./sinkc3phis1/FDM_304_ASSIMILATION_WAVY.F90': Permission denied
+du: cannot access `./sinkc3phis1/gatherdata': Permission denied
+du: cannot access `./sinkc3phis1/FDM_000_MAIN.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_032_IBM_EXTFORCING.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_042_LS.F90': Permission denied
+du: cannot access `./sinkc3phis1/INCLUDE_FFT.FI': Permission denied
+du: cannot access `./sinkc3phis1/FDM_123_WALLMODEL_POWERLAW.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_030_IBM.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_044_PRESCRIBEWAVE.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_080_FFT.F90': Permission denied
+du: cannot access `./sinkc3phis1/fort.90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_020_PRESOLVE.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_091_SEDIMENT.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_300_ASSIMILATION.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_060_STATS_TS.o': Permission denied
+du: cannot access `./sinkc3phis1/aegean_stream.sh': Permission denied
+du: cannot access `./sinkc3phis1/INCLUDE_LES.FI': Permission denied
+du: cannot access `./sinkc3phis1/screen': Permission denied
+du: cannot access `./sinkc3phis1/INCLUDE_IO.FI': Permission denied
+du: cannot access `./sinkc3phis1/sink.dat': Permission denied
+du: cannot access `./sinkc3phis1/Makefile': Permission denied
+du: cannot access `./sinkc3phis1/DYE.IN': Permission denied
+du: cannot access `./sinkc3phis1/INCLUDE_WAVEGENERATOR.FI': Permission denied
+du: cannot access `./sinkc3phis1/FDM_303_MEANFLUC_DECOMPOSITION.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_070_PARALLEL.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_305_ASSIMILATION_VORT.o': Permission denied
+du: cannot access `./sinkc3phis1/submit_data': Permission denied
+du: cannot access `./sinkc3phis1/FDM_301_ASSIMILATION_GEOMETRY.F90': Permission denied
+du: cannot access `./sinkc3phis1/WAVE': Permission denied
+du: cannot access `./sinkc3phis1/INCLUDE_PARALLEL.FI': Permission denied
+du: cannot access `./sinkc3phis1/FDM_033_IBM_INTFORCING.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_030_IBM.F90': Permission denied
+du: cannot access `./sinkc3phis1/STATS': Permission denied
+du: cannot access `./sinkc3phis1/FDM_306_ASSIMILATION_TOTAL.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_027_RK.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_020_PRESOLVE.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_021_RHS.o': Permission denied
+du: cannot access `./sinkc3phis1/submit': Permission denied
+du: cannot access `./sinkc3phis1/FDM_111_GERMANO.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_999_FINALIZE.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_090_DYE.o': Permission denied
+du: cannot access `./sinkc3phis1/resga': Permission denied
+du: cannot access `./sinkc3phis1/FDM_051_IO.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_061_STATS_TA.F90': Permission denied
+du: cannot access `./sinkc3phis1/aga.sh': Permission denied
+du: cannot access `./sinkc3phis1/FDM_022_WG.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_050_OUTPUT.o': Permission denied
+du: cannot access `./sinkc3phis1/TAGS': Permission denied
+du: cannot access `./sinkc3phis1/core': Permission denied
+du: cannot access `./sinkc3phis1/screen1': Permission denied
+du: cannot access `./sinkc3phis1/INCLUDE_ASSIMILATION.FI': Permission denied
+du: cannot access `./sinkc3phis1/FDM_121_WALLMODEL_KANG.o': Permission denied
+du: cannot access `./sinkc3phis1/PARAM.IN': Permission denied
+du: cannot access `./sinkc3phis1/FDM_043_VOF.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_090_DYE.F90': Permission denied
+du: cannot access `./sinkc3phis1/INCLUDE_IBM.FI': Permission denied
+du: cannot access `./sinkc3phis1/FDM_120_WALLMODEL_TBL.o': Permission denied
+du: cannot access `./sinkc3phis1/INCLUDE_SINKPARAM.FI': Permission denied
+du: cannot access `./sinkc3phis1/INCLUDE_PARAMETER.FI': Permission denied
+du: cannot access `./sinkc3phis1/FDM_021_RHS.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_303_MEANFLUC_DECOMPOSITION.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_306_ASSIMILATION_TOTAL.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_100_LES.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_031_IBM_INIT.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_061_STATS_TA.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_301_ASSIMILATION_GEOMETRY.o': Permission denied
+du: cannot access `./sinkc3phis1/TIME_SERIES': Permission denied
+du: cannot access `./sinkc3phis1/screenga': Permission denied
+du: cannot access `./sinkc3phis1/FDM_300_ASSIMILATION.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_010_INIT_PARALLEL.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_050_OUTPUT.F90': Permission denied
+du: cannot access `./sinkc3phis1/GATHERDATA': Permission denied
+du: cannot access `./sinkc3phis1/FDM_044_PRESCRIBEWAVE.o': Permission denied
+du: cannot access `./sinkc3phis1/INCLUDE_SCALAR.FI': Permission denied
+du: cannot access `./sinkc3phis1/tags': Permission denied
+du: cannot access `./sinkc3phis1/INCLUDE_COMMON.FI': Permission denied
+du: cannot access `./sinkc3phis1/wave': Permission denied
+du: cannot access `./sinkc3phis1/POST_WAVY_WALL': Permission denied
+du: cannot access `./sinkc3phis1/TRACER': Permission denied
+du: cannot access `./sinkc3phis1/FDM_051_IO.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_110_RNG.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_022_WG.o': Permission denied
+du: cannot access `./sinkc3phis1/GRID.IN': Permission denied
+du: cannot access `./sinkc3phis1/INSTANTANEOUS': Permission denied
+du: cannot access `./sinkc3phis1/FDM_999_FINALIZE.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_025_PD.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_122_WALLMODEL_ROMAN.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_012_INIT_FIELD.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_200_PETSC_SOLVER.F90': Permission denied
+du: cannot access `./sinkc3phis1/results_aegean': Permission denied
+du: cannot access `./sinkc3phis1/FDM_307_TRACER.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_305_ASSIMILATION_VORT.F90': Permission denied
+du: cannot access `./sinkc3phis1/SURFACE': Permission denied
+du: cannot access `./sinkc3phis1/INCLUDE_STATS.FI': Permission denied
+du: cannot access `./sinkc3phis1/FDM_100_LES.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_060_STATS_TS.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_091_SEDIMENT.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_307_TRACER.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_031_IBM_INIT.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_302_WAVYVOR_DECOMPOSITION.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_080_FFT.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_120_WALLMODEL_TBL.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_026_PD_SPE.F90': Permission denied
+du: cannot access `./sinkc3phis1/FDM_012_INIT_FIELD.o': Permission denied
+du: cannot access `./sinkc3phis1/prof_step': Permission denied
+du: cannot access `./sinkc3phis1/post_skewness': Permission denied
+du: cannot access `./sinkc3phis1/FDM_000_MAIN.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_042_LS.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_011_INIT_CONSTANTS.o': Permission denied
+du: cannot access `./sinkc3phis1/FDM_200_PETSC_SOLVER.o': Permission denied
+du: cannot access `./sinkc3phis1/MID': Permission denied
+du: cannot access `./sinkc3phis1/INCLUDE_POISSON.FI': Permission denied
+du: cannot access `./sinkc3phis1/PRIO_GENERATE_GRID': Permission denied
+12	./sinkc3phis1
+4	./st136/GEOMETRY
+310272	./st136/DATA/V00024200.H5
+310272	./st136/DATA/V00008200.H5
+310272	./st136/DATA/V00008000.H5
+310272	./st136/DATA/V00019000.H5
+310272	./st136/DATA/V00001800.H5
+310272	./st136/DATA/V00003800.H5
+310272	./st136/DATA/V00024400.H5
+310272	./st136/DATA/V00022200.H5
+310272	./st136/DATA/V00018600.H5
+310272	./st136/DATA/V00011000.H5
+310272	./st136/DATA/V00019200.H5
+310272	./st136/DATA/V00018000.H5
+310272	./st136/DATA/V00015200.H5
+310272	./st136/DATA/V00000200.H5
+310272	./st136/DATA/V00009600.H5
+310272	./st136/DATA/V00023600.H5
+310272	./st136/DATA/V00018800.H5
+310272	./st136/DATA/V00005200.H5
+310272	./st136/DATA/V00021800.H5
+310272	./st136/DATA/V00012800.H5
+310272	./st136/DATA/V00023400.H5
+310272	./st136/DATA/V00011400.H5
+310272	./st136/DATA/V00012200.H5
+310272	./st136/DATA/V00019800.H5
+310272	./st136/DATA/V00014800.H5
+310272	./st136/DATA/V00007600.H5
+310272	./st136/DATA/V00006600.H5
+310272	./st136/DATA/V00013200.H5
+310272	./st136/DATA/V00018200.H5
+310272	./st136/DATA/V00024600.H5
+310272	./st136/DATA/V00019600.H5
+310272	./st136/DATA/V00020800.H5
+310272	./st136/DATA/V00021200.H5
+310272	./st136/DATA/V00015400.H5
+310272	./st136/DATA/V00005800.H5
+310272	./st136/DATA/V00016400.H5
+310272	./st136/DATA/V00005600.H5
+310272	./st136/DATA/V00025200.H5
+310272	./st136/DATA/V00009200.H5
+310272	./st136/DATA/V00001000.H5
+310272	./st136/DATA/V00014600.H5
+310272	./st136/DATA/V00005000.H5
+310272	./st136/DATA/V00016800.H5
+310272	./st136/DATA/V00009400.H5
+310272	./st136/DATA/V00000800.H5
+310272	./st136/DATA/V00007200.H5
+310272	./st136/DATA/V00010400.H5
+310272	./st136/DATA/V00012400.H5
+310272	./st136/DATA/V00010600.H5
+310272	./st136/DATA/V00007400.H5
+310272	./st136/DATA/V00007000.H5
+310272	./st136/DATA/V00002600.H5
+310272	./st136/DATA/V00002000.H5
+310272	./st136/DATA/V00010000.H5
+310272	./st136/DATA/V00006000.H5
+310272	./st136/DATA/V00004000.H5
+310272	./st136/DATA/V00013600.H5
+310272	./st136/DATA/V00010200.H5
+310272	./st136/DATA/V00004800.H5
+310272	./st136/DATA/V00013800.H5
+310272	./st136/DATA/V00017600.H5
+310272	./st136/DATA/V00012000.H5
+310272	./st136/DATA/V00001200.H5
+310272	./st136/DATA/V00013000.H5
+310272	./st136/DATA/V00007800.H5
+310272	./st136/DATA/V00001400.H5
+310272	./st136/DATA/V00020600.H5
+310272	./st136/DATA/V00022400.H5
+310272	./st136/DATA/V00016000.H5
+310272	./st136/DATA/V00009800.H5
+310272	./st136/DATA/V00000400.H5
+310272	./st136/DATA/V00011800.H5
+310272	./st136/DATA/V00015000.H5
+310272	./st136/DATA/V00024000.H5
+310272	./st136/DATA/V00003400.H5
+310272	./st136/DATA/V00017200.H5
+310272	./st136/DATA/V00021400.H5
+310272	./st136/DATA/V00020200.H5
+310272	./st136/DATA/V00023000.H5
+310272	./st136/DATA/V00015600.H5
+310272	./st136/DATA/V00011200.H5
+310272	./st136/DATA/V00023200.H5
+310272	./st136/DATA/V00024800.H5
+310272	./st136/DATA/V00004200.H5
+310272	./st136/DATA/V00012600.H5
+310272	./st136/DATA/V00023800.H5
+310272	./st136/DATA/V00006200.H5
+310272	./st136/DATA/V00003200.H5
+310272	./st136/DATA/V00008400.H5
+310272	./st136/DATA/V00002400.H5
+310272	./st136/DATA/V00004400.H5
+310272	./st136/DATA/V00018400.H5
+310272	./st136/DATA/V00009000.H5
+310272	./st136/DATA/V00020000.H5
+310272	./st136/DATA/V00022600.H5
+310272	./st136/DATA/V00008800.H5
+310272	./st136/DATA/V00000000.H5
+310272	./st136/DATA/V00006800.H5
+310272	./st136/DATA/V00017800.H5
+310272	./st136/DATA/V00000600.H5
+310272	./st136/DATA/V00015800.H5
+310272	./st136/DATA/V00014200.H5
+310272	./st136/DATA/V00014000.H5
+310272	./st136/DATA/V00022800.H5
+310272	./st136/DATA/V00003600.H5
+310272	./st136/DATA/V00016600.H5
+310272	./st136/DATA/V00001600.H5
+310272	./st136/DATA/V00022000.H5
+310272	./st136/DATA/V00014400.H5
+310272	./st136/DATA/V00020400.H5
+310272	./st136/DATA/V00002800.H5
+310272	./st136/DATA/V00017400.H5
+310272	./st136/DATA/V00021000.H5
+310272	./st136/DATA/V00011600.H5
+310272	./st136/DATA/V00005400.H5
+310272	./st136/DATA/V00017000.H5
+310272	./st136/DATA/V00019400.H5
+310272	./st136/DATA/V00025000.H5
+310272	./st136/DATA/V00013400.H5
+310272	./st136/DATA/V00006400.H5
+310272	./st136/DATA/V00003000.H5
+310272	./st136/DATA/V00008600.H5
+310272	./st136/DATA/V00010800.H5
+310272	./st136/DATA/V00002200.H5
+310272	./st136/DATA/V00021600.H5
+310272	./st136/DATA/V00004600.H5
+310272	./st136/DATA/V00016200.H5
+39404556	./st136/DATA
+4	./st136/aegean_stream.sh
+2624	./st136/sink.dat
+4	./st136/WAVE
+356440	./st136/STATS/BASIC.H5
+4	./st136/STATS/STAT_STEP
+356448	./st136/STATS
+1312	./st136/test3vof.dat
+4	./st136/aga.sh
+4	./st136/PARAM.IN
+4832	./st136/TIME_SERIES/MAXUVW.DAT
+2960	./st136/TIME_SERIES/CDCF.DAT
+7796	./st136/TIME_SERIES
+16724	./st136/wave
+4	./st136/TRACER
+8	./st136/GRID.IN
+6956	./st136/results_aegean
+8	./st136/SURFACE/00024400.dat
+8	./st136/SURFACE/00002850.dat
+8	./st136/SURFACE/00025200.dat
+8	./st136/SURFACE/00003250.dat
+8	./st136/SURFACE/00005900.dat
+8	./st136/SURFACE/00010950.dat
+8	./st136/SURFACE/00016350.dat
+8	./st136/SURFACE/00010700.dat
+8	./st136/SURFACE/00016500.dat
+8	./st136/SURFACE/00012650.dat
+8	./st136/SURFACE/00009400.dat
+8	./st136/SURFACE/00018950.dat
+8	./st136/SURFACE/00024900.dat
+8	./st136/SURFACE/00009850.dat
+8	./st136/SURFACE/00013150.dat
+8	./st136/SURFACE/00019950.dat
+8	./st136/SURFACE/00014300.dat
+8	./st136/SURFACE/00007200.dat
+8	./st136/SURFACE/00021400.dat
+8	./st136/SURFACE/00018550.dat
+8	./st136/SURFACE/00013600.dat
+8	./st136/SURFACE/00004950.dat
+8	./st136/SURFACE/00004450.dat
+8	./st136/SURFACE/00020800.dat
+8	./st136/SURFACE/00009000.dat
+8	./st136/SURFACE/00014250.dat
+8	./st136/SURFACE/00024300.dat
+8	./st136/SURFACE/00009450.dat
+8	./st136/SURFACE/00011600.dat
+8	./st136/SURFACE/00002950.dat
+8	./st136/SURFACE/00001650.dat
+8	./st136/SURFACE/00010800.dat
+8	./st136/SURFACE/00024350.dat
+8	./st136/SURFACE/00006100.dat
+8	./st136/SURFACE/00015700.dat
+8	./st136/SURFACE/00016750.dat
+8	./st136/SURFACE/00015200.dat
+8	./st136/SURFACE/00016250.dat
+8	./st136/SURFACE/00011100.dat
+8	./st136/SURFACE/00004300.dat
+8	./st136/SURFACE/00012350.dat
+8	./st136/SURFACE/00021000.dat
+8	./st136/SURFACE/00022300.dat
+8	./st136/SURFACE/00005000.dat
+8	./st136/SURFACE/00006250.dat
+8	./st136/SURFACE/00019300.dat
+8	./st136/SURFACE/00023300.dat
+8	./st136/SURFACE/00007050.dat
+8	./st136/SURFACE/00012600.dat
+8	./st136/SURFACE/00001500.dat
+8	./st136/SURFACE/00011300.dat
+8	./st136/SURFACE/00023200.dat
+8	./st136/SURFACE/00003300.dat
+8	./st136/SURFACE/00007300.dat
+8	./st136/SURFACE/00017400.dat
+8	./st136/SURFACE/00004550.dat
+8	./st136/SURFACE/00007950.dat
+8	./st136/SURFACE/00022000.dat
+8	./st136/SURFACE/00008100.dat
+8	./st136/SURFACE/00014850.dat
+8	./st136/SURFACE/00007800.dat
+8	./st136/SURFACE/00005300.dat
+8	./st136/SURFACE/00018000.dat
+8	./st136/SURFACE/00005700.dat
+8	./st136/SURFACE/00020300.dat
+8	./st136/SURFACE/00004500.dat
+8	./st136/SURFACE/00018800.dat
+8	./st136/SURFACE/00017750.dat
+8	./st136/SURFACE/00003100.dat
+8	./st136/SURFACE/00018400.dat
+8	./st136/SURFACE/00023250.dat
+8	./st136/SURFACE/00008650.dat
+8	./st136/SURFACE/00023150.dat
+8	./st136/SURFACE/00007450.dat
+8	./st136/SURFACE/00013400.dat
+8	./st136/SURFACE/00004150.dat
+8	./st136/SURFACE/00016050.dat
+8	./st136/SURFACE/00020650.dat
+8	./st136/SURFACE/00006850.dat
+8	./st136/SURFACE/00009650.dat
+8	./st136/SURFACE/00000750.dat
+8	./st136/SURFACE/00019750.dat
+8	./st136/SURFACE/00000100.dat
+8	./st136/SURFACE/00002700.dat
+8	./st136/SURFACE/00005650.dat
+8	./st136/SURFACE/00003450.dat
+8	./st136/SURFACE/00009100.dat
+8	./st136/SURFACE/00019150.dat
+8	./st136/SURFACE/00010400.dat
+8	./st136/SURFACE/00009250.dat
+8	./st136/SURFACE/00012800.dat
+8	./st136/SURFACE/00024050.dat
+8	./st136/SURFACE/00021800.dat
+8	./st136/SURFACE/00000200.dat
+8	./st136/SURFACE/00011750.dat
+8	./st136/SURFACE/00000900.dat
+8	./st136/SURFACE/00001900.dat
+8	./st136/SURFACE/00008450.dat
+8	./st136/SURFACE/00018500.dat
+8	./st136/SURFACE/00023850.dat
+0	./st136/SURFACE/00025250.dat
+8	./st136/SURFACE/00010900.dat
+8	./st136/SURFACE/00012300.dat
+8	./st136/SURFACE/00020150.dat
+8	./st136/SURFACE/00010250.dat
+8	./st136/SURFACE/00004000.dat
+8	./st136/SURFACE/00014050.dat
+8	./st136/SURFACE/00023450.dat
+8	./st136/SURFACE/00019450.dat
+8	./st136/SURFACE/00016650.dat
+8	./st136/SURFACE/00002900.dat
+8	./st136/SURFACE/00024000.dat
+8	./st136/SURFACE/00018100.dat
+8	./st136/SURFACE/00005850.dat
+8	./st136/SURFACE/00009750.dat
+8	./st136/SURFACE/00002800.dat
+8	./st136/SURFACE/00014450.dat
+8	./st136/SURFACE/00012250.dat
+8	./st136/SURFACE/00017000.dat
+8	./st136/SURFACE/00001700.dat
+8	./st136/SURFACE/00006400.dat
+8	./st136/SURFACE/00015050.dat
+8	./st136/SURFACE/00016300.dat
+8	./st136/SURFACE/00006550.dat
+8	./st136/SURFACE/00003950.dat
+8	./st136/SURFACE/00002200.dat
+8	./st136/SURFACE/00021350.dat
+8	./st136/SURFACE/00019700.dat
+8	./st136/SURFACE/00010450.dat
+8	./st136/SURFACE/00011150.dat
+8	./st136/SURFACE/00015350.dat
+8	./st136/SURFACE/00004750.dat
+8	./st136/SURFACE/00000850.dat
+8	./st136/SURFACE/00023550.dat
+8	./st136/SURFACE/00020600.dat
+8	./st136/SURFACE/00022050.dat
+8	./st136/SURFACE/00004350.dat
+8	./st136/SURFACE/00007500.dat
+8	./st136/SURFACE/00013300.dat
+8	./st136/SURFACE/00002000.dat
+8	./st136/SURFACE/00023900.dat
+8	./st136/SURFACE/00013350.dat
+8	./st136/SURFACE/00016450.dat
+8	./st136/SURFACE/00007700.dat
+8	./st136/SURFACE/00023800.dat
+8	./st136/SURFACE/00011700.dat
+8	./st136/SURFACE/00024500.dat
+8	./st136/SURFACE/00018050.dat
+8	./st136/SURFACE/00002350.dat
+8	./st136/SURFACE/00024700.dat
+8	./st136/SURFACE/00025150.dat
+8	./st136/SURFACE/00017650.dat
+8	./st136/SURFACE/00017800.dat
+8	./st136/SURFACE/00004100.dat
+8	./st136/SURFACE/00006300.dat
+8	./st136/SURFACE/00014100.dat
+8	./st136/SURFACE/00017950.dat
+8	./st136/SURFACE/00002550.dat
+8	./st136/SURFACE/00015300.dat
+8	./st136/SURFACE/00001100.dat
+8	./st136/SURFACE/00016100.dat
+8	./st136/SURFACE/00005750.dat
+8	./st136/SURFACE/00021950.dat
+8	./st136/SURFACE/00022450.dat
+8	./st136/SURFACE/00002500.dat
+8	./st136/SURFACE/00023000.dat
+8	./st136/SURFACE/00008800.dat
+8	./st136/SURFACE/00023950.dat
+8	./st136/SURFACE/00015150.dat
+8	./st136/SURFACE/00011650.dat
+8	./st136/SURFACE/00003700.dat
+8	./st136/SURFACE/00005400.dat
+8	./st136/SURFACE/00008750.dat
+8	./st136/SURFACE/00021050.dat
+8	./st136/SURFACE/00011950.dat
+8	./st136/SURFACE/00017550.dat
+8	./st136/SURFACE/00011550.dat
+8	./st136/SURFACE/00022850.dat
+8	./st136/SURFACE/00005500.dat
+8	./st136/SURFACE/00009950.dat
+8	./st136/SURFACE/00024450.dat
+8	./st136/SURFACE/00009150.dat
+8	./st136/SURFACE/00007000.dat
+8	./st136/SURFACE/00024950.dat
+8	./st136/SURFACE/00013100.dat
+8	./st136/SURFACE/00017300.dat
+8	./st136/SURFACE/00015250.dat
+8	./st136/SURFACE/00003150.dat
+8	./st136/SURFACE/00010150.dat
+8	./st136/SURFACE/00017050.dat
+8	./st136/SURFACE/00021550.dat
+8	./st136/SURFACE/00004700.dat
+8	./st136/SURFACE/00016800.dat
+8	./st136/SURFACE/00000400.dat
+8	./st136/SURFACE/00017350.dat
+8	./st136/SURFACE/00006450.dat
+8	./st136/SURFACE/00004650.dat
+8	./st136/SURFACE/00017850.dat
+8	./st136/SURFACE/00007750.dat
+8	./st136/SURFACE/00006350.dat
+8	./st136/SURFACE/00020050.dat
+8	./st136/SURFACE/00009200.dat
+8	./st136/SURFACE/00004900.dat
+8	./st136/SURFACE/00022950.dat
+8	./st136/SURFACE/00012750.dat
+8	./st136/SURFACE/00000150.dat
+8	./st136/SURFACE/00008000.dat
+8	./st136/SURFACE/00010500.dat
+8	./st136/SURFACE/00021450.dat
+8	./st136/SURFACE/00020900.dat
+8	./st136/SURFACE/00020700.dat
+8	./st136/SURFACE/00007100.dat
+8	./st136/SURFACE/00009700.dat
+8	./st136/SURFACE/00021650.dat
+8	./st136/SURFACE/00004250.dat
+8	./st136/SURFACE/00015800.dat
+8	./st136/SURFACE/00001550.dat
+8	./st136/SURFACE/00019800.dat
+8	./st136/SURFACE/00010550.dat
+8	./st136/SURFACE/00021750.dat
+8	./st136/SURFACE/00013500.dat
+8	./st136/SURFACE/00025100.dat
+8	./st136/SURFACE/00005200.dat
+8	./st136/SURFACE/00012450.dat
+8	./st136/SURFACE/00014800.dat
+8	./st136/SURFACE/00011350.dat
+8	./st136/SURFACE/00002300.dat
+8	./st136/SURFACE/00014000.dat
+8	./st136/SURFACE/00007250.dat
+8	./st136/SURFACE/00002650.dat
+8	./st136/SURFACE/00006600.dat
+8	./st136/SURFACE/00019850.dat
+8	./st136/SURFACE/00011400.dat
+8	./st136/SURFACE/00013650.dat
+8	./st136/SURFACE/00006950.dat
+8	./st136/SURFACE/00018900.dat
+8	./st136/SURFACE/00006000.dat
+8	./st136/SURFACE/00024150.dat
+8	./st136/SURFACE/00012050.dat
+8	./st136/SURFACE/00006750.dat
+8	./st136/SURFACE/00003850.dat
+8	./st136/SURFACE/00008150.dat
+8	./st136/SURFACE/00001050.dat
+8	./st136/SURFACE/00020450.dat
+8	./st136/SURFACE/00018600.dat
+8	./st136/SURFACE/00007600.dat
+8	./st136/SURFACE/00000600.dat
+8	./st136/SURFACE/00020000.dat
+8	./st136/SURFACE/00024600.dat
+8	./st136/SURFACE/00019600.dat
+8	./st136/SURFACE/00013700.dat
+8	./st136/SURFACE/00000700.dat
+8	./st136/SURFACE/00007350.dat
+8	./st136/SURFACE/00003600.dat
+8	./st136/SURFACE/00000450.dat
+8	./st136/SURFACE/00017450.dat
+8	./st136/SURFACE/00022100.dat
+8	./st136/SURFACE/00023700.dat
+8	./st136/SURFACE/00001000.dat
+8	./st136/SURFACE/00009900.dat
+8	./st136/SURFACE/00000350.dat
+8	./st136/SURFACE/00010650.dat
+8	./st136/SURFACE/00019500.dat
+8	./st136/SURFACE/00025000.dat
+8	./st136/SURFACE/00017100.dat
+8	./st136/SURFACE/00019400.dat
+8	./st136/SURFACE/00001600.dat
+8	./st136/SURFACE/00005550.dat
+8	./st136/SURFACE/00018150.dat
+8	./st136/SURFACE/00017600.dat
+8	./st136/SURFACE/00021900.dat
+8	./st136/SURFACE/00021300.dat
+8	./st136/SURFACE/00021200.dat
+8	./st136/SURFACE/00000050.dat
+8	./st136/SURFACE/00002250.dat
+8	./st136/SURFACE/00005050.dat
+8	./st136/SURFACE/00022500.dat
+8	./st136/SURFACE/00020950.dat
+8	./st136/SURFACE/00008950.dat
+8	./st136/SURFACE/00000650.dat
+8	./st136/SURFACE/00022350.dat
+8	./st136/SURFACE/00003750.dat
+8	./st136/SURFACE/00020350.dat
+8	./st136/SURFACE/00022700.dat
+8	./st136/SURFACE/00024200.dat
+8	./st136/SURFACE/00006700.dat
+8	./st136/SURFACE/00004050.dat
+8	./st136/SURFACE/00008350.dat
+8	./st136/SURFACE/00011800.dat
+8	./st136/SURFACE/00010050.dat
+8	./st136/SURFACE/00020750.dat
+8	./st136/SURFACE/00002750.dat
+8	./st136/SURFACE/00019200.dat
+8	./st136/SURFACE/00019100.dat
+8	./st136/SURFACE/00015850.dat
+8	./st136/SURFACE/00002150.dat
+8	./st136/SURFACE/00016550.dat
+8	./st136/SURFACE/00021500.dat
+8	./st136/SURFACE/00011000.dat
+8	./st136/SURFACE/00015750.dat
+8	./st136/SURFACE/00002600.dat
+8	./st136/SURFACE/00020850.dat
+8	./st136/SURFACE/00021700.dat
+8	./st136/SURFACE/00018750.dat
+8	./st136/SURFACE/00007150.dat
+8	./st136/SURFACE/00022200.dat
+8	./st136/SURFACE/00012100.dat
+8	./st136/SURFACE/00000550.dat
+8	./st136/SURFACE/00019000.dat
+8	./st136/SURFACE/00016600.dat
+8	./st136/SURFACE/00022650.dat
+8	./st136/SURFACE/00017150.dat
+8	./st136/SURFACE/00016850.dat
+8	./st136/SURFACE/00021250.dat
+8	./st136/SURFACE/00009300.dat
+8	./st136/SURFACE/00010200.dat
+8	./st136/SURFACE/00020200.dat
+8	./st136/SURFACE/00017500.dat
+8	./st136/SURFACE/00023400.dat
+8	./st136/SURFACE/00022600.dat
+8	./st136/SURFACE/00018700.dat
+8	./st136/SURFACE/00014650.dat
+8	./st136/SURFACE/00019650.dat
+8	./st136/SURFACE/00013450.dat
+8	./st136/SURFACE/00019900.dat
+8	./st136/SURFACE/00007850.dat
+8	./st136/SURFACE/00003350.dat
+8	./st136/SURFACE/00001350.dat
+8	./st136/SURFACE/00016900.dat
+8	./st136/SURFACE/00025050.dat
+8	./st136/SURFACE/00019250.dat
+8	./st136/SURFACE/00009550.dat
+8	./st136/SURFACE/00015550.dat
+8	./st136/SURFACE/00009600.dat
+8	./st136/SURFACE/00006800.dat
+8	./st136/SURFACE/00020250.dat
+8	./st136/SURFACE/00024750.dat
+8	./st136/SURFACE/00014150.dat
+8	./st136/SURFACE/00001150.dat
+8	./st136/SURFACE/00014900.dat
+8	./st136/SURFACE/00022800.dat
+8	./st136/SURFACE/00012000.dat
+8	./st136/SURFACE/00006500.dat
+8	./st136/SURFACE/00020500.dat
+8	./st136/SURFACE/00015400.dat
+8	./st136/SURFACE/00015500.dat
+8	./st136/SURFACE/00015900.dat
+8	./st136/SURFACE/00007400.dat
+8	./st136/SURFACE/00008900.dat
+8	./st136/SURFACE/00021850.dat
+8	./st136/SURFACE/00016400.dat
+8	./st136/SURFACE/00009500.dat
+8	./st136/SURFACE/00014500.dat
+8	./st136/SURFACE/00008600.dat
+8	./st136/SURFACE/00015950.dat
+8	./st136/SURFACE/00010750.dat
+8	./st136/SURFACE/00008550.dat
+8	./st136/SURFACE/00018650.dat
+8	./st136/SURFACE/00022250.dat
+8	./st136/SURFACE/00006650.dat
+8	./st136/SURFACE/00013000.dat
+8	./st136/SURFACE/00003050.dat
+8	./st136/SURFACE/00014700.dat
+8	./st136/SURFACE/00001750.dat
+8	./st136/SURFACE/00006900.dat
+8	./st136/SURFACE/00001250.dat
+8	./st136/SURFACE/00023650.dat
+8	./st136/SURFACE/00022400.dat
+8	./st136/SURFACE/00014750.dat
+8	./st136/SURFACE/00024650.dat
+8	./st136/SURFACE/00024250.dat
+8	./st136/SURFACE/00010350.dat
+8	./st136/SURFACE/00018300.dat
+8	./st136/SURFACE/00005600.dat
+8	./st136/SURFACE/00004200.dat
+8	./st136/SURFACE/00015100.dat
+8	./st136/SURFACE/00001800.dat
+8	./st136/SURFACE/00017900.dat
+8	./st136/SURFACE/00018350.dat
+8	./st136/SURFACE/00009350.dat
+8	./st136/SURFACE/00008250.dat
+8	./st136/SURFACE/00012150.dat
+8	./st136/SURFACE/00000250.dat
+8	./st136/SURFACE/00012500.dat
+8	./st136/SURFACE/00022750.dat
+8	./st136/SURFACE/00024850.dat
+8	./st136/SURFACE/00006050.dat
+8	./st136/SURFACE/00011850.dat
+8	./st136/SURFACE/00012950.dat
+8	./st136/SURFACE/00020100.dat
+8	./st136/SURFACE/00019350.dat
+8	./st136/SURFACE/00011450.dat
+8	./st136/SURFACE/00000950.dat
+8	./st136/SURFACE/00015600.dat
+8	./st136/SURFACE/00013050.dat
+8	./st136/SURFACE/00023350.dat
+8	./st136/SURFACE/00005950.dat
+8	./st136/SURFACE/00016950.dat
+8	./st136/SURFACE/00010850.dat
+8	./st136/SURFACE/00017250.dat
+8	./st136/SURFACE/00013850.dat
+8	./st136/SURFACE/00004600.dat
+8	./st136/SURFACE/00013750.dat
+8	./st136/SURFACE/00009800.dat
+8	./st136/SURFACE/00017700.dat
+8	./st136/SURFACE/00024100.dat
+8	./st136/SURFACE/00002100.dat
+8	./st136/SURFACE/00002050.dat
+8	./st136/SURFACE/00019550.dat
+8	./st136/SURFACE/00014200.dat
+8	./st136/SURFACE/00009050.dat
+8	./st136/SURFACE/00005350.dat
+8	./st136/SURFACE/00020550.dat
+8	./st136/SURFACE/00020400.dat
+8	./st136/SURFACE/00014400.dat
+8	./st136/SURFACE/00023600.dat
+8	./st136/SURFACE/00001450.dat
+8	./st136/SURFACE/00023500.dat
+8	./st136/SURFACE/00001200.dat
+8	./st136/SURFACE/00011050.dat
+8	./st136/SURFACE/00013200.dat
+8	./st136/SURFACE/00016200.dat
+8	./st136/SURFACE/00011250.dat
+8	./st136/SURFACE/00003400.dat
+8	./st136/SURFACE/00014550.dat
+8	./st136/SURFACE/00008700.dat
+8	./st136/SURFACE/00005250.dat
+8	./st136/SURFACE/00003650.dat
+8	./st136/SURFACE/00014600.dat
+8	./st136/SURFACE/00002400.dat
+8	./st136/SURFACE/00011200.dat
+8	./st136/SURFACE/00008050.dat
+8	./st136/SURFACE/00001850.dat
+8	./st136/SURFACE/00006200.dat
+8	./st136/SURFACE/00024800.dat
+8	./st136/SURFACE/00007900.dat
+8	./st136/SURFACE/00013950.dat
+8	./st136/SURFACE/00022550.dat
+8	./st136/SURFACE/00013900.dat
+8	./st136/SURFACE/00000300.dat
+8	./st136/SURFACE/00013800.dat
+8	./st136/SURFACE/00021600.dat
+8	./st136/SURFACE/00008400.dat
+8	./st136/SURFACE/00018250.dat
+8	./st136/SURFACE/00007650.dat
+8	./st136/SURFACE/00010100.dat
+8	./st136/SURFACE/00010300.dat
+8	./st136/SURFACE/00004400.dat
+8	./st136/SURFACE/00012900.dat
+8	./st136/SURFACE/00021100.dat
+8	./st136/SURFACE/00005800.dat
+8	./st136/SURFACE/00003200.dat
+8	./st136/SURFACE/00015450.dat
+8	./st136/SURFACE/00011900.dat
+8	./st136/SURFACE/00023750.dat
+8	./st136/SURFACE/00002450.dat
+8	./st136/SURFACE/00016150.dat
+8	./st136/SURFACE/00023050.dat
+8	./st136/SURFACE/00005150.dat
+8	./st136/SURFACE/00014950.dat
+8	./st136/SURFACE/00005100.dat
+8	./st136/SURFACE/00015000.dat
+8	./st136/SURFACE/00019050.dat
+8	./st136/SURFACE/00003000.dat
+8	./st136/SURFACE/00012700.dat
+8	./st136/SURFACE/00005450.dat
+8	./st136/SURFACE/00016700.dat
+8	./st136/SURFACE/00004800.dat
+8	./st136/SURFACE/00024550.dat
+8	./st136/SURFACE/00023100.dat
+8	./st136/SURFACE/00001300.dat
+8	./st136/SURFACE/00008300.dat
+8	./st136/SURFACE/00003500.dat
+8	./st136/SURFACE/00012550.dat
+8	./st136/SURFACE/00008850.dat
+8	./st136/SURFACE/00008500.dat
+8	./st136/SURFACE/00018850.dat
+8	./st136/SURFACE/00018450.dat
+8	./st136/SURFACE/00000500.dat
+8	./st136/SURFACE/00022900.dat
+8	./st136/SURFACE/00015650.dat
+8	./st136/SURFACE/00010000.dat
+8	./st136/SURFACE/00006150.dat
+8	./st136/SURFACE/00003550.dat
+8	./st136/SURFACE/00007550.dat
+8	./st136/SURFACE/00011500.dat
+8	./st136/SURFACE/00012200.dat
+8	./st136/SURFACE/00003900.dat
+8	./st136/SURFACE/00013550.dat
+8	./st136/SURFACE/00012400.dat
+8	./st136/SURFACE/00012850.dat
+8	./st136/SURFACE/00010600.dat
+8	./st136/SURFACE/00018200.dat
+8	./st136/SURFACE/00013250.dat
+8	./st136/SURFACE/00017200.dat
+8	./st136/SURFACE/00008200.dat
+8	./st136/SURFACE/00014350.dat
+8	./st136/SURFACE/00022150.dat
+8	./st136/SURFACE/00001950.dat
+8	./st136/SURFACE/00004850.dat
+8	./st136/SURFACE/00001400.dat
+8	./st136/SURFACE/00000800.dat
+8	./st136/SURFACE/00003800.dat
+8	./st136/SURFACE/00021150.dat
+8	./st136/SURFACE/00016000.dat
+4068	./st136/SURFACE
+4	./st136/prof_step
+4	./st136/MID/TIME.MID
+8	./st136/MID
+39800532	./st136
+1011311932	.

--- a/tkdu.py
+++ b/tkdu.py
@@ -428,8 +428,14 @@ def main(f=sys.stdin):
     for line in f.readlines():
         sz, name = line[:-1].split(None, 1)
 #       name = name.split("/")
-        sz = int(sz)*1024
-        putname(files, name, sz)
+        
+        try: # For normal lines of du output
+            sz = long(sz)*1024
+            putname(files, name, sz)
+        except ValueError: # For error lines of du output, which is caused by 'Permission denied' when accessing certain folders of other users.
+            pass # do nothing (if met with permission error)!
+            #print "Something went wrong {!s}".format(line)   # the problem value 
+
     doit(name, files)
 
 

--- a/tkdu.py
+++ b/tkdu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 #    This is tkdu.py, an interactive program to display disk usage
 #    Copyright 2004 Jeff Epler <jepler@unpythonic.net>
@@ -18,22 +18,28 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import sys
-import sys
 import os
 import stat
 import time
 import gzip
 
-if sys.version_info[0] == 2:
+try:
     import Tkinter as tkinter
-    import FileDialog
-    from tkFileDialog import askdirectory
-    from FileDialog import LoadFileDialog
-    import codecs
-    from io import open
-else:
+except ImportError:
     import tkinter
-    from tkinter.filedialog import askdirectory, LoadFileDialog
+
+try:
+    from FileDialog import LoadFileDialog
+except ImportError:
+    from tkinter.filedialog import LoadFileDialog
+
+try:
+    from tkFileDialog import askdirectory
+except ImportError:
+    from tkinter.filedialog import askdirectory
+
+import codecs
+from io import open
 
 MIN_PSZ = 1000
 MIN_IPSZ = 240
@@ -539,12 +545,11 @@ def main_builtin_du(args):
         if os.path.isfile(p):
             if p.endswith('.gz'):
                 # gzipped file
-                if sys.version_info[0] == 2:
-                    fp0 = gzip.open(p, 'rt')
-                    fp = codecs.getreader('utf-8')(fp0, errors='replace')
-                    main(fp)
-                else:
-                    main(gzip.open(p, 'rt', encoding="utf-8", errors='replace'))
+                fp0 = gzip.open(p, 'rb')
+                fp = codecs.getreader('utf-8')(fp0, errors='replace')
+                main(fp)
+                # python3 offers a simpler instruction:
+                # main(gzip.open(p, 'rt', encoding="utf-8", errors='replace'))
             else:
                 main(open(p, 'rt', encoding="utf-8", errors='replace'))
         else:

--- a/tkdu.py
+++ b/tkdu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #    This is tkdu.py, an interactive program to display disk usage
 #    Copyright 2004 Jeff Epler <jepler@unpythonic.net>
@@ -17,8 +17,23 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-import math, Tkinter, sys, os, stat, string, time, gzip, FileDialog
-from tkFileDialog import askdirectory
+import sys
+import sys
+import os
+import stat
+import time
+import gzip
+
+if sys.version_info[0] == 2:
+    import Tkinter as tkinter
+    import FileDialog
+    from tkFileDialog import askdirectory
+    from FileDialog import LoadFileDialog
+    import codecs
+    from io import open
+else:
+    import tkinter
+    from tkinter.filedialog import askdirectory, LoadFileDialog
 
 MIN_PSZ = 1000
 MIN_IPSZ = 240
@@ -35,40 +50,48 @@ FONT_HEIGHT2 = 20
 dircolors = ['#ff7070', '#70ff70', '#7070ff']
 leafcolors = ['#bf5454', '#54bf54', '#5454bf']
 
+
 def allocate(path, files, canvas, x, y, w, h, first, depth):
     tk_call = canvas.tk.call
-    if w < MIN_W or h < MIN_H: return
+    if w < MIN_W or h < MIN_H:
+        return
     psz = w*h
-    if psz < MIN_PSZ: return
+    if psz < MIN_PSZ:
+        return
     if path and path[-1] == "/":
         basename_idx = len(path)
-        nslashes = string.count(path, os.sep) - 1
+        nslashes = path.count(os.sep) - 1
     else:
         basename_idx = len(path) + 1
-        nslashes = string.count(path, os.sep)
+        nslashes = path.count(os.sep)
     dircolor = dircolors[nslashes % len(dircolors)]
     leafcolor = leafcolors[nslashes % len(dircolors)]
     colors = (leafcolor, dircolor)
     totsz = 0
     ff = getkids(files, path)
-    if not ff: return
-    if ff[0][1] == '/': del ff[0]
+    if not ff:
+        return
+    if ff[0][1] == '/':
+        del ff[0]
     ff = ff[first:]
     for item in ff:
         totsz = totsz + item[0]
         item[2] = None
 
-    if totsz == 0: return
+    if totsz == 0:
+        return
 
     i = 0
     ratio = psz*1./totsz
 
-    while i < len(ff) and w>2*BORDER and h>2*BORDER:
+    while i < len(ff) and w > 2*BORDER and h > 2*BORDER:
         if w > h:
             orient = VERTICAL
             usew = w - h*2./3
-            if usew < 50: usew = 50
-            if usew > 200: usew = 200
+            if usew < 50:
+                usew = 50
+            if usew > 200:
+                usew = 200
             first_height = ff[i][0]/usew*ratio
             while first_height < .65 * usew:
                 usew = usew / 1.5
@@ -78,8 +101,10 @@ def allocate(path, files, canvas, x, y, w, h, first, depth):
         else:
             orient = HORIZONTAL
             useh = h - w*2./3
-            if useh < 50: useh = 50
-            if useh > 100: useh = 100
+            if useh < 50:
+                useh = 50
+            if useh > 100:
+                useh = 100
             first_width = ff[i][0]/useh*ratio
             while first_width < .65 * useh:
                 useh = useh / 1.5
@@ -87,16 +112,16 @@ def allocate(path, files, canvas, x, y, w, h, first, depth):
             want = useh * w / ratio
             maxcnt = w/30
 
-
         j = i+1
         use = ff[i][0]
-        while j < len(ff) and use < want: #and j < i + maxcnt:
+        while j < len(ff) and use < want:  # and j < i + maxcnt:
             use = use + ff[j][0]
-            j=j+1
+            j = j+1
 
         if orient is VERTICAL:
             usew = use * ratio / h
-            if usew <= 2*BORDER: break
+            if usew <= 2*BORDER:
+                break
             y0 = y
             for item in ff[i:j]:
                 dy = item[0]/usew*ratio
@@ -106,7 +131,8 @@ def allocate(path, files, canvas, x, y, w, h, first, depth):
             w = w - usew
         else:
             useh = use * ratio / w
-            if useh <= 2*BORDER: break
+            if useh <= 2*BORDER:
+                break
             x0 = x
             for item in ff[i:j]:
                 dx = item[0]/useh*ratio
@@ -121,19 +147,20 @@ def allocate(path, files, canvas, x, y, w, h, first, depth):
         name = item[1]
         haskids = bool(getkids(files, name))
         color = colors[haskids]
-        if item[2] is None: continue
+        if item[2] is None:
+            continue
         x, y, w, h = pos = item[2]
         if w > 3*BORDER and h > 3*BORDER:
             tk_call(canvas._w,
-                "create", "rectangle",
-                x+BORDER+2, y+BORDER+2, x+w-BORDER+1, y+h-BORDER+1,
-                "-fill", "#3f3f3f",
-                "-outline", "#3f3f3f")
+                    "create", "rectangle",
+                    x+BORDER+2, y+BORDER+2, x+w-BORDER+1, y+h-BORDER+1,
+                    "-fill", "#3f3f3f",
+                    "-outline", "#3f3f3f")
 
         i = tk_call(canvas._w,
-            "create", "rectangle",
-            x+BORDER, y+BORDER, x+w-BORDER, y+h-BORDER,
-            "-fill", color)
+                    "create", "rectangle",
+                    x+BORDER, y+BORDER, x+w-BORDER, y+h-BORDER,
+                    "-fill", color)
         canvas.map[int(i)] = name
 
         if h > FONT_HEIGHT+2*BORDER:
@@ -150,37 +177,39 @@ def allocate(path, files, canvas, x, y, w, h, first, depth):
                     if tw < w1:
                         text = "%s\n%s" % (stem, ssz)
                         i = tk_call(canvas._w, "create", "text",
-                            x+BORDER+2, y+BORDER,
-                            "-text", text,
-                            "-font", FONT_FACE, "-anchor", "nw")
+                                    x+BORDER+2, y+BORDER,
+                                    "-text", text,
+                                    "-font", FONT_FACE, "-anchor", "nw")
                         canvas.map[int(i)] = name
                         y = y + FONT_HEIGHT2
                         h = h - FONT_HEIGHT2
                         if w*h > MIN_PSZ and haskids and depth != 1:
                             queue(canvas, allocate, name, files, canvas,
-                                x+2*BORDER, y+2*BORDER,
-                                w-4*BORDER, h-4*BORDER, 0, depth-1)
+                                  x+2*BORDER, y+2*BORDER,
+                                  w-4*BORDER, h-4*BORDER, 0, depth-1)
                         continue
                 text = stem
                 tw = int(tk_call("font", "measure", FONT_FACE, text))
             if tw < w1:
                 i = tk_call(canvas._w, "create", "text",
-                        x+BORDER+2, y+BORDER,
-                        "-text", text,
-                        "-font", FONT_FACE, "-anchor", "nw")
+                            x+BORDER+2, y+BORDER,
+                            "-text", text,
+                            "-font", FONT_FACE, "-anchor", "nw")
                 canvas.map[int(i)] = name
                 y = y + FONT_HEIGHT
                 h = h - FONT_HEIGHT
         if w*h > MIN_PSZ and haskids and depth != 1:
             queue(canvas, allocate, name, files, canvas,
-                x+2*BORDER, y+2*BORDER,
-                w-4*BORDER, h-4*BORDER, 0, depth-1)
+                  x+2*BORDER, y+2*BORDER,
+                  w-4*BORDER, h-4*BORDER, 0, depth-1)
+
 
 def queue(c, *args):
     if c.aid is None:
         c.aid = c.after_idle(run_queue, c)
         c.configure(cursor="watch")
     c.queue.append(args)
+
 
 def run_queue(c):
     queue = c.queue
@@ -190,18 +219,21 @@ def run_queue(c):
             c.aid = None
             c.configure(cursor="")
             break
-        if time.time() > end: break
+        if time.time() > end:
+            break
         item = queue[0]
         del queue[0]
-        apply(item[0], item[1:])
+        item[0](*item[1:])
     if queue:
         c.aid = c.after_idle(run_queue, c)
+
 
 def chroot(e, r):
     c = e.widget
     if not getkids(c.files, r):
         r = os.path.dirname(r)
-        if r == c.cur: return
+        if r == c.cur:
+            return
     if r is None:
         return
     if not r.startswith(c.root):
@@ -213,23 +245,27 @@ def chroot(e, r):
     e.height = c.winfo_height()
     reconfigure(e)
 
+
 def item_under_cursor(e):
     c = e.widget
     try:
         item = c.find_overlapping(e.x, e.y, e.x, e.y)[-1]
     except IndexError:
         return None
-    return  c.map.get(item, None)
+    return c.map.get(item, None)
+
 
 def descend(e):
     c = e.widget
     item = item_under_cursor(e)
     chroot(e, item)
 
+
 def ascend(e):
     c = e.widget
     parent = os.path.dirname(c.cur)
     chroot(e, parent)
+
 
 def size(n):
     if n > 1024*1024*1024:
@@ -240,25 +276,31 @@ def size(n):
         return "%.1fKB" % (n/1024.)
     return "%d" % n
 
+
 def scroll(e, dir):
     c = e.widget
     offset = c.first + 5*dir
     l = len(getkids(c.files, c.cur))
-    if offset + 5 > l: offset = l-5
-    if offset < 0: offset = 0
+    if offset + 5 > l:
+        offset = l-5
+    if offset < 0:
+        offset = 0
     if offset != c.first:
         c.first = offset
         e.width = c.winfo_width()
         e.height = c.winfo_height()
         reconfigure(e)
 
+
 def schedule_tip(e):
     c = e.widget
     s = item_under_cursor(e)
-    if not s: return
+    if not s:
+        return
     sz = getname(c.files, s)
     s = "%s (%s)" % (s, size(sz))
     c.tipa = c.after(500, make_tip, e, s)
+
 
 def make_tip(e, s):
     c = e.widget
@@ -266,6 +308,7 @@ def make_tip(e, s):
     c.tipl.configure(text=s)
     c.tip.wm_geometry("+%d+%d" % (e.x_root+5, e.y_root+5))
     c.tip.wm_deiconify()
+
 
 def cancel_tip(e, c=None):
     if c is None:
@@ -275,6 +318,7 @@ def cancel_tip(e, c=None):
         c.tipa = None
     else:
         c.tip.wm_withdraw()
+
 
 def reconfigure(e):
     c = e.widget
@@ -292,18 +336,20 @@ def reconfigure(e):
     if c.cur == "/":
         nslashes = -1
     else:
-        nslashes = string.count(c.cur, os.sep) - 1
+        nslashes = c.cur.count(os.sep) - 1
     parent = os.path.dirname(c.cur)
     color = dircolors[nslashes % len(dircolors)]
     c.configure(background=color)
     c.queue = [(allocate, c.cur, c.files, c, 0, 0, w, h, c.first, c.depth)]
     run_queue(c)
-    
+
+
 def putname_base(dict, name, base, size):
     try:
         dict[base][name] = size
     except:
         dict[base] = {name: size}
+
 
 def putname(dict, name, size):
     base = os.path.dirname(name)
@@ -312,26 +358,29 @@ def putname(dict, name, size):
     except:
         dict[base] = {name: size}
 
+
 def getname(dict, name):
     base = os.path.dirname(name)
     return dict[base][0][name]
 
+
 def getkids(dict, path):
     return dict.get(path, ((), {}))[1]
-        
+
+
 def doit(dir, files):
     sorted_files = {}
     for k, v in files.items():
-        sv = map(lambda (k, v): [v, k, None], v.items())
+        sv = list(map(lambda k_v: [k_v[1], k_v[0], None], v.items()))
         sv.sort()
         sv.reverse()
         sorted_files[k] = (v, sv)
 
-    t = Tkinter.Tk()
-    c = Tkinter.Canvas(t, width=1024, height=768)
-    c.tip = Tkinter.Toplevel(t)
+    t = tkinter.Tk()
+    c = tkinter.Canvas(t, width=1024, height=768)
+    c.tip = tkinter.Toplevel(t)
     c.tip.wm_overrideredirect(1)
-    c.tipl = Tkinter.Label(c.tip)
+    c.tipl = tkinter.Label(c.tip)
     c.tipl.pack()
     c.pack(expand="yes", fill="both")
     c.files = sorted_files
@@ -358,6 +407,7 @@ def doit(dir, files):
     c.tag_bind("all", "<Leave>", cancel_tip)
     c.mainloop()
 
+
 def setdepth(e, c, i):
     e.widget = c
     e.width = c.winfo_width()
@@ -365,23 +415,30 @@ def setdepth(e, c, i):
     c.depth = i
     reconfigure(e)
 
-def main(f = sys.stdin):
+
+def main(f=sys.stdin):
     files = {}
     firstfile = None
     for line in f.readlines():
-        sz, name = string.split(line[:-1], None, 1)
+        sz, name = line[:-1].split(None, 1)
 #       name = name.split("/")
-        sz = long(sz)*1024
+        sz = int(sz)*1024
         putname(files, name, sz)
     doit(name, files)
 
-def du(dir, files, fs=0, ST_MODE=stat.ST_MODE, ST_SIZE = stat.ST_SIZE, S_IFMT = 0170000, S_IFDIR = 0040000, lstat = os.lstat, putname_base = putname_base, fmt="%%s%s%%s" % os.sep):
+
+def du(dir, files, fs=0, ST_MODE=stat.ST_MODE, ST_SIZE=stat.ST_SIZE,
+       S_IFMT=0o170000, S_IFDIR=0o040000, lstat=os.lstat,
+       putname_base=putname_base, fmt="%%s%s%%s" % os.sep):
     tsz = 0
 
-    try: fns = os.listdir(dir)
-    except: return 0
+    try:
+        fns = os.listdir(dir)
+    except:
+        return 0
 
-    if not files.has_key(dir): files[dir] = {}
+    if dir not in files.keys():
+        files[dir] = {}
     d = files[dir]
 
     for fn in fns:
@@ -393,19 +450,21 @@ def du(dir, files, fs=0, ST_MODE=stat.ST_MODE, ST_SIZE = stat.ST_SIZE, S_IFMT = 
             continue
 
         if info[ST_MODE] & S_IFMT == S_IFDIR:
-            sz = du(fn, files) + long(info[ST_SIZE])
+            sz = du(fn, files) + int(info[ST_SIZE])
         else:
             sz = info[ST_SIZE]
         d[fn] = sz
         tsz = tsz + sz
     return tsz
 
+
 def abspath(p):
     return os.path.normpath(os.path.join(os.getcwd(), p))
 
-class DirDialog(FileDialog.LoadFileDialog):
+
+class DirDialog(LoadFileDialog):
     def __init__(self, master, title=None):
-        FileDialog.LoadFileDialog.__init__(self, master, title)
+        LoadFileDialog.__init__(self, master, title)
         self.files.destroy()
         self.filesbar.destroy()
 
@@ -417,7 +476,7 @@ class DirDialog(FileDialog.LoadFileDialog):
             self.quit(file)
 
     def filter_command(self, event=None):
-        END="end"
+        END = "end"
         dir, pat = self.get_filter()
         try:
             names = os.listdir(dir)
@@ -437,19 +496,20 @@ class DirDialog(FileDialog.LoadFileDialog):
         for name in subdirs:
             self.dirs.insert(END, name)
         head, tail = os.path.split(self.get_selection())
-        if tail == os.curdir: tail = ''
+        if tail == os.curdir:
+            tail = ''
         self.set_selection(tail)
 
+
 def main_builtin_du(args):
-    import sys
     if len(args) > 1:
         p = args[1]
     else:
-        t = Tkinter.Tk()
+        t = tkinter.Tk()
         t.wm_withdraw()
         p = askdirectory()
-        if Tkinter._default_root is t:
-            Tkinter._default_root = None
+        if tkinter._default_root is t:
+            tkinter._default_root = None
         t.destroy()
         if p is None:
             return
@@ -457,19 +517,19 @@ def main_builtin_du(args):
 
     if p == '-h' or p == '--help' or p == '-?':
         base = os.path.basename(args[0])
-        print 'Usage:'
-        print ' ', base, '<file.gz>     interpret file as gzipped du -ak output and visualize it'
-        print ' ', base, '<file>        interpret file as du -ak output and visualize it'
-        print ' ', base, '<folder>      analyze disk usage in that folder'
-        print ' ', base, '-             interpret stdin input as du -ak output and visualize it'
-        print ' ', base, '              ask for folder to analyze'
-        print
-        print 'Controls:'
-        print '  * Press `q` to quit'
-        print '  * LMB: zoom in to item'
-        print '  * RMB: zoom out one level'
-        print '  * Press `1`..`9`: Show that many nested levels'
-        print '  * Press `0`: Show man nested levels'
+        print('Usage:')
+        print(' ', base, '<file.gz>     interpret file as gzipped du -ak output and visualize it')
+        print(' ', base, '<file>        interpret file as du -ak output and visualize it')
+        print(' ', base, '<folder>      analyze disk usage in that folder')
+        print(' ', base, '-             interpret stdin input as du -ak output and visualize it')
+        print(' ', base, '              ask for folder to analyze')
+        print()
+        print('Controls:')
+        print('  * Press `q` to quit')
+        print('  * LMB: zoom in to item')
+        print('  * RMB: zoom out one level')
+        print('  * Press `1`..`9`: Show that many nested levels')
+        print('  * Press `0`: Show man nested levels')
         return
 
     if p == "-":
@@ -479,9 +539,14 @@ def main_builtin_du(args):
         if os.path.isfile(p):
             if p.endswith('.gz'):
                 # gzipped file
-                main(gzip.open(p, 'r'))
+                if sys.version_info[0] == 2:
+                    fp0 = gzip.open(p, 'rt')
+                    fp = codecs.getreader('utf-8')(fp0, errors='replace')
+                    main(fp)
+                else:
+                    main(gzip.open(p, 'rt', encoding="utf-8", errors='replace'))
             else:
-                main(open(p, 'r'))
+                main(open(p, 'rt', encoding="utf-8", errors='replace'))
         else:
             putname(files, p, du(p, files))
             doit(p, files)


### PR DESCRIPTION
Problem background:
I did an disk usage analysis on a server where some folders were protected by their owners. Therefore 'du' output many lines like "du: cannot access './aaa/bbb': Permission denied". This situation was not considered in last version.
```
for line in f.readlines():
    sz, name = line[:-1].split(None, 1)
    sz = long(sz)*1024
```
sz was expected to be an integer describing the size of file, which was not true when meeting lines of 'Permission denied'.
My solution:
Add an try/except for 'long(sz)'. 
I also provide an example of input file, which could be deleted in further commit.